### PR TITLE
fix: make x-money component locale-aware using NumberFormatter (E1-S21)

### DIFF
--- a/app/View/Components/Money.php
+++ b/app/View/Components/Money.php
@@ -7,22 +7,31 @@ namespace App\View\Components;
 use Closure;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
+use NumberFormatter;
 
 final class Money extends Component
 {
     public readonly string $formatted;
 
+    private const LOCALE_MAP = [
+        'fr' => 'fr_BE',
+        'en' => 'en_GB',
+        'nl' => 'nl_BE',
+    ];
+
     /**
      * Create a new component instance.
      *
      * @param  int  $cents  Amount in EUR cents
+     * @param  string|null  $locale  Override locale (fr, en, nl); defaults to app locale
      */
-    public function __construct(public readonly int $cents)
+    public function __construct(public readonly int $cents, ?string $locale = null)
     {
-        $euros = $cents / 100;
+        $locale ??= app()->getLocale();
+        $ietfLocale = self::LOCALE_MAP[$locale] ?? self::LOCALE_MAP['fr'];
 
-        // Belgian format: comma decimal separator, dot thousands separator
-        $this->formatted = '€'."\u{00A0}".number_format($euros, 2, ',', '.');
+        $formatter = new NumberFormatter($ietfLocale, NumberFormatter::CURRENCY);
+        $this->formatted = $formatter->formatCurrency($cents / 100, 'EUR');
     }
 
     public function render(): View|Closure|string

--- a/tests/Feature/Components/MoneyTest.php
+++ b/tests/Feature/Components/MoneyTest.php
@@ -3,49 +3,115 @@
 declare(strict_types=1);
 
 use App\View\Components\Money;
+use Illuminate\Support\Facades\App;
 
 describe('Money Blade component', function () {
 
-    it('formats cents to Belgian EUR format', function () {
-        $component = new Money(cents: 1250);
+    describe('French (fr_BE) locale', function () {
+        beforeEach(fn () => App::setLocale('fr'));
 
-        expect($component->formatted)->toBe("€\u{00A0}12,50");
+        it('formats cents with comma decimal and euro suffix', function () {
+            $component = new Money(cents: 1250);
+
+            // fr_BE: "12,50 €" (NBSP before €)
+            expect($component->formatted)->toBe("12,50\u{00A0}€");
+        });
+
+        it('formats zero cents', function () {
+            $component = new Money(cents: 0);
+
+            expect($component->formatted)->toBe("0,00\u{00A0}€");
+        });
+
+        it('formats large amounts with narrow no-break space as thousands separator', function () {
+            $component = new Money(cents: 123456);
+
+            // fr_BE uses narrow NBSP (\u202F) as thousands separator
+            expect($component->formatted)->toBe("1\u{202F}234,56\u{00A0}€");
+        });
+
+        it('formats single digit cents', function () {
+            $component = new Money(cents: 5);
+
+            expect($component->formatted)->toBe("0,05\u{00A0}€");
+        });
+
+        it('formats negative amounts', function () {
+            $component = new Money(cents: -750);
+
+            expect($component->formatted)->toBe("-7,50\u{00A0}€");
+        });
     });
 
-    it('formats zero cents', function () {
-        $component = new Money(cents: 0);
+    describe('English (en_GB) locale', function () {
+        beforeEach(fn () => App::setLocale('en'));
 
-        expect($component->formatted)->toBe("€\u{00A0}0,00");
+        it('formats cents with dot decimal and euro prefix', function () {
+            $component = new Money(cents: 1250);
+
+            // en_GB: "€12.50"
+            expect($component->formatted)->toBe('€12.50');
+        });
+
+        it('formats large amounts with comma thousands separator', function () {
+            $component = new Money(cents: 123456);
+
+            expect($component->formatted)->toBe('€1,234.56');
+        });
+
+        it('formats negative amounts', function () {
+            $component = new Money(cents: -750);
+
+            expect($component->formatted)->toBe('-€7.50');
+        });
     });
 
-    it('formats large amounts with dot as thousands separator', function () {
-        $component = new Money(cents: 123456);
+    describe('Dutch (nl_BE) locale', function () {
+        beforeEach(fn () => App::setLocale('nl'));
 
-        expect($component->formatted)->toBe("€\u{00A0}1.234,56");
+        it('formats cents with comma decimal and euro prefix with space', function () {
+            $component = new Money(cents: 1250);
+
+            // nl_BE: "€ 12,50" (NBSP after €)
+            expect($component->formatted)->toBe("€\u{00A0}12,50");
+        });
+
+        it('formats large amounts with dot thousands separator', function () {
+            $component = new Money(cents: 123456);
+
+            expect($component->formatted)->toBe("€\u{00A0}1.234,56");
+        });
+
+        it('formats negative amounts', function () {
+            $component = new Money(cents: -750);
+
+            expect($component->formatted)->toBe("€\u{00A0}-7,50");
+        });
     });
 
-    it('formats single digit cents correctly', function () {
-        $component = new Money(cents: 5);
+    describe('locale override', function () {
+        it('uses explicit locale instead of app locale', function () {
+            App::setLocale('fr');
 
-        expect($component->formatted)->toBe("€\u{00A0}0,05");
+            $component = new Money(cents: 1250, locale: 'en');
+
+            expect($component->formatted)->toBe('€12.50');
+        });
     });
 
-    it('formats negative amounts', function () {
-        $component = new Money(cents: -750);
+    describe('Blade rendering', function () {
+        it('renders the component with correct markup', function () {
+            App::setLocale('nl');
+            $view = $this->blade('<x-money :cents="1250" />');
 
-        expect($component->formatted)->toBe("€\u{00A0}-7,50");
-    });
+            $view->assertSee("€\u{00A0}12,50", false);
+            $view->assertSee('whitespace-nowrap', false);
+        });
 
-    it('renders the component with correct markup', function () {
-        $view = $this->blade('<x-money :cents="1250" />');
+        it('accepts additional html attributes', function () {
+            $view = $this->blade('<x-money :cents="1250" class="text-green-600" />');
 
-        $view->assertSee("€\u{00A0}12,50", false);
-        $view->assertSee('whitespace-nowrap', false);
-    });
-
-    it('accepts additional html attributes', function () {
-        $view = $this->blade('<x-money :cents="1250" class="text-green-600" />');
-
-        $view->assertSee('text-green-600', false);
+            $view->assertSee('text-green-600', false);
+        });
     });
 });


### PR DESCRIPTION
## Fix: Make `<x-money>` locale-aware using NumberFormatter

Relates to #37

### Problem

The initial `<x-money>` implementation hardcoded Belgian Dutch formatting (`€ 12,50`) for all locales. Per our [i18n instructions](.github/instructions/i18n-localization.instructions.md), each locale has a different currency format:

| Locale | Expected | Was getting |
|--------|----------|-------------|
| `fr` (fr_BE) | `12,50 €` | `€ 12,50` ❌ |
| `en` (en_GB) | `€12.50` | `€ 12,50` ❌ |
| `nl` (nl_BE) | `€ 12,50` | `€ 12,50` ✅ (by accident) |

### Fix

Replaced `number_format()` with PHP's `NumberFormatter::CURRENCY` (intl extension), which natively handles locale-specific formatting:

```php
$formatter = new NumberFormatter($ietfLocale, NumberFormatter::CURRENCY);
$this->formatted = $formatter->formatCurrency($cents / 100, 'EUR');
```

Added an optional `locale` parameter to allow explicit override: `<x-money :cents=\"1250\" locale=\"en\" />`

### Tests

14 tests (up from 7), organized by locale:
- 5 tests for `fr_BE` format
- 3 tests for `en_GB` format
- 3 tests for `nl_BE` format
- 1 test for locale override
- 2 tests for Blade rendering

All 194 tests passing, no regressions.