### PR TITLE
feat: E1-S14 · User profile page (view + edit + 2FA settings)

### DIFF
--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Fortify;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
+use Laravel\Fortify\Contracts\UpdatesUserPasswords;
+
+class UpdateUserPassword implements UpdatesUserPasswords
+{
+    use PasswordValidationRules;
+
+    /**
+     * Validate and update the user's password.
+     *
+     * @param  array<string, string>  $input
+     */
+    public function update(User $user, array $input): void
+    {
+        Validator::make($input, [
+            'current_password' => ['required', 'string', 'current_password:web'],
+            'password' => $this->passwordRules(),
+        ])->validateWithBag('updatePassword');
+
+        $user->forceFill([
+            'password' => Hash::make($input['password']),
+        ])->save();
+    }
+}

--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Fortify;
+
+use App\Models\User;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
+
+class UpdateUserProfileInformation implements UpdatesUserProfileInformation
+{
+    /**
+     * Validate and update the given user's profile information.
+     *
+     * @param  array<string, string>  $input
+     */
+    public function update(User $user, array $input): void
+    {
+        Validator::make($input, [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => [
+                'required',
+                'string',
+                'email',
+                'max:255',
+                Rule::unique('users')->ignore($user->id),
+            ],
+        ])->validateWithBag('updateProfileInformation');
+
+        if (
+            $input['email'] !== $user->email
+            && $user instanceof MustVerifyEmail
+        ) {
+            $this->updateVerifiedUser($user, $input);
+        } else {
+            $user->forceFill([
+                'name' => $input['name'],
+                'email' => $input['email'],
+            ])->save();
+        }
+    }
+
+    /**
+     * Update the given verified user's profile information.
+     *
+     * @param  array<string, string>  $input
+     */
+    protected function updateVerifiedUser(User $user, array $input): void
+    {
+        $user->forceFill([
+            'name' => $input['name'],
+            'email' => $input['email'],
+            'email_verified_at' => null,
+        ])->save();
+
+        $user->sendEmailVerificationNotification();
+    }
+}

--- a/app/Livewire/Profile/Edit.php
+++ b/app/Livewire/Profile/Edit.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Profile;
+
+use App\Models\User;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
+
+final class Edit extends Component
+{
+    public string $locale = '';
+
+    public function mount(): void
+    {
+        /** @var User $user */
+        $user = Auth::user();
+        $this->locale = $user->locale ?? 'fr';
+    }
+
+    public function updateLocale(): void
+    {
+        $this->validate([
+            'locale' => ['required', 'string', 'in:fr,en,nl'],
+        ]);
+
+        /** @var User $user */
+        $user = Auth::user();
+        $user->update(['locale' => $this->locale]);
+
+        session(['locale' => $this->locale]);
+        app()->setLocale($this->locale);
+
+        $this->dispatch('notify', type: 'success', message: __('profile.locale_updated'));
+    }
+
+    public function render(): View
+    {
+        return view('livewire.profile.edit', [
+            'user' => Auth::user(),
+        ])->title(__('profile.title'));
+    }
+}

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -6,6 +6,8 @@ namespace App\Providers;
 
 use App\Actions\Fortify\CreateNewUser;
 use App\Actions\Fortify\ResetUserPassword;
+use App\Actions\Fortify\UpdateUserPassword;
+use App\Actions\Fortify\UpdateUserProfileInformation;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
@@ -29,6 +31,8 @@ class FortifyServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Fortify::createUsersUsing(CreateNewUser::class);
+        Fortify::updateUserProfileInformationUsing(UpdateUserProfileInformation::class);
+        Fortify::updateUserPasswordsUsing(UpdateUserPassword::class);
         Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
 
         RateLimiter::for('login', function (Request $request) {

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -147,6 +147,8 @@ return [
         Features::registration(),
         Features::resetPasswords(),
         Features::emailVerification(),
+        Features::updateProfileInformation(),
+        Features::updatePasswords(),
     ],
 
 ];

--- a/lang/en/profile.php
+++ b/lang/en/profile.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Profile Page
+    |--------------------------------------------------------------------------
+    */
+
+    'title' => 'Profile',
+    'heading' => 'Profile Settings',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Personal Information
+    |--------------------------------------------------------------------------
+    */
+
+    'info_heading' => 'Personal Information',
+    'info_description' => 'Update your name and email address.',
+    'info_name' => 'Full name',
+    'info_email' => 'Email address',
+    'info_submit' => 'Save',
+    'info_saved' => 'Saved.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password
+    |--------------------------------------------------------------------------
+    */
+
+    'password_heading' => 'Update Password',
+    'password_description' => 'Ensure your account is using a long, random password to stay secure.',
+    'password_current' => 'Current password',
+    'password_new' => 'New password',
+    'password_confirm' => 'Confirm password',
+    'password_submit' => 'Save',
+    'password_saved' => 'Saved.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Locale Preference
+    |--------------------------------------------------------------------------
+    */
+
+    'locale_heading' => 'Language Preference',
+    'locale_description' => 'Choose your preferred language for the interface.',
+    'locale_label' => 'Language',
+    'locale_fr' => 'Français',
+    'locale_en' => 'English',
+    'locale_nl' => 'Nederlands',
+    'locale_submit' => 'Save',
+    'locale_updated' => 'Language preference updated.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Two-Factor Authentication
+    |--------------------------------------------------------------------------
+    */
+
+    'twofa_heading' => 'Two-Factor Authentication',
+    'twofa_description' => 'Add additional security to your account using two-factor authentication.',
+    'twofa_not_available' => 'Two-factor authentication will be available in a future update.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Delete Account
+    |--------------------------------------------------------------------------
+    */
+
+    'delete_heading' => 'Delete Account',
+    'delete_description' => 'Once your account is deleted, all of its resources and data will be permanently deleted.',
+
+];

--- a/lang/fr/profile.php
+++ b/lang/fr/profile.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Page Profil
+    |--------------------------------------------------------------------------
+    */
+
+    'title' => 'Profil',
+    'heading' => 'Paramètres du profil',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Informations personnelles
+    |--------------------------------------------------------------------------
+    */
+
+    'info_heading' => 'Informations personnelles',
+    'info_description' => 'Mettez à jour votre nom et votre adresse e-mail.',
+    'info_name' => 'Nom complet',
+    'info_email' => 'Adresse e-mail',
+    'info_submit' => 'Enregistrer',
+    'info_saved' => 'Enregistré.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Mot de passe
+    |--------------------------------------------------------------------------
+    */
+
+    'password_heading' => 'Modifier le mot de passe',
+    'password_description' => 'Assurez-vous que votre compte utilise un mot de passe long et aléatoire pour rester sécurisé.',
+    'password_current' => 'Mot de passe actuel',
+    'password_new' => 'Nouveau mot de passe',
+    'password_confirm' => 'Confirmer le mot de passe',
+    'password_submit' => 'Enregistrer',
+    'password_saved' => 'Enregistré.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Préférence linguistique
+    |--------------------------------------------------------------------------
+    */
+
+    'locale_heading' => 'Préférence linguistique',
+    'locale_description' => 'Choisissez votre langue préférée pour l\'interface.',
+    'locale_label' => 'Langue',
+    'locale_fr' => 'Français',
+    'locale_en' => 'English',
+    'locale_nl' => 'Nederlands',
+    'locale_submit' => 'Enregistrer',
+    'locale_updated' => 'Préférence linguistique mise à jour.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentification à deux facteurs
+    |--------------------------------------------------------------------------
+    */
+
+    'twofa_heading' => 'Authentification à deux facteurs',
+    'twofa_description' => 'Ajoutez une sécurité supplémentaire à votre compte en utilisant l\'authentification à deux facteurs.',
+    'twofa_not_available' => 'L\'authentification à deux facteurs sera disponible dans une prochaine mise à jour.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Supprimer le compte
+    |--------------------------------------------------------------------------
+    */
+
+    'delete_heading' => 'Supprimer le compte',
+    'delete_description' => 'Une fois que votre compte est supprimé, toutes ses ressources et données seront définitivement supprimées.',
+
+];

--- a/lang/nl/profile.php
+++ b/lang/nl/profile.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Profielpagina
+    |--------------------------------------------------------------------------
+    */
+
+    'title' => 'Profiel',
+    'heading' => 'Profielinstellingen',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Persoonlijke informatie
+    |--------------------------------------------------------------------------
+    */
+
+    'info_heading' => 'Persoonlijke informatie',
+    'info_description' => 'Werk uw naam en e-mailadres bij.',
+    'info_name' => 'Volledige naam',
+    'info_email' => 'E-mailadres',
+    'info_submit' => 'Opslaan',
+    'info_saved' => 'Opgeslagen.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Wachtwoord
+    |--------------------------------------------------------------------------
+    */
+
+    'password_heading' => 'Wachtwoord wijzigen',
+    'password_description' => 'Zorg ervoor dat uw account een lang, willekeurig wachtwoord gebruikt om veilig te blijven.',
+    'password_current' => 'Huidig wachtwoord',
+    'password_new' => 'Nieuw wachtwoord',
+    'password_confirm' => 'Bevestig wachtwoord',
+    'password_submit' => 'Opslaan',
+    'password_saved' => 'Opgeslagen.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Taalvoorkeur
+    |--------------------------------------------------------------------------
+    */
+
+    'locale_heading' => 'Taalvoorkeur',
+    'locale_description' => 'Kies uw voorkeurstaal voor de interface.',
+    'locale_label' => 'Taal',
+    'locale_fr' => 'Français',
+    'locale_en' => 'English',
+    'locale_nl' => 'Nederlands',
+    'locale_submit' => 'Opslaan',
+    'locale_updated' => 'Taalvoorkeur bijgewerkt.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Tweefactorauthenticatie
+    |--------------------------------------------------------------------------
+    */
+
+    'twofa_heading' => 'Tweefactorauthenticatie',
+    'twofa_description' => 'Voeg extra beveiliging toe aan uw account met tweefactorauthenticatie.',
+    'twofa_not_available' => 'Tweefactorauthenticatie zal beschikbaar zijn in een toekomstige update.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Account verwijderen
+    |--------------------------------------------------------------------------
+    */
+
+    'delete_heading' => 'Account verwijderen',
+    'delete_description' => 'Zodra uw account is verwijderd, worden alle bronnen en gegevens permanent verwijderd.',
+
+];

--- a/resources/views/components/nav/mobile-menu.blade.php
+++ b/resources/views/components/nav/mobile-menu.blade.php
@@ -26,9 +26,9 @@
                class="block rounded-md px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-gray-700">
                 {{ __('common.nav.bookings') }}
             </a>
-            {{-- TODO: replace href with route('profile.edit') when E1-S14 profile route is implemented --}}
-            <a href="#"
-               class="block rounded-md px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-gray-700">
+            <a href="{{ route('profile.edit') }}"
+               class="block rounded-md px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-gray-700"
+               wire:navigate>
                 {{ __('common.nav.profile') }}
             </a>
 

--- a/resources/views/components/nav/user-menu.blade.php
+++ b/resources/views/components/nav/user-menu.blade.php
@@ -36,11 +36,11 @@
         aria-label="{{ __('common.user_menu') }}"
         style="display: none;"
     >
-        {{-- TODO: replace href with route('profile.edit') when E1-S14 profile route is implemented --}}
         <a
-            href="#"
+            href="{{ route('profile.edit') }}"
             class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
             role="menuitem"
+            wire:navigate
         >
             {{ __('common.nav.profile') }}
         </a>

--- a/resources/views/livewire/profile/edit.blade.php
+++ b/resources/views/livewire/profile/edit.blade.php
@@ -1,0 +1,203 @@
+<div class="mx-auto max-w-3xl space-y-8 px-4 py-8 sm:px-6 lg:px-8">
+    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
+        {{ __('profile.heading') }}
+    </h1>
+
+    {{-- Personal Information --}}
+    <section class="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+            {{ __('profile.info_heading') }}
+        </h2>
+        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            {{ __('profile.info_description') }}
+        </p>
+
+        <form method="POST" action="{{ route('user-profile-information.update') }}" class="mt-6 space-y-4">
+            @csrf
+            @method('PUT')
+
+            <div>
+                <label for="name" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('profile.info_name') }}
+                </label>
+                <input
+                    type="text"
+                    id="name"
+                    name="name"
+                    value="{{ old('name', $user->name) }}"
+                    required
+                    autocomplete="name"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                />
+                @error('name', 'updateProfileInformation')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div>
+                <label for="email" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('profile.info_email') }}
+                </label>
+                <input
+                    type="email"
+                    id="email"
+                    name="email"
+                    value="{{ old('email', $user->email) }}"
+                    required
+                    autocomplete="email"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                />
+                @error('email', 'updateProfileInformation')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div class="flex items-center gap-4">
+                <button
+                    type="submit"
+                    class="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                >
+                    {{ __('profile.info_submit') }}
+                </button>
+
+                @if (session('status') === 'profile-information-updated')
+                    <p class="text-sm text-green-600 dark:text-green-400">{{ __('profile.info_saved') }}</p>
+                @endif
+            </div>
+        </form>
+    </section>
+
+    {{-- Update Password --}}
+    <section class="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+            {{ __('profile.password_heading') }}
+        </h2>
+        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            {{ __('profile.password_description') }}
+        </p>
+
+        <form method="POST" action="{{ route('user-password.update') }}" class="mt-6 space-y-4">
+            @csrf
+            @method('PUT')
+
+            <div>
+                <label for="current_password" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('profile.password_current') }}
+                </label>
+                <input
+                    type="password"
+                    id="current_password"
+                    name="current_password"
+                    required
+                    autocomplete="current-password"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                />
+                @error('current_password', 'updatePassword')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div>
+                <label for="password" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('profile.password_new') }}
+                </label>
+                <input
+                    type="password"
+                    id="password"
+                    name="password"
+                    required
+                    autocomplete="new-password"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                />
+                @error('password', 'updatePassword')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div>
+                <label for="password_confirmation" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('profile.password_confirm') }}
+                </label>
+                <input
+                    type="password"
+                    id="password_confirmation"
+                    name="password_confirmation"
+                    required
+                    autocomplete="new-password"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                />
+                @error('password_confirmation', 'updatePassword')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div class="flex items-center gap-4">
+                <button
+                    type="submit"
+                    class="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                >
+                    {{ __('profile.password_submit') }}
+                </button>
+
+                @if (session('status') === 'password-updated')
+                    <p class="text-sm text-green-600 dark:text-green-400">{{ __('profile.password_saved') }}</p>
+                @endif
+            </div>
+        </form>
+    </section>
+
+    {{-- Locale Preference --}}
+    <section class="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+            {{ __('profile.locale_heading') }}
+        </h2>
+        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            {{ __('profile.locale_description') }}
+        </p>
+
+        <form wire:submit="updateLocale" class="mt-6 space-y-4">
+            <div>
+                <label for="locale" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('profile.locale_label') }}
+                </label>
+                <select
+                    wire:model="locale"
+                    id="locale"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                >
+                    <option value="fr">{{ __('profile.locale_fr') }}</option>
+                    <option value="en">{{ __('profile.locale_en') }}</option>
+                    <option value="nl">{{ __('profile.locale_nl') }}</option>
+                </select>
+                @error('locale')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div>
+                <button
+                    type="submit"
+                    class="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                >
+                    {{ __('profile.locale_submit') }}
+                </button>
+            </div>
+        </form>
+    </section>
+
+    {{-- Two-Factor Authentication (placeholder) --}}
+    <section class="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+            {{ __('profile.twofa_heading') }}
+        </h2>
+        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            {{ __('profile.twofa_description') }}
+        </p>
+
+        <div class="mt-4 rounded-md bg-gray-50 p-4 dark:bg-gray-700">
+            <p class="text-sm text-gray-500 dark:text-gray-400">
+                {{ __('profile.twofa_not_available') }}
+            </p>
+        </div>
+    </section>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Livewire\Auth\Login;
 use App\Livewire\Auth\Register;
 use App\Livewire\Auth\ResetPassword;
 use App\Livewire\Auth\VerifyEmail;
+use App\Livewire\Profile\Edit as ProfileEdit;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
 
@@ -25,6 +26,10 @@ Route::middleware('guest')->group(function () {
 Route::get('/email/verify', VerifyEmail::class)
     ->middleware('auth')
     ->name('verification.notice');
+
+Route::get('/profile', ProfileEdit::class)
+    ->middleware('auth')
+    ->name('profile.edit');
 
 Route::get('/health', function () {
     $checks = ['status' => 'ok'];

--- a/tests/Feature/Livewire/Profile/EditTest.php
+++ b/tests/Feature/Livewire/Profile/EditTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Profile\Edit;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+describe('Profile Edit Livewire Component', function () {
+
+    it('renders the profile page for authenticated users', function () {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('profile.edit'))
+            ->assertOk()
+            ->assertSeeLivewire(Edit::class);
+    });
+
+    it('redirects guests to login', function () {
+        $this->get(route('profile.edit'))
+            ->assertRedirect(route('login'));
+    });
+
+    it('displays translated heading', function () {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('profile.edit'))
+            ->assertSee(__('profile.heading'));
+    });
+
+    it('shows all profile sections', function () {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('profile.edit'))
+            ->assertSee(__('profile.info_heading'))
+            ->assertSee(__('profile.password_heading'))
+            ->assertSee(__('profile.locale_heading'))
+            ->assertSee(__('profile.twofa_heading'));
+    });
+
+    it('contains the profile information form posting to Fortify route', function () {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('profile.edit'))
+            ->assertSee('action="'.route('user-profile-information.update').'"', escape: false)
+            ->assertSee('name="name"', escape: false)
+            ->assertSee('name="email"', escape: false);
+    });
+
+    it('contains the password update form posting to Fortify route', function () {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('profile.edit'))
+            ->assertSee('action="'.route('user-password.update').'"', escape: false)
+            ->assertSee('name="current_password"', escape: false)
+            ->assertSee('name="password"', escape: false)
+            ->assertSee('name="password_confirmation"', escape: false);
+    });
+
+    it('pre-fills the user name and email', function () {
+        $user = User::factory()->create([
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('profile.edit'))
+            ->assertSee('value="John Doe"', escape: false)
+            ->assertSee('value="john@example.com"', escape: false);
+    });
+
+    it('shows the 2FA placeholder section', function () {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('profile.edit'))
+            ->assertSee(__('profile.twofa_not_available'));
+    });
+
+});
+
+describe('Profile Edit — Locale Preference', function () {
+
+    it('pre-fills the locale from user profile', function () {
+        $user = User::factory()->create(['locale' => 'nl']);
+
+        Livewire::actingAs($user)
+            ->test(Edit::class)
+            ->assertSet('locale', 'nl');
+    });
+
+    it('updates the user locale preference', function () {
+        $user = User::factory()->create(['locale' => 'fr']);
+
+        Livewire::actingAs($user)
+            ->test(Edit::class)
+            ->set('locale', 'en')
+            ->call('updateLocale')
+            ->assertHasNoErrors();
+
+        expect($user->fresh()->locale)->toBe('en');
+    });
+
+    it('rejects invalid locale values', function () {
+        $user = User::factory()->create(['locale' => 'fr']);
+
+        Livewire::actingAs($user)
+            ->test(Edit::class)
+            ->set('locale', 'de')
+            ->call('updateLocale')
+            ->assertHasErrors('locale');
+    });
+
+    it('updates the session locale', function () {
+        $user = User::factory()->create(['locale' => 'fr']);
+
+        Livewire::actingAs($user)
+            ->test(Edit::class)
+            ->set('locale', 'nl')
+            ->call('updateLocale');
+
+        expect(session('locale'))->toBe('nl');
+    });
+
+});
+
+describe('Profile Edit — Fortify Profile Information Update', function () {
+
+    it('updates the user name', function () {
+        $user = User::factory()->create([
+            'name' => 'Old Name',
+            'email' => 'user@example.com',
+        ]);
+
+        $this->actingAs($user)
+            ->put(route('user-profile-information.update'), [
+                'name' => 'New Name',
+                'email' => 'user@example.com',
+            ])
+            ->assertSessionHasNoErrors()
+            ->assertRedirect();
+
+        expect($user->fresh()->name)->toBe('New Name');
+    });
+
+    it('updates the user email and resets verification', function () {
+        $user = User::factory()->create([
+            'name' => 'Test User',
+            'email' => 'old@example.com',
+            'email_verified_at' => now(),
+        ]);
+
+        $this->actingAs($user)
+            ->put(route('user-profile-information.update'), [
+                'name' => 'Test User',
+                'email' => 'new@example.com',
+            ])
+            ->assertSessionHasNoErrors()
+            ->assertRedirect();
+
+        $user->refresh();
+        expect($user->email)->toBe('new@example.com');
+        expect($user->email_verified_at)->toBeNull();
+    });
+
+    it('rejects duplicate email', function () {
+        User::factory()->create(['email' => 'taken@example.com']);
+        $user = User::factory()->create(['email' => 'mine@example.com']);
+
+        $this->actingAs($user)
+            ->put(route('user-profile-information.update'), [
+                'name' => 'Test',
+                'email' => 'taken@example.com',
+            ])
+            ->assertSessionHasErrors('email', errorBag: 'updateProfileInformation');
+    });
+
+});
+
+describe('Profile Edit — Fortify Password Update', function () {
+
+    it('updates the user password', function () {
+        $user = User::factory()->create([
+            'password' => bcrypt('OldPassword1!'),
+        ]);
+
+        $this->actingAs($user)
+            ->put(route('user-password.update'), [
+                'current_password' => 'OldPassword1!',
+                'password' => 'NewPassword1!',
+                'password_confirmation' => 'NewPassword1!',
+            ])
+            ->assertSessionHasNoErrors()
+            ->assertRedirect();
+
+        expect(app('hash')->check('NewPassword1!', $user->fresh()->password))->toBeTrue();
+    });
+
+    it('rejects incorrect current password', function () {
+        $user = User::factory()->create([
+            'password' => bcrypt('CorrectPassword1!'),
+        ]);
+
+        $this->actingAs($user)
+            ->put(route('user-password.update'), [
+                'current_password' => 'WrongPassword!',
+                'password' => 'NewPassword1!',
+                'password_confirmation' => 'NewPassword1!',
+            ])
+            ->assertSessionHasErrors('current_password', errorBag: 'updatePassword');
+    });
+
+    it('rejects mismatched password confirmation', function () {
+        $user = User::factory()->create([
+            'password' => bcrypt('OldPassword1!'),
+        ]);
+
+        $this->actingAs($user)
+            ->put(route('user-password.update'), [
+                'current_password' => 'OldPassword1!',
+                'password' => 'NewPassword1!',
+                'password_confirmation' => 'Different1!',
+            ])
+            ->assertSessionHasErrors('password', errorBag: 'updatePassword');
+    });
+
+});


### PR DESCRIPTION
## Summary

Implements the user profile page where authenticated users can view/edit their personal information, change their password, and set their locale preference.

## Changes

### Fortify Integration
- Enable `updateProfileInformation` and `updatePasswords` features in `config/fortify.php`
- Create `UpdateUserProfileInformation` action — validates name/email, resets email verification on change
- Create `UpdateUserPassword` action — validates current password + new password with confirmation
- Register both actions in `FortifyServiceProvider`

### Profile Page
- `app/Livewire/Profile/Edit.php` — Livewire component serving as view wrapper; handles locale preference via Livewire action
- `resources/views/livewire/profile/edit.blade.php` — mobile-first layout with 4 sections:
  - **Personal Information** — name & email form POSTing to Fortify's `PUT /user/profile-information`
  - **Update Password** — current + new password form POSTing to Fortify's `PUT /user/password`
  - **Language Preference** — Livewire-powered locale selector (fr/en/nl)
  - **Two-Factor Authentication** — placeholder section (depends on E1-S05/E1-S06, not yet implemented)

### Navigation
- Wire profile links in `user-menu.blade.php` and `mobile-menu.blade.php` (replacing TODO placeholders)

### Translations
- `lang/{fr,en,nl}/profile.php` — all profile page strings in 3 locales

### Route
- `GET /profile` → `Profile\Edit` (requires `auth` middleware), named `profile.edit`

### Tests (18 tests)
- Livewire component rendering tests (auth required, redirects guests, shows all sections)
- Fortify form structure verification (correct routes, field names, pre-filled values)
- Locale preference update (valid/invalid values, session sync)
- Profile information update via Fortify (name change, email change resets verification, duplicate rejection)
- Password update via Fortify (success, wrong current password, mismatched confirmation)
- 2FA placeholder visibility

## Acceptance Criteria Status

- [x] `app/Livewire/Profile/Edit.php`
- [x] Sections: personal info, password change, 2FA management, locale preference
- [x] 2FA section: placeholder (E1-S05/E1-S06 not yet implemented — shows "coming soon" message)
- [x] All strings localized (fr, en, nl)
- [x] Mobile-first layout
- [x] Livewire component test

> **Note**: The `ProfileForm.php` Form Object listed in the AC was intentionally omitted. Personal info and password forms POST directly to Fortify routes (standard Laravel best practice), so a Livewire Form Object would duplicate Fortify's validation. Only the locale preference uses Livewire's action method with inline validation.

Resolves #30