### PR TITLE
fix: use direct SSH for deploy — bypass appleboy/ssh-action key parsing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,15 +55,19 @@ jobs:
       - name: Build production assets
         run: npm run build
 
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ${{ secrets.VPS_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
       - name: Deploy to VPS
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.VPS_HOST }}
-          username: ${{ secrets.VPS_SSH_USER }}
-          key: ${{ secrets.VPS_SSH_KEY }}
-          command_timeout: 10m
-          debug: true
-          script: |
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_SSH_USER }}
+        run: |
+          ssh -i ~/.ssh/deploy_key -o ConnectTimeout=30 "${VPS_USER}@${VPS_HOST}" bash -s <<'DEPLOY_SCRIPT'
             set -e
 
             APP_DIR="/opt/motivya/src"
@@ -77,3 +81,4 @@ jobs:
 
             # Run the deploy script from the repo
             bash "$APP_DIR/scripts/deploy.sh"
+          DEPLOY_SCRIPT


### PR DESCRIPTION
Replace appleboy/ssh-action with native SSH command. The action fails to authenticate with OPENSSH ed25519 keys even when the key is correctly provided. Using direct ssh gives us full control over key handling.