### PR TITLE
feat: Locale detection middleware + switcher (E1-S09)

### DIFF
--- a/app/Http/Middleware/SetLocale.php
+++ b/app/Http/Middleware/SetLocale.php
@@ -57,8 +57,7 @@ final class SetLocale
                     'locale' => $userLocale,
                 ]);
             }
-            // Authenticated user with no locale set — expected before the
-            // locale column migration (E1-S09) is applied. Not an error yet.
+            // Authenticated user with no locale set — fall through to session/header.
         }
 
         // 2. Session value

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -26,6 +26,7 @@ class User extends Authenticatable implements MustVerifyEmail
         'email',
         'password',
         'role',
+        'locale',
     ];
 
     /**

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -66,4 +66,9 @@ class UserFactory extends Factory
     {
         return $this->state(['role' => UserRole::Admin->value]);
     }
+
+    public function withLocale(string $locale): static
+    {
+        return $this->state(['locale' => $locale]);
+    }
 }

--- a/database/migrations/2026_04_07_201632_add_locale_to_users_table.php
+++ b/database/migrations/2026_04_07_201632_add_locale_to_users_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('locale')->default('fr')->after('role');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('locale');
+        });
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,6 +50,11 @@ Route::get('/locale/{locale}', function (string $locale) {
 
     if (in_array($locale, $supported, strict: true)) {
         session(['locale' => $locale]);
+
+        $user = request()->user();
+        if ($user !== null) {
+            $user->update(['locale' => $locale]);
+        }
     }
 
     return redirect()->back(fallback: '/');

--- a/tests/Feature/Middleware/SetLocaleTest.php
+++ b/tests/Feature/Middleware/SetLocaleTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Route;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Route::middleware('web')->get('/_test/locale-check', fn () => response()->json([
+        'locale' => App::getLocale(),
+    ]));
+});
+
+describe('SetLocale middleware', function () {
+
+    it('uses the authenticated user locale preference', function () {
+        $user = User::factory()->withLocale('nl')->create();
+
+        $response = $this->actingAs($user)
+            ->getJson('/_test/locale-check')
+            ->assertOk();
+
+        expect($response->json('locale'))->toBe('nl');
+    });
+
+    it('prefers user locale over session locale', function () {
+        $user = User::factory()->withLocale('en')->create();
+
+        $response = $this->actingAs($user)
+            ->withSession(['locale' => 'nl'])
+            ->getJson('/_test/locale-check')
+            ->assertOk();
+
+        expect($response->json('locale'))->toBe('en');
+    });
+
+    it('uses session locale when user is not authenticated', function () {
+        $response = $this->withSession(['locale' => 'en'])
+            ->getJson('/_test/locale-check')
+            ->assertOk();
+
+        expect($response->json('locale'))->toBe('en');
+    });
+
+    it('uses Accept-Language header when no user and no session locale', function () {
+        $response = $this->getJson('/_test/locale-check', ['Accept-Language' => 'nl'])
+            ->assertOk();
+
+        expect($response->json('locale'))->toBe('nl');
+    });
+
+    it('falls back to fr when Accept-Language header contains unsupported locale', function () {
+        $response = $this->getJson('/_test/locale-check', ['Accept-Language' => 'de'])
+            ->assertOk();
+
+        expect($response->json('locale'))->toBe('fr');
+    });
+
+    it('falls back to fr when no locale source is available', function () {
+        $response = $this->getJson('/_test/locale-check', ['Accept-Language' => '*'])
+            ->assertOk();
+
+        expect($response->json('locale'))->toBe('fr');
+    });
+
+    it('ignores unsupported locale on authenticated user and falls through', function () {
+        $user = User::factory()->create(['locale' => 'de']);
+
+        $response = $this->actingAs($user)
+            ->withSession(['locale' => 'en'])
+            ->getJson('/_test/locale-check')
+            ->assertOk();
+
+        expect($response->json('locale'))->toBe('en');
+    });
+
+    it('ignores unsupported session locale and falls through to header', function () {
+        $response = $this->withSession(['locale' => 'de'])
+            ->getJson('/_test/locale-check', ['Accept-Language' => 'nl'])
+            ->assertOk();
+
+        expect($response->json('locale'))->toBe('nl');
+    });
+});
+
+describe('GET /locale/{locale} switch route', function () {
+
+    it('sets session locale and redirects back', function () {
+        $this->get('/locale/en')
+            ->assertRedirect('/');
+
+        $response = $this->getJson('/_test/locale-check')
+            ->assertOk();
+
+        expect($response->json('locale'))->toBe('en');
+    });
+
+    it('updates authenticated user locale in database', function () {
+        $user = User::factory()->withLocale('fr')->create();
+
+        $this->actingAs($user)
+            ->get('/locale/nl')
+            ->assertRedirect('/');
+
+        expect($user->fresh()->locale)->toBe('nl');
+    });
+
+    it('sets session locale for authenticated user', function () {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get('/locale/en')
+            ->assertRedirect('/');
+
+        $response = $this->actingAs($user)
+            ->getJson('/_test/locale-check')
+            ->assertOk();
+
+        expect($response->json('locale'))->toBe('en');
+    });
+
+    it('ignores unsupported locale and redirects back without changing session', function () {
+        $this->withSession(['locale' => 'fr'])
+            ->get('/locale/de')
+            ->assertRedirect('/');
+
+        $response = $this->withSession(['locale' => 'fr'])
+            ->getJson('/_test/locale-check')
+            ->assertOk();
+
+        expect($response->json('locale'))->toBe('fr');
+    });
+
+    it('does not update user locale for unsupported locale', function () {
+        $user = User::factory()->withLocale('fr')->create();
+
+        $this->actingAs($user)
+            ->get('/locale/de')
+            ->assertRedirect('/');
+
+        expect($user->fresh()->locale)->toBe('fr');
+    });
+
+    it('accepts all three supported locales', function (string $locale) {
+        $this->get("/locale/{$locale}")
+            ->assertRedirect('/');
+
+        $response = $this->getJson('/_test/locale-check')
+            ->assertOk();
+
+        expect($response->json('locale'))->toBe($locale);
+    })->with(['fr', 'en', 'nl']);
+});


### PR DESCRIPTION
## Summary

Implements E1-S09: Locale detection middleware, locale switch route with user persistence, and the `locale` migration on the users table.

Resolves #25

## Changes

### Migration
- **`database/migrations/2026_04_07_201632_add_locale_to_users_table.php`** — Adds `locale` column (string, default `'fr'`) to `users` table with reversible `down()`.

### Model & Factory
- **`app/Models/User.php`** — Added `locale` to `$fillable`.
- **`database/factories/UserFactory.php`** — Added `withLocale(string $locale)` state method.

### Route
- **`routes/web.php`** — Updated `GET /locale/{locale}` to also persist locale to authenticated user's database record.

### Middleware
- **`app/Http/Middleware/SetLocale.php`** — Updated comment (no longer references E1-S09 as future work).

### Tests
- **`tests/Feature/Middleware/SetLocaleTest.php`** — 16 tests covering:
  - Detection order: user preference > session > Accept-Language > fallback `fr`
  - Unsupported locales fall through to the next source
  - Locale switch route sets session and persists to user
  - Unsupported locales ignored by switch route
  - All three supported locales (`fr`, `en`, `nl`) accepted

## Acceptance Criteria Checklist

- [x] `SetLocale` middleware reads locale from: 1) authenticated user's `locale` column, 2) session value, 3) `Accept-Language` header, 4) fallback `fr`
- [x] Only `fr`, `en`, `nl` are accepted; anything else falls back to `fr`
- [x] `GET /locale/{locale}` route sets the session locale and redirects back
- [x] `locale` column added to users table (string, default `'fr'`)
- [x] Middleware registered in the `web` middleware group
- [x] Feature test: middleware picks correct locale from header; switch route works