### PR TITLE
feat: E1-S20 · GDPR / Privacy page (FR/EN/NL)

### DIFF
--- a/lang/en/common.php
+++ b/lang/en/common.php
@@ -28,6 +28,7 @@ return [
 
     'footer' => [
         'rights' => 'All rights reserved.',
+        'privacy' => 'Privacy Policy',
     ],
 
     /*

--- a/lang/en/privacy.php
+++ b/lang/en/privacy.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | GDPR / Privacy Policy — English (en-GB)
+    |--------------------------------------------------------------------------
+    */
+
+    'title' => 'Privacy Policy',
+    'print' => 'Print',
+    'last_updated' => 'Last updated: :date',
+
+    'intro' => [
+        'heading' => 'Introduction',
+        'body' => 'Motivya (hereinafter "the Platform") operates in compliance with the General Data Protection Regulation (GDPR — EU Regulation 2016/679) and applicable Belgian legislation. This policy describes how we collect, use, store, and protect your personal data.',
+    ],
+
+    'controller' => [
+        'heading' => 'Data Controller',
+        'body' => 'The data controller is the company operating Motivya. For any questions regarding your personal data, you can contact us via the email address provided on the platform.',
+    ],
+
+    'data_collected' => [
+        'heading' => 'Data Collected',
+        'body' => 'We collect the following categories of data:',
+        'items' => [
+            'identity' => 'Identity data: name, email address',
+            'auth' => 'Authentication data: hashed password, OAuth identifiers (Google, Facebook)',
+            'role' => 'Role data: your role on the platform (athlete, coach, accountant, administrator)',
+            'payment' => 'Payment data: processed by Stripe; we do not store your card details',
+            'coach' => 'Coach data: enterprise number (BCE/KBO), specialties, biography, geographic zone',
+            'booking' => 'Booking data: booked sessions, amounts paid, statuses',
+            'technical' => 'Technical data: IP address, browser type, language preference',
+        ],
+    ],
+
+    'purpose' => [
+        'heading' => 'Purpose of Processing',
+        'body' => 'Your data is processed for the following purposes:',
+        'items' => [
+            'account' => 'Account management and authentication',
+            'booking' => 'Processing bookings and payments',
+            'communication' => 'Communication regarding your bookings and account',
+            'legal' => 'Compliance with our legal obligations (invoicing, VAT, anti-money laundering)',
+            'improvement' => 'Platform and user experience improvement',
+        ],
+    ],
+
+    'legal_basis' => [
+        'heading' => 'Legal Basis',
+        'body' => 'The processing of your data is based on the following legal grounds: contract performance (bookings, payments), consent (non-essential cookies), legal obligations (Belgian invoicing, PEPPOL), and legitimate interest (platform security, service improvement).',
+    ],
+
+    'retention' => [
+        'heading' => 'Data Retention',
+        'body' => 'Your personal data is retained as long as your account is active. Invoicing data is retained for 7 years in accordance with Belgian accounting legislation. You may request deletion of your account at any time.',
+    ],
+
+    'rights' => [
+        'heading' => 'Your Rights',
+        'body' => 'Under the GDPR, you have the following rights:',
+        'items' => [
+            'access' => 'Right of access to your personal data',
+            'rectification' => 'Right to rectification of inaccurate data',
+            'erasure' => 'Right to erasure ("right to be forgotten")',
+            'restriction' => 'Right to restriction of processing',
+            'portability' => 'Right to data portability',
+            'objection' => 'Right to object to processing',
+        ],
+        'contact' => 'To exercise your rights, contact us via the platform\'s email address. You also have the right to lodge a complaint with the Belgian Data Protection Authority (DPA).',
+    ],
+
+    'third_parties' => [
+        'heading' => 'Third-Party Sharing',
+        'body' => 'Your data may be shared with the following third parties:',
+        'items' => [
+            'stripe' => 'Stripe — payment processing and coach account management (Stripe Connect)',
+            'hosting' => 'Hosting provider — secure data storage on EU-based servers',
+            'google' => 'Google — if you use Google OAuth login',
+        ],
+    ],
+
+    'cookies' => [
+        'heading' => 'Cookies',
+        'body' => 'The platform uses essential cookies for site operation (session, CSRF token, language preference). No advertising tracking cookies are used.',
+    ],
+
+    'security' => [
+        'heading' => 'Security',
+        'body' => 'We implement appropriate technical and organisational measures to protect your personal data, including password encryption, HTTPS connections, and two-factor authentication for sensitive roles.',
+    ],
+
+    'changes' => [
+        'heading' => 'Changes',
+        'body' => 'We may update this privacy policy. Any changes will be published on this page with a revised update date.',
+    ],
+
+];

--- a/lang/fr/common.php
+++ b/lang/fr/common.php
@@ -28,6 +28,7 @@ return [
 
     'footer' => [
         'rights' => 'Tous droits réservés.',
+        'privacy' => 'Politique de confidentialité',
     ],
 
     /*

--- a/lang/fr/privacy.php
+++ b/lang/fr/privacy.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | GDPR / Privacy Policy — French (fr-BE)
+    |--------------------------------------------------------------------------
+    */
+
+    'title' => 'Politique de confidentialité',
+    'print' => 'Imprimer',
+    'last_updated' => 'Dernière mise à jour : :date',
+
+    'intro' => [
+        'heading' => 'Introduction',
+        'body' => 'Motivya (ci-après « la Plateforme ») est exploitée conformément au Règlement Général sur la Protection des Données (RGPD — Règlement UE 2016/679) et à la législation belge applicable. La présente politique décrit comment nous collectons, utilisons, stockons et protégeons vos données personnelles.',
+    ],
+
+    'controller' => [
+        'heading' => 'Responsable du traitement',
+        'body' => 'Le responsable du traitement des données est la société exploitant Motivya. Pour toute question relative à vos données personnelles, vous pouvez nous contacter via l\'adresse e-mail indiquée sur la plateforme.',
+    ],
+
+    'data_collected' => [
+        'heading' => 'Données collectées',
+        'body' => 'Nous collectons les catégories de données suivantes :',
+        'items' => [
+            'identity' => 'Données d\'identité : nom, adresse e-mail',
+            'auth' => 'Données d\'authentification : mot de passe haché, identifiants OAuth (Google, Facebook)',
+            'role' => 'Données de rôle : votre rôle sur la plateforme (athlète, coach, comptable, administrateur)',
+            'payment' => 'Données de paiement : traitées par Stripe ; nous ne stockons pas vos données de carte bancaire',
+            'coach' => 'Données de coach : numéro d\'entreprise (BCE/KBO), spécialités, biographie, zone géographique',
+            'booking' => 'Données de réservation : séances réservées, montants payés, statuts',
+            'technical' => 'Données techniques : adresse IP, type de navigateur, préférence de langue',
+        ],
+    ],
+
+    'purpose' => [
+        'heading' => 'Finalités du traitement',
+        'body' => 'Vos données sont traitées pour les finalités suivantes :',
+        'items' => [
+            'account' => 'Gestion de votre compte et authentification',
+            'booking' => 'Traitement des réservations et paiements',
+            'communication' => 'Communication relative à vos réservations et à votre compte',
+            'legal' => 'Respect de nos obligations légales (facturation, TVA, lutte anti-blanchiment)',
+            'improvement' => 'Amélioration de la plateforme et de l\'expérience utilisateur',
+        ],
+    ],
+
+    'legal_basis' => [
+        'heading' => 'Base juridique',
+        'body' => 'Le traitement de vos données repose sur les bases juridiques suivantes : l\'exécution du contrat (réservations, paiements), le consentement (cookies non essentiels), les obligations légales (facturation belge, PEPPOL) et l\'intérêt légitime (sécurité de la plateforme, amélioration du service).',
+    ],
+
+    'retention' => [
+        'heading' => 'Durée de conservation',
+        'body' => 'Vos données personnelles sont conservées aussi longtemps que votre compte est actif. Les données de facturation sont conservées pendant 7 ans conformément à la législation comptable belge. Vous pouvez demander la suppression de votre compte à tout moment.',
+    ],
+
+    'rights' => [
+        'heading' => 'Vos droits',
+        'body' => 'Conformément au RGPD, vous disposez des droits suivants :',
+        'items' => [
+            'access' => 'Droit d\'accès à vos données personnelles',
+            'rectification' => 'Droit de rectification des données inexactes',
+            'erasure' => 'Droit à l\'effacement (« droit à l\'oubli »)',
+            'restriction' => 'Droit à la limitation du traitement',
+            'portability' => 'Droit à la portabilité des données',
+            'objection' => 'Droit d\'opposition au traitement',
+        ],
+        'contact' => 'Pour exercer vos droits, contactez-nous via l\'adresse e-mail de la plateforme. Vous avez également le droit d\'introduire une réclamation auprès de l\'Autorité de Protection des Données (APD) belge.',
+    ],
+
+    'third_parties' => [
+        'heading' => 'Partage avec des tiers',
+        'body' => 'Vos données peuvent être partagées avec les tiers suivants :',
+        'items' => [
+            'stripe' => 'Stripe — traitement des paiements et gestion des comptes coach (Stripe Connect)',
+            'hosting' => 'Hébergeur — stockage sécurisé des données sur des serveurs situés dans l\'UE',
+            'google' => 'Google — si vous utilisez la connexion via Google OAuth',
+        ],
+    ],
+
+    'cookies' => [
+        'heading' => 'Cookies',
+        'body' => 'La plateforme utilise des cookies essentiels pour le fonctionnement du site (session, jeton CSRF, préférence de langue). Aucun cookie de suivi publicitaire n\'est utilisé.',
+    ],
+
+    'security' => [
+        'heading' => 'Sécurité',
+        'body' => 'Nous mettons en œuvre des mesures techniques et organisationnelles appropriées pour protéger vos données personnelles, notamment le chiffrement des mots de passe, les connexions HTTPS, et l\'authentification à deux facteurs pour les rôles sensibles.',
+    ],
+
+    'changes' => [
+        'heading' => 'Modifications',
+        'body' => 'Nous pouvons mettre à jour cette politique de confidentialité. Toute modification sera publiée sur cette page avec une date de mise à jour révisée.',
+    ],
+
+];

--- a/lang/nl/common.php
+++ b/lang/nl/common.php
@@ -28,6 +28,7 @@ return [
 
     'footer' => [
         'rights' => 'Alle rechten voorbehouden.',
+        'privacy' => 'Privacybeleid',
     ],
 
     /*

--- a/lang/nl/privacy.php
+++ b/lang/nl/privacy.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | GDPR / Privacy Policy — Dutch (nl-BE)
+    |--------------------------------------------------------------------------
+    */
+
+    'title' => 'Privacybeleid',
+    'print' => 'Afdrukken',
+    'last_updated' => 'Laatst bijgewerkt: :date',
+
+    'intro' => [
+        'heading' => 'Inleiding',
+        'body' => 'Motivya (hierna "het Platform") opereert in overeenstemming met de Algemene Verordening Gegevensbescherming (AVG — EU-Verordening 2016/679) en de toepasselijke Belgische wetgeving. Dit beleid beschrijft hoe wij uw persoonsgegevens verzamelen, gebruiken, opslaan en beschermen.',
+    ],
+
+    'controller' => [
+        'heading' => 'Verwerkingsverantwoordelijke',
+        'body' => 'De verwerkingsverantwoordelijke is het bedrijf dat Motivya beheert. Voor vragen over uw persoonsgegevens kunt u contact met ons opnemen via het e-mailadres vermeld op het platform.',
+    ],
+
+    'data_collected' => [
+        'heading' => 'Verzamelde gegevens',
+        'body' => 'Wij verzamelen de volgende categorieën gegevens:',
+        'items' => [
+            'identity' => 'Identiteitsgegevens: naam, e-mailadres',
+            'auth' => 'Authenticatiegegevens: gehasht wachtwoord, OAuth-identifiers (Google, Facebook)',
+            'role' => 'Rolgegevens: uw rol op het platform (atleet, coach, boekhouder, beheerder)',
+            'payment' => 'Betalingsgegevens: verwerkt door Stripe; wij slaan uw kaartgegevens niet op',
+            'coach' => 'Coachgegevens: ondernemingsnummer (KBO/BCE), specialiteiten, biografie, geografische zone',
+            'booking' => 'Boekingsgegevens: geboekte sessies, betaalde bedragen, statussen',
+            'technical' => 'Technische gegevens: IP-adres, browsertype, taalvoorkeur',
+        ],
+    ],
+
+    'purpose' => [
+        'heading' => 'Doeleinden van de verwerking',
+        'body' => 'Uw gegevens worden verwerkt voor de volgende doeleinden:',
+        'items' => [
+            'account' => 'Accountbeheer en authenticatie',
+            'booking' => 'Verwerking van boekingen en betalingen',
+            'communication' => 'Communicatie over uw boekingen en account',
+            'legal' => 'Naleving van onze wettelijke verplichtingen (facturatie, btw, antiwitwas)',
+            'improvement' => 'Verbetering van het platform en de gebruikerservaring',
+        ],
+    ],
+
+    'legal_basis' => [
+        'heading' => 'Rechtsgrond',
+        'body' => 'De verwerking van uw gegevens is gebaseerd op de volgende rechtsgronden: uitvoering van het contract (boekingen, betalingen), toestemming (niet-essentiële cookies), wettelijke verplichtingen (Belgische facturatie, PEPPOL) en gerechtvaardigd belang (platformbeveiliging, verbetering van de dienst).',
+    ],
+
+    'retention' => [
+        'heading' => 'Bewaartermijn',
+        'body' => 'Uw persoonsgegevens worden bewaard zolang uw account actief is. Facturatiegegevens worden 7 jaar bewaard in overeenstemming met de Belgische boekhoudwetgeving. U kunt op elk moment verzoeken om verwijdering van uw account.',
+    ],
+
+    'rights' => [
+        'heading' => 'Uw rechten',
+        'body' => 'Op grond van de AVG heeft u de volgende rechten:',
+        'items' => [
+            'access' => 'Recht op inzage van uw persoonsgegevens',
+            'rectification' => 'Recht op rectificatie van onjuiste gegevens',
+            'erasure' => 'Recht op wissing ("recht om vergeten te worden")',
+            'restriction' => 'Recht op beperking van de verwerking',
+            'portability' => 'Recht op overdraagbaarheid van gegevens',
+            'objection' => 'Recht van bezwaar tegen de verwerking',
+        ],
+        'contact' => 'Om uw rechten uit te oefenen, kunt u contact met ons opnemen via het e-mailadres van het platform. U heeft ook het recht om een klacht in te dienen bij de Belgische Gegevensbeschermingsautoriteit (GBA).',
+    ],
+
+    'third_parties' => [
+        'heading' => 'Delen met derden',
+        'body' => 'Uw gegevens kunnen worden gedeeld met de volgende derden:',
+        'items' => [
+            'stripe' => 'Stripe — betalingsverwerking en beheer van coachaccounts (Stripe Connect)',
+            'hosting' => 'Hostingprovider — veilige gegevensopslag op servers binnen de EU',
+            'google' => 'Google — als u gebruik maakt van Google OAuth-aanmelding',
+        ],
+    ],
+
+    'cookies' => [
+        'heading' => 'Cookies',
+        'body' => 'Het platform maakt gebruik van essentiële cookies voor de werking van de site (sessie, CSRF-token, taalvoorkeur). Er worden geen advertentie-trackingcookies gebruikt.',
+    ],
+
+    'security' => [
+        'heading' => 'Beveiliging',
+        'body' => 'Wij nemen passende technische en organisatorische maatregelen om uw persoonsgegevens te beschermen, waaronder versleuteling van wachtwoorden, HTTPS-verbindingen en tweefactorauthenticatie voor gevoelige rollen.',
+    ],
+
+    'changes' => [
+        'heading' => 'Wijzigingen',
+        'body' => 'Wij kunnen dit privacybeleid bijwerken. Eventuele wijzigingen worden op deze pagina gepubliceerd met een herziene datum.',
+    ],
+
+];

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -2,10 +2,15 @@
 <footer class="mt-auto border-t border-gray-200 bg-white py-6 dark:border-gray-700 dark:bg-gray-800">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div class="flex flex-col items-center gap-2 text-center text-sm text-gray-500 dark:text-gray-400 sm:flex-row sm:justify-between">
-            <p>
-                &copy; {{ date('Y') }} {{ config('app.name') }}.
-                {{ __('common.footer.rights') }}
-            </p>
+            <div class="flex flex-col items-center gap-1 sm:flex-row sm:gap-3">
+                <p>
+                    &copy; {{ date('Y') }} {{ config('app.name') }}.
+                    {{ __('common.footer.rights') }}
+                </p>
+                <a href="{{ route('privacy') }}" class="hover:text-gray-700 dark:hover:text-gray-200">
+                    {{ __('common.footer.privacy') }}
+                </a>
+            </div>
             <x-nav.locale-switcher />
         </div>
     </div>

--- a/resources/views/pages/privacy.blade.php
+++ b/resources/views/pages/privacy.blade.php
@@ -1,0 +1,101 @@
+<x-layouts.app>
+    <x-slot:title>{{ __('privacy.title') }}</x-slot:title>
+
+    <x-slot:head>
+        <style>
+            @media print {
+                nav, footer, .no-print, [x-data] { display: none !important; }
+                main { max-width: 100% !important; padding: 0 !important; margin: 0 !important; }
+                body { background: white !important; color: black !important; }
+                a { text-decoration: underline; color: black !important; }
+                a::after { content: " (" attr(href) ")"; font-size: 0.8em; }
+            }
+        </style>
+    </x-slot:head>
+
+    <article class="prose mx-auto max-w-3xl dark:prose-invert lg:prose-lg">
+
+        <div class="mb-8 flex items-center justify-between">
+            <h1>{{ __('privacy.title') }}</h1>
+            <button type="button"
+                    onclick="window.print()"
+                    class="no-print inline-flex items-center gap-2 rounded-md bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />
+                </svg>
+                {{ __('privacy.print') }}
+            </button>
+        </div>
+
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+            {{ __('privacy.last_updated', ['date' => '2026-04-07']) }}
+        </p>
+
+        {{-- Introduction --}}
+        <h2>{{ __('privacy.intro.heading') }}</h2>
+        <p>{{ __('privacy.intro.body') }}</p>
+
+        {{-- Data Controller --}}
+        <h2>{{ __('privacy.controller.heading') }}</h2>
+        <p>{{ __('privacy.controller.body') }}</p>
+
+        {{-- Data Collected --}}
+        <h2>{{ __('privacy.data_collected.heading') }}</h2>
+        <p>{{ __('privacy.data_collected.body') }}</p>
+        <ul>
+            @foreach (__('privacy.data_collected.items') as $item)
+                <li>{{ $item }}</li>
+            @endforeach
+        </ul>
+
+        {{-- Purpose --}}
+        <h2>{{ __('privacy.purpose.heading') }}</h2>
+        <p>{{ __('privacy.purpose.body') }}</p>
+        <ul>
+            @foreach (__('privacy.purpose.items') as $item)
+                <li>{{ $item }}</li>
+            @endforeach
+        </ul>
+
+        {{-- Legal Basis --}}
+        <h2>{{ __('privacy.legal_basis.heading') }}</h2>
+        <p>{{ __('privacy.legal_basis.body') }}</p>
+
+        {{-- Retention --}}
+        <h2>{{ __('privacy.retention.heading') }}</h2>
+        <p>{{ __('privacy.retention.body') }}</p>
+
+        {{-- Your Rights --}}
+        <h2>{{ __('privacy.rights.heading') }}</h2>
+        <p>{{ __('privacy.rights.body') }}</p>
+        <ul>
+            @foreach (__('privacy.rights.items') as $item)
+                <li>{{ $item }}</li>
+            @endforeach
+        </ul>
+        <p>{{ __('privacy.rights.contact') }}</p>
+
+        {{-- Third Parties --}}
+        <h2>{{ __('privacy.third_parties.heading') }}</h2>
+        <p>{{ __('privacy.third_parties.body') }}</p>
+        <ul>
+            @foreach (__('privacy.third_parties.items') as $item)
+                <li>{{ $item }}</li>
+            @endforeach
+        </ul>
+
+        {{-- Cookies --}}
+        <h2>{{ __('privacy.cookies.heading') }}</h2>
+        <p>{{ __('privacy.cookies.body') }}</p>
+
+        {{-- Security --}}
+        <h2>{{ __('privacy.security.heading') }}</h2>
+        <p>{{ __('privacy.security.body') }}</p>
+
+        {{-- Changes --}}
+        <h2>{{ __('privacy.changes.heading') }}</h2>
+        <p>{{ __('privacy.changes.body') }}</p>
+
+    </article>
+
+</x-layouts.app>

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,6 +45,10 @@ Route::get('/health', function () {
     return response()->json($checks, $httpStatus);
 })->name('health');
 
+Route::get('/privacy', function () {
+    return view('pages.privacy');
+})->name('privacy');
+
 Route::get('/locale/{locale}', function (string $locale) {
     $supported = ['fr', 'en', 'nl'];
 

--- a/tests/Feature/Pages/PrivacyPageTest.php
+++ b/tests/Feature/Pages/PrivacyPageTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+describe('GET /privacy', function () {
+
+    it('returns a 200 response', function () {
+        $this->get(route('privacy'))
+            ->assertOk();
+    });
+
+    it('renders the privacy page title in French', function () {
+        $this->withSession(['locale' => 'fr'])
+            ->get(route('privacy'))
+            ->assertOk()
+            ->assertSee(__('privacy.title', [], 'fr'));
+    });
+
+    it('renders all section headings in French', function () {
+        $sections = [
+            'intro',
+            'controller',
+            'data_collected',
+            'purpose',
+            'legal_basis',
+            'retention',
+            'rights',
+            'third_parties',
+            'cookies',
+            'security',
+            'changes',
+        ];
+
+        $response = $this->withSession(['locale' => 'fr'])
+            ->get(route('privacy'));
+        $response->assertOk();
+
+        foreach ($sections as $section) {
+            $response->assertSee(__("privacy.{$section}.heading", [], 'fr'));
+        }
+    });
+
+    it('contains a print button', function () {
+        $this->get(route('privacy'))
+            ->assertOk()
+            ->assertSee('window.print()', false)
+            ->assertSee(__('privacy.print'));
+    });
+
+    it('renders correctly in English locale', function () {
+        $this->withSession(['locale' => 'en'])
+            ->get(route('privacy'))
+            ->assertOk()
+            ->assertSee(__('privacy.title', [], 'en'))
+            ->assertSee(__('privacy.intro.heading', [], 'en'));
+    });
+
+    it('renders correctly in Dutch locale', function () {
+        $this->withSession(['locale' => 'nl'])
+            ->get(route('privacy'))
+            ->assertOk()
+            ->assertSee(__('privacy.title', [], 'nl'))
+            ->assertSee(__('privacy.intro.heading', [], 'nl'));
+    });
+
+    it('is accessible from the footer on the home page', function () {
+        $this->get(route('home'))
+            ->assertOk()
+            ->assertSee(route('privacy'));
+    });
+
+    it('contains print-friendly CSS media query', function () {
+        $this->get(route('privacy'))
+            ->assertOk()
+            ->assertSee('@media print', false);
+    });
+
+});


### PR DESCRIPTION
## Summary

Implements the GDPR/Privacy page as a static legal page translated in all three locales (FR/EN/NL) with print support.

Resolves #36

## Changes

### New files
- `resources/views/pages/privacy.blade.php` — Privacy page using the master layout, with all GDPR sections and print-friendly CSS
- `lang/fr/privacy.php` — French translation (11 sections)
- `lang/en/privacy.php` — English translation (11 sections)
- `lang/nl/privacy.php` — Dutch translation (11 sections)
- `tests/Feature/Pages/PrivacyPageTest.php` — 8 Pest tests

### Modified files
- `routes/web.php` — Added `GET /privacy` route
- `resources/views/components/footer.blade.php` — Added privacy link
- `lang/{fr,en,nl}/common.php` — Added `footer.privacy` translation key

## Acceptance Criteria

- [x] `resources/views/pages/privacy.blade.php` — renders content based on current locale
- [x] Content in `lang/fr/privacy.php`, `lang/en/privacy.php`, `lang/nl/privacy.php`
- [x] Print-friendly CSS (`@media print`)
- [x] "Print" button on the page
- [x] Route: `GET /privacy`
- [x] Accessible from the footer
- [x] Feature test: page renders in each locale

## Tests

8 tests, 28 assertions — all passing. Full suite: 60 tests, 161 assertions passing.