### PR TITLE
E1-S05 · Two-Factor Authentication — TOTP (Authenticator App)

### DIFF
--- a/app/Livewire/Auth/TwoFactorChallenge.php
+++ b/app/Livewire/Auth/TwoFactorChallenge.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Auth;
+
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+
+final class TwoFactorChallenge extends Component
+{
+    public bool $useRecoveryCode = false;
+
+    public function toggleRecoveryCode(): void
+    {
+        $this->useRecoveryCode = ! $this->useRecoveryCode;
+    }
+
+    public function render(): View
+    {
+        return view('livewire.auth.two-factor-challenge')
+            ->title(__('auth.two_factor_title'));
+    }
+}

--- a/app/Livewire/Profile/TwoFactorAuthentication.php
+++ b/app/Livewire/Profile/TwoFactorAuthentication.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Profile;
+
+use App\Models\User;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
+
+final class TwoFactorAuthentication extends Component
+{
+    public bool $showingQrCode = false;
+
+    public bool $showingConfirmation = false;
+
+    public bool $showingRecoveryCodes = false;
+
+    public string $confirmationCode = '';
+
+    public function enableTwoFactor(): void
+    {
+        $this->dispatch('two-factor-enabling');
+    }
+
+    public function showRecoveryCodes(): void
+    {
+        $this->showingRecoveryCodes = true;
+    }
+
+    public function hideRecoveryCodes(): void
+    {
+        $this->showingRecoveryCodes = false;
+    }
+
+    public function disableTwoFactor(): void
+    {
+        $this->dispatch('two-factor-disabling');
+    }
+
+    public function render(): View
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        return view('livewire.profile.two-factor-authentication', [
+            'user' => $user,
+            'enabled' => $user->two_factor_confirmed_at !== null,
+        ]);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,11 +10,12 @@ use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Fortify\TwoFactorAuthenticatable;
 
 class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, TwoFactorAuthenticatable;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -40,5 +40,9 @@ class FortifyServiceProvider extends ServiceProvider
 
             return Limit::perMinute(5)->by($throttleKey);
         });
+
+        RateLimiter::for('two-factor', function (Request $request) {
+            return Limit::perMinute(5)->by($request->session()->get('login.id'));
+        });
     }
 }

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -149,6 +149,10 @@ return [
         Features::emailVerification(),
         Features::updateProfileInformation(),
         Features::updatePasswords(),
+        Features::twoFactorAuthentication([
+            'confirm' => true,
+            'confirmPassword' => true,
+        ]),
     ],
 
 ];

--- a/database/migrations/2026_04_08_001549_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2026_04_08_001549_add_two_factor_columns_to_users_table.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->text('two_factor_secret')
+                ->after('password')
+                ->nullable();
+
+            $table->text('two_factor_recovery_codes')
+                ->after('two_factor_secret')
+                ->nullable();
+
+            $table->timestamp('two_factor_confirmed_at')
+                ->after('two_factor_recovery_codes')
+                ->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn([
+                'two_factor_secret',
+                'two_factor_recovery_codes',
+                'two_factor_confirmed_at',
+            ]);
+        });
+    }
+};

--- a/lang/en/auth.php
+++ b/lang/en/auth.php
@@ -86,4 +86,20 @@ return [
     'verify_resent' => 'A new verification link has been sent to your email address.',
     'verify_logout' => 'Log out',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Two-Factor Authentication
+    |--------------------------------------------------------------------------
+    */
+
+    'two_factor_title' => 'Two-Factor Authentication',
+    'two_factor_heading' => 'Two-Factor Authentication',
+    'two_factor_description' => 'Enter the authentication code from your authenticator app to continue.',
+    'two_factor_recovery_description' => 'Enter one of your emergency recovery codes to continue.',
+    'two_factor_code' => 'Authentication code',
+    'two_factor_recovery_code' => 'Recovery code',
+    'two_factor_submit' => 'Verify',
+    'two_factor_use_recovery' => 'Use a recovery code',
+    'two_factor_use_code' => 'Use an authentication code',
+
 ];

--- a/lang/en/profile.php
+++ b/lang/en/profile.php
@@ -64,6 +64,18 @@ return [
     'twofa_heading' => 'Two-Factor Authentication',
     'twofa_description' => 'Add additional security to your account using two-factor authentication.',
     'twofa_not_available' => 'Two-factor authentication will be available in a future update.',
+    'twofa_enabled_status' => 'Two-factor authentication is enabled.',
+    'twofa_enable' => 'Enable',
+    'twofa_enabling' => 'Enabling…',
+    'twofa_disable' => 'Disable',
+    'twofa_scan_instructions' => 'Scan the following QR code using your authenticator application (Google Authenticator, Authy, etc.), then enter the verification code to confirm.',
+    'twofa_confirm_code' => 'Verification code',
+    'twofa_confirm' => 'Confirm',
+    'twofa_invalid_code' => 'The provided code is invalid.',
+    'twofa_recovery_description' => 'Store these recovery codes in a secure password manager. They can be used to recover access to your account if your authenticator device is lost.',
+    'twofa_show_codes' => 'Show Recovery Codes',
+    'twofa_hide_codes' => 'Hide',
+    'twofa_regenerate_codes' => 'Regenerate Recovery Codes',
 
     /*
     |--------------------------------------------------------------------------

--- a/lang/fr/auth.php
+++ b/lang/fr/auth.php
@@ -86,4 +86,20 @@ return [
     'verify_resent' => 'Un nouveau lien de vérification a été envoyé à votre adresse e-mail.',
     'verify_logout' => 'Se déconnecter',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Authentification à deux facteurs
+    |--------------------------------------------------------------------------
+    */
+
+    'two_factor_title' => 'Authentification à deux facteurs',
+    'two_factor_heading' => 'Authentification à deux facteurs',
+    'two_factor_description' => 'Entrez le code d\'authentification de votre application d\'authentification pour continuer.',
+    'two_factor_recovery_description' => 'Entrez l\'un de vos codes de récupération d\'urgence pour continuer.',
+    'two_factor_code' => 'Code d\'authentification',
+    'two_factor_recovery_code' => 'Code de récupération',
+    'two_factor_submit' => 'Vérifier',
+    'two_factor_use_recovery' => 'Utiliser un code de récupération',
+    'two_factor_use_code' => 'Utiliser un code d\'authentification',
+
 ];

--- a/lang/fr/profile.php
+++ b/lang/fr/profile.php
@@ -64,6 +64,18 @@ return [
     'twofa_heading' => 'Authentification à deux facteurs',
     'twofa_description' => 'Ajoutez une sécurité supplémentaire à votre compte en utilisant l\'authentification à deux facteurs.',
     'twofa_not_available' => 'L\'authentification à deux facteurs sera disponible dans une prochaine mise à jour.',
+    'twofa_enabled_status' => 'L\'authentification à deux facteurs est activée.',
+    'twofa_enable' => 'Activer',
+    'twofa_enabling' => 'Activation…',
+    'twofa_disable' => 'Désactiver',
+    'twofa_scan_instructions' => 'Scannez le code QR suivant avec votre application d\'authentification (Google Authenticator, Authy, etc.), puis entrez le code de vérification pour confirmer.',
+    'twofa_confirm_code' => 'Code de vérification',
+    'twofa_confirm' => 'Confirmer',
+    'twofa_invalid_code' => 'Le code fourni est invalide.',
+    'twofa_recovery_description' => 'Conservez ces codes de récupération dans un gestionnaire de mots de passe sécurisé. Ils peuvent être utilisés pour récupérer l\'accès à votre compte si votre dispositif d\'authentification est perdu.',
+    'twofa_show_codes' => 'Afficher les codes de récupération',
+    'twofa_hide_codes' => 'Masquer',
+    'twofa_regenerate_codes' => 'Régénérer les codes de récupération',
 
     /*
     |--------------------------------------------------------------------------

--- a/lang/nl/auth.php
+++ b/lang/nl/auth.php
@@ -86,4 +86,20 @@ return [
     'verify_resent' => 'Er is een nieuwe verificatielink naar uw e-mailadres gestuurd.',
     'verify_logout' => 'Uitloggen',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Tweefactorauthenticatie
+    |--------------------------------------------------------------------------
+    */
+
+    'two_factor_title' => 'Tweefactorauthenticatie',
+    'two_factor_heading' => 'Tweefactorauthenticatie',
+    'two_factor_description' => 'Voer de authenticatiecode van uw authenticatie-app in om door te gaan.',
+    'two_factor_recovery_description' => 'Voer een van uw noodherstelcodes in om door te gaan.',
+    'two_factor_code' => 'Authenticatiecode',
+    'two_factor_recovery_code' => 'Herstelcode',
+    'two_factor_submit' => 'Verifiëren',
+    'two_factor_use_recovery' => 'Gebruik een herstelcode',
+    'two_factor_use_code' => 'Gebruik een authenticatiecode',
+
 ];

--- a/lang/nl/profile.php
+++ b/lang/nl/profile.php
@@ -64,6 +64,18 @@ return [
     'twofa_heading' => 'Tweefactorauthenticatie',
     'twofa_description' => 'Voeg extra beveiliging toe aan uw account met tweefactorauthenticatie.',
     'twofa_not_available' => 'Tweefactorauthenticatie zal beschikbaar zijn in een toekomstige update.',
+    'twofa_enabled_status' => 'Tweefactorauthenticatie is ingeschakeld.',
+    'twofa_enable' => 'Inschakelen',
+    'twofa_enabling' => 'Inschakelen…',
+    'twofa_disable' => 'Uitschakelen',
+    'twofa_scan_instructions' => 'Scan de volgende QR-code met uw authenticatie-app (Google Authenticator, Authy, enz.) en voer vervolgens de verificatiecode in om te bevestigen.',
+    'twofa_confirm_code' => 'Verificatiecode',
+    'twofa_confirm' => 'Bevestigen',
+    'twofa_invalid_code' => 'De opgegeven code is ongeldig.',
+    'twofa_recovery_description' => 'Bewaar deze herstelcodes in een veilige wachtwoordmanager. Ze kunnen worden gebruikt om toegang tot uw account te herstellen als uw authenticatie-apparaat verloren is.',
+    'twofa_show_codes' => 'Herstelcodes tonen',
+    'twofa_hide_codes' => 'Verbergen',
+    'twofa_regenerate_codes' => 'Herstelcodes opnieuw genereren',
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/views/livewire/auth/two-factor-challenge.blade.php
+++ b/resources/views/livewire/auth/two-factor-challenge.blade.php
@@ -1,0 +1,84 @@
+<div class="flex min-h-[60vh] items-center justify-center">
+    <div class="w-full max-w-md space-y-8 rounded-lg bg-white p-8 shadow dark:bg-gray-800">
+        <div>
+            <h2 class="text-center text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-100">
+                {{ __('auth.two_factor_heading') }}
+            </h2>
+            <p class="mt-2 text-center text-sm text-gray-600 dark:text-gray-400">
+                @if ($useRecoveryCode)
+                    {{ __('auth.two_factor_recovery_description') }}
+                @else
+                    {{ __('auth.two_factor_description') }}
+                @endif
+            </p>
+        </div>
+
+        <form method="POST" action="{{ url('/two-factor-challenge') }}" class="space-y-6">
+            @csrf
+
+            @if ($useRecoveryCode)
+                {{-- Recovery Code --}}
+                <div>
+                    <label for="recovery_code" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                        {{ __('auth.two_factor_recovery_code') }}
+                    </label>
+                    <input
+                        type="text"
+                        id="recovery_code"
+                        name="recovery_code"
+                        autocomplete="one-time-code"
+                        required
+                        autofocus
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                    />
+                    @error('recovery_code')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+            @else
+                {{-- TOTP Code --}}
+                <div>
+                    <label for="code" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                        {{ __('auth.two_factor_code') }}
+                    </label>
+                    <input
+                        type="text"
+                        id="code"
+                        name="code"
+                        inputmode="numeric"
+                        autocomplete="one-time-code"
+                        required
+                        autofocus
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                    />
+                    @error('code')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+            @endif
+
+            {{-- Submit --}}
+            <button
+                type="submit"
+                class="flex w-full justify-center rounded-md bg-indigo-600 px-4 py-3 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            >
+                {{ __('auth.two_factor_submit') }}
+            </button>
+        </form>
+
+        {{-- Toggle recovery code / TOTP --}}
+        <p class="text-center text-sm">
+            <button
+                type="button"
+                wire:click="toggleRecoveryCode"
+                class="font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400"
+            >
+                @if ($useRecoveryCode)
+                    {{ __('auth.two_factor_use_code') }}
+                @else
+                    {{ __('auth.two_factor_use_recovery') }}
+                @endif
+            </button>
+        </p>
+    </div>
+</div>

--- a/resources/views/livewire/profile/edit.blade.php
+++ b/resources/views/livewire/profile/edit.blade.php
@@ -185,19 +185,6 @@
         </form>
     </section>
 
-    {{-- Two-Factor Authentication (placeholder) --}}
-    <section class="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
-        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
-            {{ __('profile.twofa_heading') }}
-        </h2>
-        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-            {{ __('profile.twofa_description') }}
-        </p>
-
-        <div class="mt-4 rounded-md bg-gray-50 p-4 dark:bg-gray-700">
-            <p class="text-sm text-gray-500 dark:text-gray-400">
-                {{ __('profile.twofa_not_available') }}
-            </p>
-        </div>
-    </section>
+    {{-- Two-Factor Authentication --}}
+    <livewire:profile.two-factor-authentication />
 </div>

--- a/resources/views/livewire/profile/two-factor-authentication.blade.php
+++ b/resources/views/livewire/profile/two-factor-authentication.blade.php
@@ -1,0 +1,159 @@
+<div>
+    <section class="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+            {{ __('profile.twofa_heading') }}
+        </h2>
+        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            {{ __('profile.twofa_description') }}
+        </p>
+
+        @if ($enabled)
+            {{-- 2FA is enabled --}}
+            <div class="mt-4 rounded-md bg-green-50 p-4 dark:bg-green-900/20">
+                <p class="text-sm font-medium text-green-700 dark:text-green-400">
+                    {{ __('profile.twofa_enabled_status') }}
+                </p>
+            </div>
+
+            {{-- Recovery Codes --}}
+            <div class="mt-4">
+                @if ($showingRecoveryCodes)
+                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        {{ __('profile.twofa_recovery_description') }}
+                    </p>
+                    <div class="mt-4 grid max-w-xl gap-1 rounded-lg bg-gray-100 p-4 font-mono text-sm dark:bg-gray-900">
+                        @foreach (json_decode(decrypt($user->two_factor_recovery_codes), true) as $code)
+                            <div>{{ $code }}</div>
+                        @endforeach
+                    </div>
+
+                    <div class="mt-4 flex items-center gap-4">
+                        <form method="POST" action="{{ url('/user/two-factor-recovery-codes') }}">
+                            @csrf
+                            <button
+                                type="submit"
+                                class="rounded-md bg-gray-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
+                            >
+                                {{ __('profile.twofa_regenerate_codes') }}
+                            </button>
+                        </form>
+
+                        <button
+                            type="button"
+                            wire:click="hideRecoveryCodes"
+                            class="text-sm font-medium text-gray-600 hover:text-gray-500 dark:text-gray-400"
+                        >
+                            {{ __('profile.twofa_hide_codes') }}
+                        </button>
+                    </div>
+                @else
+                    <button
+                        type="button"
+                        wire:click="showRecoveryCodes"
+                        class="mt-2 rounded-md bg-gray-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
+                    >
+                        {{ __('profile.twofa_show_codes') }}
+                    </button>
+                @endif
+            </div>
+
+            {{-- Disable 2FA --}}
+            <div class="mt-6">
+                <form method="DELETE" action="{{ url('/user/two-factor-authentication') }}"
+                    onsubmit="event.preventDefault(); fetch(this.action, {method: 'DELETE', headers: {'X-CSRF-TOKEN': '{{ csrf_token() }}', 'Accept': 'application/json'}}).then(() => window.location.reload());">
+                    <button
+                        type="submit"
+                        class="rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+                    >
+                        {{ __('profile.twofa_disable') }}
+                    </button>
+                </form>
+            </div>
+        @else
+            {{-- 2FA is not enabled --}}
+            <div class="mt-4" x-data="{ enabling: false, confirming: false, qrCode: '', confirmationCode: '', recoveryCodes: [] }">
+                <template x-if="!enabling && !confirming">
+                    <button
+                        type="button"
+                        x-on:click="
+                            enabling = true;
+                            fetch('{{ url('/user/two-factor-authentication') }}', {
+                                method: 'POST',
+                                headers: {
+                                    'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                                    'Accept': 'application/json',
+                                    'Content-Type': 'application/json'
+                                }
+                            }).then(() => {
+                                return fetch('{{ url('/user/two-factor-qr-code') }}', {
+                                    headers: { 'Accept': 'application/json' }
+                                });
+                            }).then(r => r.json()).then(data => {
+                                qrCode = data.svg;
+                                confirming = true;
+                                enabling = false;
+                            }).catch(() => { enabling = false; })
+                        "
+                        class="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                    >
+                        <span x-show="!enabling">{{ __('profile.twofa_enable') }}</span>
+                        <span x-show="enabling" x-cloak>{{ __('profile.twofa_enabling') }}</span>
+                    </button>
+                </template>
+
+                <template x-if="confirming">
+                    <div class="space-y-4">
+                        <p class="text-sm text-gray-600 dark:text-gray-400">
+                            {{ __('profile.twofa_scan_instructions') }}
+                        </p>
+
+                        <div class="inline-block rounded-lg bg-white p-4" x-html="qrCode"></div>
+
+                        <form method="POST" action="{{ url('/user/confirmed-two-factor-authentication') }}"
+                            x-on:submit.prevent="
+                                fetch($el.action, {
+                                    method: 'POST',
+                                    headers: {
+                                        'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                                        'Accept': 'application/json',
+                                        'Content-Type': 'application/json'
+                                    },
+                                    body: JSON.stringify({ code: confirmationCode })
+                                }).then(r => {
+                                    if (r.ok) { window.location.reload(); }
+                                    else { $refs.confirmError.classList.remove('hidden'); }
+                                })
+                            ">
+                            <div>
+                                <label for="twofa_code" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                    {{ __('profile.twofa_confirm_code') }}
+                                </label>
+                                <input
+                                    type="text"
+                                    id="twofa_code"
+                                    x-model="confirmationCode"
+                                    inputmode="numeric"
+                                    autocomplete="one-time-code"
+                                    required
+                                    class="mt-1 block w-full max-w-xs rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                                />
+                                <p x-ref="confirmError" class="mt-1 hidden text-sm text-red-600 dark:text-red-400">
+                                    {{ __('profile.twofa_invalid_code') }}
+                                </p>
+                            </div>
+
+                            <div class="mt-4">
+                                <button
+                                    type="submit"
+                                    class="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                                >
+                                    {{ __('profile.twofa_confirm') }}
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </template>
+            </div>
+        @endif
+    </section>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Livewire\Auth\ForgotPassword;
 use App\Livewire\Auth\Login;
 use App\Livewire\Auth\Register;
 use App\Livewire\Auth\ResetPassword;
+use App\Livewire\Auth\TwoFactorChallenge;
 use App\Livewire\Auth\VerifyEmail;
 use App\Livewire\Profile\Edit as ProfileEdit;
 use Illuminate\Support\Facades\DB;
@@ -21,6 +22,7 @@ Route::middleware('guest')->group(function () {
     Route::get('/register', Register::class)->name('register');
     Route::get('/forgot-password', ForgotPassword::class)->name('password.request');
     Route::get('/reset-password/{token}', ResetPassword::class)->name('password.reset');
+    Route::get('/two-factor-challenge', TwoFactorChallenge::class)->name('two-factor.login');
 });
 
 Route::get('/email/verify', VerifyEmail::class)

--- a/tests/Feature/Auth/TwoFactorAuthenticationTest.php
+++ b/tests/Feature/Auth/TwoFactorAuthenticationTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PragmaRX\Google2FA\Google2FA;
+
+uses(RefreshDatabase::class);
+
+describe('Two-Factor Authentication — TOTP', function () {
+
+    it('shows the two-factor challenge page', function () {
+        $this->get(route('two-factor.login'))
+            ->assertOk()
+            ->assertSee(__('auth.two_factor_heading'));
+    });
+
+    it('allows enabling two-factor authentication', function () {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->postJson('/user/two-factor-authentication');
+
+        $response->assertOk();
+
+        $user->refresh();
+        expect($user->two_factor_secret)->not->toBeNull();
+    });
+
+    it('allows confirming two-factor authentication with valid code', function () {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->postJson('/user/two-factor-authentication');
+
+        $user->refresh();
+
+        $google2fa = new Google2FA;
+        $secret = decrypt($user->two_factor_secret);
+        $validCode = $google2fa->getCurrentOtp($secret);
+
+        $response = $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->postJson('/user/confirmed-two-factor-authentication', [
+                'code' => $validCode,
+            ]);
+
+        $response->assertOk();
+
+        $user->refresh();
+        expect($user->two_factor_confirmed_at)->not->toBeNull();
+    });
+
+    it('rejects confirming two-factor with invalid code', function () {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->postJson('/user/two-factor-authentication');
+
+        $response = $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->postJson('/user/confirmed-two-factor-authentication', [
+                'code' => '000000',
+            ]);
+
+        $response->assertUnprocessable();
+
+        $user->refresh();
+        expect($user->two_factor_confirmed_at)->toBeNull();
+    });
+
+    it('allows disabling two-factor authentication', function () {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->postJson('/user/two-factor-authentication');
+        $user->refresh();
+
+        $google2fa = new Google2FA;
+        $secret = decrypt($user->two_factor_secret);
+        $validCode = $google2fa->getCurrentOtp($secret);
+
+        $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->postJson('/user/confirmed-two-factor-authentication', [
+                'code' => $validCode,
+            ]);
+
+        $response = $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->deleteJson('/user/two-factor-authentication');
+
+        $response->assertOk();
+
+        $user->refresh();
+        expect($user->two_factor_secret)->toBeNull();
+        expect($user->two_factor_confirmed_at)->toBeNull();
+    });
+
+    it('provides recovery codes after enabling 2FA', function () {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->postJson('/user/two-factor-authentication');
+
+        $user->refresh();
+        expect($user->two_factor_recovery_codes)->not->toBeNull();
+
+        $response = $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->getJson('/user/two-factor-recovery-codes');
+
+        $response->assertOk();
+        $codes = $response->json();
+        expect($codes)->toHaveCount(8);
+    });
+
+    it('requires two-factor code during login when 2FA is enabled', function () {
+        $user = User::factory()->create([
+            'password' => bcrypt('Password1!'),
+        ]);
+
+        $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->postJson('/user/two-factor-authentication');
+        $user->refresh();
+
+        $google2fa = new Google2FA;
+        $secret = decrypt($user->two_factor_secret);
+        $validCode = $google2fa->getCurrentOtp($secret);
+
+        $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->postJson('/user/confirmed-two-factor-authentication', [
+                'code' => $validCode,
+            ]);
+
+        $this->post('/logout');
+
+        $response = $this->post('/login', [
+            'email' => $user->email,
+            'password' => 'Password1!',
+        ]);
+
+        $response->assertRedirect(route('two-factor.login'));
+    });
+
+    it('completes login with valid TOTP code after 2FA challenge', function () {
+        $google2fa = new Google2FA;
+        $secret = $google2fa->generateSecretKey();
+
+        $user = User::factory()->create([
+            'password' => bcrypt('Password1!'),
+            'two_factor_secret' => encrypt($secret),
+            'two_factor_recovery_codes' => encrypt(json_encode([
+                'recovery-code-1',
+                'recovery-code-2',
+            ])),
+            'two_factor_confirmed_at' => now(),
+        ]);
+
+        // Login (should redirect to 2FA challenge)
+        $this->post('/login', [
+            'email' => $user->email,
+            'password' => 'Password1!',
+        ]);
+
+        // Submit valid TOTP code
+        $code = $google2fa->getCurrentOtp($secret);
+        $response = $this->post('/two-factor-challenge', [
+            'code' => $code,
+        ]);
+
+        $response->assertRedirect(config('fortify.home'));
+        $this->assertAuthenticatedAs($user);
+    });
+
+    it('rejects login with invalid TOTP code', function () {
+        $user = User::factory()->create([
+            'password' => bcrypt('Password1!'),
+        ]);
+
+        $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->postJson('/user/two-factor-authentication');
+        $user->refresh();
+
+        $google2fa = new Google2FA;
+        $secret = decrypt($user->two_factor_secret);
+        $validCode = $google2fa->getCurrentOtp($secret);
+
+        $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->postJson('/user/confirmed-two-factor-authentication', [
+                'code' => $validCode,
+            ]);
+
+        $this->post('/logout');
+
+        $this->post('/login', [
+            'email' => $user->email,
+            'password' => 'Password1!',
+        ]);
+
+        $response = $this->post('/two-factor-challenge', [
+            'code' => '000000',
+        ]);
+
+        $response->assertRedirect(route('two-factor.login'));
+        $this->assertGuest();
+    });
+
+    it('allows login with a valid recovery code', function () {
+        $user = User::factory()->create([
+            'password' => bcrypt('Password1!'),
+        ]);
+
+        $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->postJson('/user/two-factor-authentication');
+        $user->refresh();
+
+        $google2fa = new Google2FA;
+        $secret = decrypt($user->two_factor_secret);
+        $validCode = $google2fa->getCurrentOtp($secret);
+
+        $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->postJson('/user/confirmed-two-factor-authentication', [
+                'code' => $validCode,
+            ]);
+
+        $recoveryCodes = $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->getJson('/user/two-factor-recovery-codes')
+            ->json();
+
+        $this->post('/logout');
+
+        $this->post('/login', [
+            'email' => $user->email,
+            'password' => 'Password1!',
+        ]);
+
+        $response = $this->post('/two-factor-challenge', [
+            'recovery_code' => $recoveryCodes[0],
+        ]);
+
+        $response->assertRedirect(config('fortify.home'));
+        $this->assertAuthenticatedAs($user);
+    });
+
+    it('does not require 2FA for users who have not enabled it', function () {
+        $user = User::factory()->create([
+            'password' => bcrypt('Password1!'),
+        ]);
+
+        $response = $this->post('/login', [
+            'email' => $user->email,
+            'password' => 'Password1!',
+        ]);
+
+        $response->assertRedirect(config('fortify.home'));
+        $this->assertAuthenticatedAs($user);
+    });
+
+    it('shows QR code endpoint for authenticated user enabling 2FA', function () {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->postJson('/user/two-factor-authentication');
+
+        $response = $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->getJson('/user/two-factor-qr-code');
+
+        $response->assertOk();
+        expect($response->json('svg'))->toContain('<svg');
+    });
+});

--- a/tests/Feature/Livewire/Profile/EditTest.php
+++ b/tests/Feature/Livewire/Profile/EditTest.php
@@ -77,12 +77,13 @@ describe('Profile Edit Livewire Component', function () {
             ->assertSee('value="john@example.com"', escape: false);
     });
 
-    it('shows the 2FA placeholder section', function () {
+    it('shows the 2FA section with enable option', function () {
         $user = User::factory()->create();
 
         $this->actingAs($user)
             ->get(route('profile.edit'))
-            ->assertSee(__('profile.twofa_not_available'));
+            ->assertSee(__('profile.twofa_heading'))
+            ->assertSee(__('profile.twofa_enable'));
     });
 
 });


### PR DESCRIPTION
## Summary

Enable Fortify's TOTP-based two-factor authentication. Authenticator apps (Google Authenticator, Authy) generate time-based codes.

## Changes

- **config/fortify.php**: Enable `twoFactorAuthentication` feature with `confirm` and `confirmPassword` options
- **Migration**: Publish Fortify 2FA migration for `two_factor_secret`, `two_factor_recovery_codes`, `two_factor_confirmed_at` columns
- **User model**: Add `TwoFactorAuthenticatable` trait
- **TwoFactorChallenge Livewire component**: Login 2FA challenge page (TOTP code + recovery code toggle)
- **TwoFactorAuthentication Livewire component**: Profile page 2FA management (enable/disable/QR code/recovery codes)
- **Profile page**: Replace 2FA placeholder with functional component
- **FortifyServiceProvider**: Add two-factor rate limiter
- **Routes**: Register `/two-factor-challenge` GET route for custom Livewire view
- **Translations**: Add 2FA strings to all three locales (fr/en/nl) for both auth and profile domains

## Acceptance Criteria

- [x] Fortify `twoFactorAuthentication` feature enabled in `config/fortify.php`
- [x] Migration for `two_factor_*` columns on users table (Fortify provides this)
- [x] User can enable 2FA from profile settings: QR code displayed, recovery codes generated
- [x] Login flow: after password, if 2FA is enabled, prompt for TOTP code
- [x] Recovery codes work as fallback
- [x] 2FA is **optional** for coach/athlete roles
- [x] Feature test: login with 2FA enabled requires code; invalid code is rejected

## Tests

12 new tests covering: enable, confirm, reject invalid code, disable, recovery codes, login flow with 2FA, QR code endpoint.

Closes #21