### PR TITLE
docs(instructions): forbid defensive code for missing migrations

### DIFF
--- a/.github/instructions/php.instructions.md
+++ b/.github/instructions/php.instructions.md
@@ -26,6 +26,7 @@ No exceptions — migrations, seeders, config files, tests, service providers, a
 - Use Laravel built-in features over vendor-specific or low-level PHP equivalents
 - Never implement fallback logic or workarounds without explicit approval
 - Never ignore warnings or errors, even pre-existing ones
+- **Never write code that "degrades gracefully" for missing migrations** — all required migrations are assumed to have been run. There is no valid scenario where application code executes against a schema missing its own columns. If a column is needed, the migration must exist; if the migration doesn't exist yet, the code that depends on it belongs in the same story or a later one. Do not use `getAttribute()` with null-coalescing, `Schema::hasColumn()`, or try/catch around column access as a substitute for running migrations.
 
 ## Backed Enums
 


### PR DESCRIPTION
## What

Adds a rule to `php.instructions.md` forbidding defensive code patterns that attempt to "degrade gracefully" when a required migration hasn't been run.

## Why

During code review of PR #44 (E1-S08), the `SetLocale` middleware used `getAttribute()` with a `??` fallback chain and a comment saying _"this chain degrades gracefully before the locale migration is added"_. This silently swallows actual problems and prevents their discovery.

There is no valid scenario where application code executes against a schema missing its own columns — migrations are always run before the code that depends on them ships.

## Rule added

> **Never write code that "degrades gracefully" for missing migrations** — all required migrations are assumed to have been run. There is no valid scenario where application code executes against a schema missing its own columns. If a column is needed, the migration must exist; if the migration doesn't exist yet, the code that depends on it belongs in the same story or a later one. Do not use `getAttribute()` with null-coalescing, `Schema::hasColumn()`, or try/catch around column access as a substitute for running migrations.

## Scope

Single-line addition to `.github/instructions/php.instructions.md`, General Guidelines section.