### PR TITLE
feat: add <x-money> Blade component for Belgian EUR formatting (E1-S21)

### DIFF
--- a/app/View/Components/Money.php
+++ b/app/View/Components/Money.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+final class Money extends Component
+{
+    public readonly string $formatted;
+
+    /**
+     * Create a new component instance.
+     *
+     * @param  int  $cents  Amount in EUR cents
+     */
+    public function __construct(public readonly int $cents)
+    {
+        $euros = $cents / 100;
+
+        // Belgian format: comma decimal separator, dot thousands separator
+        $this->formatted = '€'."\u{00A0}".number_format($euros, 2, ',', '.');
+    }
+
+    public function render(): View|Closure|string
+    {
+        return view('components.money');
+    }
+}

--- a/resources/views/components/money.blade.php
+++ b/resources/views/components/money.blade.php
@@ -1,0 +1,1 @@
+<span {{ $attributes->merge(['class' => 'whitespace-nowrap']) }}>{{ $formatted }}</span>

--- a/tests/Feature/Components/MoneyTest.php
+++ b/tests/Feature/Components/MoneyTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use App\View\Components\Money;
+
+describe('Money Blade component', function () {
+
+    it('formats cents to Belgian EUR format', function () {
+        $component = new Money(cents: 1250);
+
+        expect($component->formatted)->toBe("€\u{00A0}12,50");
+    });
+
+    it('formats zero cents', function () {
+        $component = new Money(cents: 0);
+
+        expect($component->formatted)->toBe("€\u{00A0}0,00");
+    });
+
+    it('formats large amounts with dot as thousands separator', function () {
+        $component = new Money(cents: 123456);
+
+        expect($component->formatted)->toBe("€\u{00A0}1.234,56");
+    });
+
+    it('formats single digit cents correctly', function () {
+        $component = new Money(cents: 5);
+
+        expect($component->formatted)->toBe("€\u{00A0}0,05");
+    });
+
+    it('formats negative amounts', function () {
+        $component = new Money(cents: -750);
+
+        expect($component->formatted)->toBe("€\u{00A0}-7,50");
+    });
+
+    it('renders the component with correct markup', function () {
+        $view = $this->blade('<x-money :cents="1250" />');
+
+        $view->assertSee("€\u{00A0}12,50", false);
+        $view->assertSee('whitespace-nowrap', false);
+    });
+
+    it('accepts additional html attributes', function () {
+        $view = $this->blade('<x-money :cents="1250" class="text-green-600" />');
+
+        $view->assertSee('text-green-600', false);
+    });
+});


### PR DESCRIPTION
## E1-S21 · `<x-money>` Blade component

Resolves #37

### Changes

- `app/View/Components/Money.php` — Class-based Blade component that converts integer cents to Belgian EUR format
- `resources/views/components/money.blade.php` — Renders a `<span>` with `whitespace-nowrap`
- `tests/Feature/Components/MoneyTest.php` — 7 tests

### Usage

```blade
<x-money :cents="1250" />        {{-- renders: € 12,50 --}}
<x-money :cents="123456" />      {{-- renders: € 1.234,56 --}}
<x-money :cents="0" />           {{-- renders: € 0,00 --}}
```

### Belgian Formatting Rules

- `€` symbol followed by non-breaking space (`\u{00A0}`)
- **Comma** as decimal separator
- **Dot** as thousands separator
- Always 2 decimal places

### Tests

| Test | Input | Expected |
|------|-------|----------|
| Standard amount | 1250 | € 12,50 |
| Zero | 0 | € 0,00 |
| Large amounts | 123456 | € 1.234,56 |
| Single-digit cents | 5 | € 0,05 |
| Negative | -750 | € -7,50 |
| HTML rendering | 1250 | `<span>` with `whitespace-nowrap` |
| Custom attributes | 1250 | Passes through extra classes |

### Testing
- 7 new tests, 187 total — all passing