### PR TITLE
test: add UserFactory role states unit test (E1-S22)

### DIFF
--- a/tests/Unit/Factories/UserFactoryTest.php
+++ b/tests/Unit/Factories/UserFactoryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\UserRole;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+describe('UserFactory', function () {
+
+    it('creates an athlete by default', function () {
+        $user = User::factory()->create();
+
+        expect($user->role)->toBe(UserRole::Athlete);
+    });
+
+    it('creates a coach with the coach state', function () {
+        $user = User::factory()->coach()->create();
+
+        expect($user->role)->toBe(UserRole::Coach);
+    });
+
+    it('creates an athlete with the athlete state', function () {
+        $user = User::factory()->athlete()->create();
+
+        expect($user->role)->toBe(UserRole::Athlete);
+    });
+
+    it('creates an accountant with the accountant state', function () {
+        $user = User::factory()->accountant()->create();
+
+        expect($user->role)->toBe(UserRole::Accountant);
+    });
+
+    it('creates an admin with the admin state', function () {
+        $user = User::factory()->admin()->create();
+
+        expect($user->role)->toBe(UserRole::Admin);
+    });
+
+    it('creates a user with a specific locale', function () {
+        $user = User::factory()->withLocale('nl')->create();
+
+        expect($user->locale)->toBe('nl');
+    });
+
+    it('creates an unverified user', function () {
+        $user = User::factory()->unverified()->create();
+
+        expect($user->email_verified_at)->toBeNull();
+    });
+
+    it('creates a verified user by default', function () {
+        $user = User::factory()->create();
+
+        expect($user->email_verified_at)->not->toBeNull();
+    });
+});


### PR DESCRIPTION
## E1-S22 · UserFactory update for roles

Resolves #38

### Changes

The `UserFactory` role states (`->coach()`, `->athlete()`, `->accountant()`, `->admin()`) were already implemented in earlier stories. This PR adds the formal unit test coverage required by the story.

- `tests/Unit/Factories/UserFactoryTest.php` — 8 tests verifying all factory states

### Tests

| Test | Assertion |
|------|-----------|
| Default factory | creates athlete |
| `->coach()` | role = coach |
| `->athlete()` | role = athlete |
| `->accountant()` | role = accountant |
| `->admin()` | role = admin |
| `->withLocale('nl')` | locale = nl |
| `->unverified()` | email_verified_at = null |
| Default verified | email_verified_at != null |

### Testing
- 8 new tests, 180 total — all passing