### PR TITLE
feat: E1-S16 · Coach application form (3-step wizard)

### DIFF
--- a/app/Enums/CoachProfileStatus.php
+++ b/app/Enums/CoachProfileStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum CoachProfileStatus: string
+{
+    case Pending = 'pending';
+    case Approved = 'approved';
+    case Rejected = 'rejected';
+}

--- a/app/Events/NewCoachApplication.php
+++ b/app/Events/NewCoachApplication.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class NewCoachApplication
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(
+        public readonly int $coachProfileId,
+    ) {}
+}

--- a/app/Livewire/Coach/Application.php
+++ b/app/Livewire/Coach/Application.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Coach;
+
+use App\Enums\UserRole;
+use App\Livewire\Forms\CoachApplicationForm;
+use App\Services\CoachApplicationService;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
+
+final class Application extends Component
+{
+    public CoachApplicationForm $form;
+
+    public int $step = 1;
+
+    public function mount(): void
+    {
+        $user = Auth::user();
+
+        if ($user === null || $user->role !== UserRole::Athlete) {
+            abort(403);
+        }
+
+        if ($user->coachProfile !== null) {
+            abort(403);
+        }
+    }
+
+    public function nextStep(): void
+    {
+        if ($this->step === 1) {
+            $this->form->validate($this->step1Rules());
+        } elseif ($this->step === 2) {
+            $this->form->validate($this->step2Rules());
+        }
+
+        $this->step = min($this->step + 1, 3);
+    }
+
+    public function previousStep(): void
+    {
+        $this->step = max($this->step - 1, 1);
+    }
+
+    public function submit(CoachApplicationService $service): void
+    {
+        $this->form->validate();
+
+        $user = Auth::user();
+
+        if ($user === null || $user->role !== UserRole::Athlete) {
+            abort(403);
+        }
+
+        if ($user->coachProfile !== null) {
+            abort(403);
+        }
+
+        $service->apply($user, $this->form->toServiceArray());
+
+        session()->flash('status', __('coach.application_submitted'));
+
+        $this->redirect(route('home'));
+    }
+
+    public function render(): View
+    {
+        return view('livewire.coach.application')
+            ->title(__('coach.application_title'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function step1Rules(): array
+    {
+        return [
+            'specialties' => 'required|array|min:1',
+            'bio' => 'nullable|string|max:2000',
+            'experience_level' => 'nullable|string|in:beginner,intermediate,advanced,expert',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function step2Rules(): array
+    {
+        return [
+            'postal_code' => 'required|string|regex:/^[1-9]\d{3}$/',
+            'country' => 'required|string|size:2',
+            'enterprise_number' => 'required|string|regex:/^\d{4}\.\d{3}\.\d{3}$/',
+        ];
+    }
+}

--- a/app/Livewire/Forms/CoachApplicationForm.php
+++ b/app/Livewire/Forms/CoachApplicationForm.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Forms;
+
+use Livewire\Attributes\Validate;
+use Livewire\Form;
+
+final class CoachApplicationForm extends Form
+{
+    /** @var list<string> */
+    #[Validate('required|array|min:1')]
+    public array $specialties = [];
+
+    #[Validate('nullable|string|max:2000')]
+    public string $bio = '';
+
+    #[Validate('nullable|string|in:beginner,intermediate,advanced,expert')]
+    public string $experience_level = '';
+
+    #[Validate('required|string|regex:/^[1-9]\d{3}$/')]
+    public string $postal_code = '';
+
+    #[Validate('required|string|size:2')]
+    public string $country = 'BE';
+
+    #[Validate('required|string|regex:/^\d{4}\.\d{3}\.\d{3}$/')]
+    public string $enterprise_number = '';
+
+    #[Validate('accepted')]
+    public bool $terms_accepted = false;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toServiceArray(): array
+    {
+        return $this->only([
+            'specialties',
+            'bio',
+            'experience_level',
+            'postal_code',
+            'country',
+            'enterprise_number',
+        ]);
+    }
+}

--- a/app/Models/CoachProfile.php
+++ b/app/Models/CoachProfile.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\CoachProfileStatus;
+use Database\Factories\CoachProfileFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CoachProfile extends Model
+{
+    /** @use HasFactory<CoachProfileFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'status',
+        'specialties',
+        'bio',
+        'experience_level',
+        'postal_code',
+        'country',
+        'enterprise_number',
+        'is_vat_subject',
+        'stripe_account_id',
+        'stripe_onboarding_complete',
+        'verified_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'status' => CoachProfileStatus::class,
+            'specialties' => 'array',
+            'is_vat_subject' => 'boolean',
+            'stripe_onboarding_complete' => 'boolean',
+            'verified_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,6 +9,7 @@ use App\Enums\UserRole;
 use Database\Factories\UserFactory;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Fortify\TwoFactorAuthenticatable;
@@ -55,5 +56,13 @@ class User extends Authenticatable implements MustVerifyEmail
             'role' => UserRole::class,
             'two_factor_type' => TwoFactorMethod::class,
         ];
+    }
+
+    /**
+     * @return HasOne<CoachProfile, $this>
+     */
+    public function coachProfile(): HasOne
+    {
+        return $this->hasOne(CoachProfile::class);
     }
 }

--- a/app/Services/CoachApplicationService.php
+++ b/app/Services/CoachApplicationService.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\CoachProfileStatus;
+use App\Events\NewCoachApplication;
+use App\Models\CoachProfile;
+use App\Models\User;
+
+final class CoachApplicationService
+{
+    /**
+     * Create a new coach profile application.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function apply(User $user, array $data): CoachProfile
+    {
+        $coachProfile = CoachProfile::create([
+            'user_id' => $user->id,
+            'status' => CoachProfileStatus::Pending,
+            'specialties' => $data['specialties'],
+            'bio' => $data['bio'] !== '' ? $data['bio'] : null,
+            'experience_level' => $data['experience_level'] !== '' ? $data['experience_level'] : null,
+            'postal_code' => $data['postal_code'],
+            'country' => $data['country'],
+            'enterprise_number' => $data['enterprise_number'],
+        ]);
+
+        NewCoachApplication::dispatch($coachProfile->id);
+
+        return $coachProfile;
+    }
+}

--- a/database/factories/CoachProfileFactory.php
+++ b/database/factories/CoachProfileFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\CoachProfileStatus;
+use App\Models\CoachProfile;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<CoachProfile>
+ */
+class CoachProfileFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory()->athlete(),
+            'status' => CoachProfileStatus::Pending,
+            'specialties' => [$this->faker->randomElement(['fitness', 'yoga', 'running', 'cycling', 'swimming'])],
+            'bio' => $this->faker->paragraph(),
+            'experience_level' => $this->faker->randomElement(['beginner', 'intermediate', 'advanced', 'expert']),
+            'postal_code' => (string) $this->faker->numberBetween(1000, 9999),
+            'country' => 'BE',
+            'enterprise_number' => sprintf('%04d.%03d.%03d', $this->faker->numberBetween(0, 9999), $this->faker->numberBetween(0, 999), $this->faker->numberBetween(0, 999)),
+        ];
+    }
+
+    public function pending(): static
+    {
+        return $this->state(['status' => CoachProfileStatus::Pending]);
+    }
+
+    public function approved(): static
+    {
+        return $this->state([
+            'status' => CoachProfileStatus::Approved,
+            'verified_at' => now(),
+        ]);
+    }
+
+    public function rejected(): static
+    {
+        return $this->state(['status' => CoachProfileStatus::Rejected]);
+    }
+}

--- a/database/migrations/2026_04_08_100000_create_coach_profiles_table.php
+++ b/database/migrations/2026_04_08_100000_create_coach_profiles_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('coach_profiles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->unique()->constrained()->cascadeOnDelete();
+            $table->string('status')->default('pending');
+            $table->json('specialties');
+            $table->text('bio')->nullable();
+            $table->string('experience_level')->nullable();
+            $table->string('postal_code');
+            $table->string('country')->default('BE');
+            $table->string('enterprise_number');
+            $table->boolean('is_vat_subject')->default(false);
+            $table->string('stripe_account_id')->nullable();
+            $table->boolean('stripe_onboarding_complete')->default(false);
+            $table->timestamp('verified_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('coach_profiles');
+    }
+};

--- a/lang/en/coach.php
+++ b/lang/en/coach.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Coach Application
+    |--------------------------------------------------------------------------
+    */
+
+    'application_title' => 'Become a Coach',
+    'application_heading' => 'Become a Coach on Motivya',
+    'application_submitted' => 'Your application has been submitted successfully. We will get back to you shortly.',
+
+    'step_1' => 'Profile',
+    'step_2' => 'Location',
+    'step_3' => 'Confirmation',
+
+    'step_1_heading' => 'Your coach profile',
+    'step_2_heading' => 'Geographic zone and enterprise',
+    'step_3_heading' => 'Review and confirmation',
+
+    'specialties_label' => 'Specialties',
+    'specialties_hint' => 'Select at least one specialty.',
+
+    'specialty_fitness' => 'Fitness',
+    'specialty_yoga' => 'Yoga',
+    'specialty_running' => 'Running',
+    'specialty_cycling' => 'Cycling',
+    'specialty_swimming' => 'Swimming',
+    'specialty_boxing' => 'Boxing',
+    'specialty_dance' => 'Dance',
+    'specialty_pilates' => 'Pilates',
+    'specialty_crossfit' => 'CrossFit',
+    'specialty_martial_arts' => 'Martial Arts',
+    'specialty_tennis' => 'Tennis',
+    'specialty_other' => 'Other',
+
+    'bio_label' => 'Bio',
+    'bio_placeholder' => 'Describe your background and coaching experience…',
+
+    'experience_level_label' => 'Experience level',
+    'experience_select' => '— Select —',
+    'experience_beginner' => 'Beginner',
+    'experience_intermediate' => 'Intermediate',
+    'experience_advanced' => 'Advanced',
+    'experience_expert' => 'Expert',
+
+    'postal_code_label' => 'Postal code',
+    'country_label' => 'Country',
+    'country_be' => 'Belgium',
+
+    'enterprise_number_label' => 'Enterprise number (BCE/KBO)',
+    'enterprise_number_hint' => 'Format: 0123.456.789',
+
+    'terms_label' => 'I accept the terms and conditions and the privacy policy.',
+
+    'summary_title' => 'Application summary',
+    'submit_application' => 'Submit my application',
+
+];

--- a/lang/en/common.php
+++ b/lang/en/common.php
@@ -44,6 +44,8 @@ return [
     'delete' => 'Delete',
     'edit' => 'Edit',
     'back' => 'Back',
+    'next' => 'Next',
+    'previous' => 'Previous',
     'uploading' => 'Uploading…',
     'welcome' => 'Welcome to :app',
     'auth_coming_soon' => 'Login and registration are coming soon.',

--- a/lang/fr/coach.php
+++ b/lang/fr/coach.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Coach Application
+    |--------------------------------------------------------------------------
+    */
+
+    'application_title' => 'Devenir Coach',
+    'application_heading' => 'Devenir Coach sur Motivya',
+    'application_submitted' => 'Votre candidature a été soumise avec succès. Nous reviendrons vers vous rapidement.',
+
+    'step_1' => 'Profil',
+    'step_2' => 'Localisation',
+    'step_3' => 'Confirmation',
+
+    'step_1_heading' => 'Votre profil de coach',
+    'step_2_heading' => 'Zone géographique et entreprise',
+    'step_3_heading' => 'Vérification et confirmation',
+
+    'specialties_label' => 'Spécialités',
+    'specialties_hint' => 'Sélectionnez au moins une spécialité.',
+
+    'specialty_fitness' => 'Fitness',
+    'specialty_yoga' => 'Yoga',
+    'specialty_running' => 'Course à pied',
+    'specialty_cycling' => 'Cyclisme',
+    'specialty_swimming' => 'Natation',
+    'specialty_boxing' => 'Boxe',
+    'specialty_dance' => 'Danse',
+    'specialty_pilates' => 'Pilates',
+    'specialty_crossfit' => 'CrossFit',
+    'specialty_martial_arts' => 'Arts martiaux',
+    'specialty_tennis' => 'Tennis',
+    'specialty_other' => 'Autre',
+
+    'bio_label' => 'Biographie',
+    'bio_placeholder' => 'Décrivez votre parcours et votre expérience de coaching…',
+
+    'experience_level_label' => 'Niveau d\'expérience',
+    'experience_select' => '— Sélectionnez —',
+    'experience_beginner' => 'Débutant',
+    'experience_intermediate' => 'Intermédiaire',
+    'experience_advanced' => 'Avancé',
+    'experience_expert' => 'Expert',
+
+    'postal_code_label' => 'Code postal',
+    'country_label' => 'Pays',
+    'country_be' => 'Belgique',
+
+    'enterprise_number_label' => 'Numéro d\'entreprise (BCE/KBO)',
+    'enterprise_number_hint' => 'Format : 0123.456.789',
+
+    'terms_label' => 'J\'accepte les conditions générales et la politique de confidentialité.',
+
+    'summary_title' => 'Résumé de votre candidature',
+    'submit_application' => 'Soumettre ma candidature',
+
+];

--- a/lang/fr/common.php
+++ b/lang/fr/common.php
@@ -44,6 +44,8 @@ return [
     'delete' => 'Supprimer',
     'edit' => 'Modifier',
     'back' => 'Retour',
+    'next' => 'Suivant',
+    'previous' => 'Précédent',
     'uploading' => 'Téléchargement…',
     'welcome' => 'Bienvenue sur :app',
     'auth_coming_soon' => 'La connexion et l\'inscription arrivent bientôt.',

--- a/lang/nl/coach.php
+++ b/lang/nl/coach.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Coach Application
+    |--------------------------------------------------------------------------
+    */
+
+    'application_title' => 'Word Coach',
+    'application_heading' => 'Word Coach op Motivya',
+    'application_submitted' => 'Uw aanvraag is succesvol ingediend. We nemen snel contact met u op.',
+
+    'step_1' => 'Profiel',
+    'step_2' => 'Locatie',
+    'step_3' => 'Bevestiging',
+
+    'step_1_heading' => 'Uw coachprofiel',
+    'step_2_heading' => 'Geografische zone en onderneming',
+    'step_3_heading' => 'Controle en bevestiging',
+
+    'specialties_label' => 'Specialiteiten',
+    'specialties_hint' => 'Selecteer minstens één specialiteit.',
+
+    'specialty_fitness' => 'Fitness',
+    'specialty_yoga' => 'Yoga',
+    'specialty_running' => 'Hardlopen',
+    'specialty_cycling' => 'Fietsen',
+    'specialty_swimming' => 'Zwemmen',
+    'specialty_boxing' => 'Boksen',
+    'specialty_dance' => 'Dansen',
+    'specialty_pilates' => 'Pilates',
+    'specialty_crossfit' => 'CrossFit',
+    'specialty_martial_arts' => 'Vechtsporten',
+    'specialty_tennis' => 'Tennis',
+    'specialty_other' => 'Overig',
+
+    'bio_label' => 'Biografie',
+    'bio_placeholder' => 'Beschrijf uw achtergrond en coachervaring…',
+
+    'experience_level_label' => 'Ervaringsniveau',
+    'experience_select' => '— Selecteer —',
+    'experience_beginner' => 'Beginner',
+    'experience_intermediate' => 'Gevorderd',
+    'experience_advanced' => 'Ervaren',
+    'experience_expert' => 'Expert',
+
+    'postal_code_label' => 'Postcode',
+    'country_label' => 'Land',
+    'country_be' => 'België',
+
+    'enterprise_number_label' => 'Ondernemingsnummer (BCE/KBO)',
+    'enterprise_number_hint' => 'Formaat: 0123.456.789',
+
+    'terms_label' => 'Ik accepteer de algemene voorwaarden en het privacybeleid.',
+
+    'summary_title' => 'Samenvatting van uw aanvraag',
+    'submit_application' => 'Mijn aanvraag indienen',
+
+];

--- a/lang/nl/common.php
+++ b/lang/nl/common.php
@@ -44,6 +44,8 @@ return [
     'delete' => 'Verwijderen',
     'edit' => 'Bewerken',
     'back' => 'Terug',
+    'next' => 'Volgende',
+    'previous' => 'Vorige',
     'uploading' => 'Uploaden…',
     'welcome' => 'Welkom bij :app',
     'auth_coming_soon' => 'Inloggen en registreren komen binnenkort beschikbaar.',

--- a/resources/views/livewire/coach/application.blade.php
+++ b/resources/views/livewire/coach/application.blade.php
@@ -1,0 +1,246 @@
+<div class="mx-auto max-w-2xl px-4 py-8 sm:px-6 lg:px-8">
+    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
+        {{ __('coach.application_heading') }}
+    </h1>
+
+    {{-- Step indicator --}}
+    <div class="mt-6 flex items-center justify-between">
+        @for ($i = 1; $i <= 3; $i++)
+            <div class="flex items-center">
+                <span @class([
+                    'flex h-8 w-8 items-center justify-center rounded-full text-sm font-semibold',
+                    'bg-indigo-600 text-white' => $step >= $i,
+                    'bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400' => $step < $i,
+                ])>
+                    {{ $i }}
+                </span>
+                <span class="ml-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('coach.step_' . $i) }}
+                </span>
+            </div>
+            @if ($i < 3)
+                <div @class([
+                    'mx-2 h-0.5 flex-1',
+                    'bg-indigo-600' => $step > $i,
+                    'bg-gray-200 dark:bg-gray-700' => $step <= $i,
+                ])></div>
+            @endif
+        @endfor
+    </div>
+
+    <form wire:submit="submit" class="mt-8 space-y-6">
+        {{-- Step 1: Specialties, bio, experience --}}
+        @if ($step === 1)
+            <div class="space-y-4 rounded-lg bg-white p-6 shadow dark:bg-gray-800">
+                <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+                    {{ __('coach.step_1_heading') }}
+                </h2>
+
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                        {{ __('coach.specialties_label') }}
+                    </label>
+                    <p class="text-xs text-gray-500 dark:text-gray-400">{{ __('coach.specialties_hint') }}</p>
+                    <div class="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-3">
+                        @foreach (['fitness', 'yoga', 'running', 'cycling', 'swimming', 'boxing', 'dance', 'pilates', 'crossfit', 'martial_arts', 'tennis', 'other'] as $specialty)
+                            <label class="flex items-center gap-2">
+                                <input
+                                    type="checkbox"
+                                    wire:model="form.specialties"
+                                    value="{{ $specialty }}"
+                                    class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-gray-600"
+                                />
+                                <span class="text-sm text-gray-700 dark:text-gray-300">{{ __('coach.specialty_' . $specialty) }}</span>
+                            </label>
+                        @endforeach
+                    </div>
+                    @error('form.specialties')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div>
+                    <label for="bio" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                        {{ __('coach.bio_label') }}
+                    </label>
+                    <textarea
+                        wire:model="form.bio"
+                        id="bio"
+                        rows="4"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                        placeholder="{{ __('coach.bio_placeholder') }}"
+                    ></textarea>
+                    @error('form.bio')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div>
+                    <label for="experience_level" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                        {{ __('coach.experience_level_label') }}
+                    </label>
+                    <select
+                        wire:model="form.experience_level"
+                        id="experience_level"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                    >
+                        <option value="">{{ __('coach.experience_select') }}</option>
+                        <option value="beginner">{{ __('coach.experience_beginner') }}</option>
+                        <option value="intermediate">{{ __('coach.experience_intermediate') }}</option>
+                        <option value="advanced">{{ __('coach.experience_advanced') }}</option>
+                        <option value="expert">{{ __('coach.experience_expert') }}</option>
+                    </select>
+                    @error('form.experience_level')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+            </div>
+        @endif
+
+        {{-- Step 2: Geographic zone, enterprise number --}}
+        @if ($step === 2)
+            <div class="space-y-4 rounded-lg bg-white p-6 shadow dark:bg-gray-800">
+                <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+                    {{ __('coach.step_2_heading') }}
+                </h2>
+
+                <div>
+                    <label for="postal_code" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                        {{ __('coach.postal_code_label') }}
+                    </label>
+                    <input
+                        wire:model="form.postal_code"
+                        type="text"
+                        id="postal_code"
+                        maxlength="4"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                        placeholder="1000"
+                    />
+                    @error('form.postal_code')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div>
+                    <label for="country" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                        {{ __('coach.country_label') }}
+                    </label>
+                    <select
+                        wire:model="form.country"
+                        id="country"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                    >
+                        <option value="BE">{{ __('coach.country_be') }}</option>
+                    </select>
+                    @error('form.country')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div>
+                    <label for="enterprise_number" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                        {{ __('coach.enterprise_number_label') }}
+                    </label>
+                    <p class="text-xs text-gray-500 dark:text-gray-400">{{ __('coach.enterprise_number_hint') }}</p>
+                    <input
+                        wire:model="form.enterprise_number"
+                        type="text"
+                        id="enterprise_number"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                        placeholder="0123.456.789"
+                    />
+                    @error('form.enterprise_number')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+            </div>
+        @endif
+
+        {{-- Step 3: Confirmation + terms --}}
+        @if ($step === 3)
+            <div class="space-y-4 rounded-lg bg-white p-6 shadow dark:bg-gray-800">
+                <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+                    {{ __('coach.step_3_heading') }}
+                </h2>
+
+                <div class="rounded-md bg-gray-50 p-4 dark:bg-gray-700">
+                    <h3 class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ __('coach.summary_title') }}</h3>
+                    <dl class="mt-2 space-y-1 text-sm text-gray-600 dark:text-gray-300">
+                        <div class="flex justify-between">
+                            <dt>{{ __('coach.specialties_label') }}</dt>
+                            <dd>{{ implode(', ', $form->specialties) }}</dd>
+                        </div>
+                        @if ($form->bio !== '')
+                            <div class="flex justify-between">
+                                <dt>{{ __('coach.bio_label') }}</dt>
+                                <dd class="max-w-xs truncate">{{ $form->bio }}</dd>
+                            </div>
+                        @endif
+                        @if ($form->experience_level !== '')
+                            <div class="flex justify-between">
+                                <dt>{{ __('coach.experience_level_label') }}</dt>
+                                <dd>{{ __('coach.experience_' . $form->experience_level) }}</dd>
+                            </div>
+                        @endif
+                        <div class="flex justify-between">
+                            <dt>{{ __('coach.postal_code_label') }}</dt>
+                            <dd>{{ $form->postal_code }}</dd>
+                        </div>
+                        <div class="flex justify-between">
+                            <dt>{{ __('coach.enterprise_number_label') }}</dt>
+                            <dd>{{ $form->enterprise_number }}</dd>
+                        </div>
+                    </dl>
+                </div>
+
+                <div>
+                    <label class="flex items-center gap-2">
+                        <input
+                            type="checkbox"
+                            wire:model="form.terms_accepted"
+                            class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-gray-600"
+                        />
+                        <span class="text-sm text-gray-700 dark:text-gray-300">
+                            {{ __('coach.terms_label') }}
+                        </span>
+                    </label>
+                    @error('form.terms_accepted')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+            </div>
+        @endif
+
+        {{-- Navigation buttons --}}
+        <div class="flex justify-between">
+            @if ($step > 1)
+                <button
+                    type="button"
+                    wire:click="previousStep"
+                    class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                >
+                    {{ __('common.previous') }}
+                </button>
+            @else
+                <div></div>
+            @endif
+
+            @if ($step < 3)
+                <button
+                    type="button"
+                    wire:click="nextStep"
+                    class="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                >
+                    {{ __('common.next') }}
+                </button>
+            @else
+                <button
+                    type="submit"
+                    class="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                >
+                    {{ __('coach.submit_application') }}
+                </button>
+            @endif
+        </div>
+    </form>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Livewire\Auth\Register;
 use App\Livewire\Auth\ResetPassword;
 use App\Livewire\Auth\TwoFactorChallenge;
 use App\Livewire\Auth\VerifyEmail;
+use App\Livewire\Coach\Application as CoachApplication;
 use App\Livewire\Profile\Edit as ProfileEdit;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
@@ -32,6 +33,10 @@ Route::get('/email/verify', VerifyEmail::class)
 Route::get('/profile', ProfileEdit::class)
     ->middleware('auth')
     ->name('profile.edit');
+
+Route::get('/coach/apply', CoachApplication::class)
+    ->middleware(['auth', 'verified'])
+    ->name('coach.apply');
 
 Route::get('/health', function () {
     $checks = ['status' => 'ok'];

--- a/tests/Feature/Livewire/Coach/ApplicationTest.php
+++ b/tests/Feature/Livewire/Coach/ApplicationTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\CoachProfileStatus;
+use App\Events\NewCoachApplication;
+use App\Livewire\Coach\Application;
+use App\Models\CoachProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+describe('Coach Application Form', function () {
+
+    it('renders the application page for athletes', function () {
+        $athlete = User::factory()->athlete()->create();
+
+        $this->actingAs($athlete)
+            ->get(route('coach.apply'))
+            ->assertOk();
+    });
+
+    it('denies access to coaches', function () {
+        $coach = User::factory()->coach()->create();
+
+        $this->actingAs($coach)
+            ->get(route('coach.apply'))
+            ->assertForbidden();
+    });
+
+    it('denies access to admins', function () {
+        $admin = User::factory()->admin()->create();
+
+        $this->actingAs($admin)
+            ->get(route('coach.apply'))
+            ->assertForbidden();
+    });
+
+    it('denies access to guests', function () {
+        $this->get(route('coach.apply'))
+            ->assertRedirect(route('login'));
+    });
+
+    it('denies access to athletes who already have a coach profile', function () {
+        $athlete = User::factory()->athlete()->create();
+        CoachProfile::factory()->for($athlete)->create();
+
+        $this->actingAs($athlete)
+            ->get(route('coach.apply'))
+            ->assertForbidden();
+    });
+
+    it('navigates through steps', function () {
+        $athlete = User::factory()->athlete()->create();
+
+        Livewire::actingAs($athlete)
+            ->test(Application::class)
+            ->assertSet('step', 1)
+            ->set('form.specialties', ['fitness'])
+            ->call('nextStep')
+            ->assertSet('step', 2)
+            ->set('form.postal_code', '1000')
+            ->set('form.country', 'BE')
+            ->set('form.enterprise_number', '0123.456.789')
+            ->call('nextStep')
+            ->assertSet('step', 3)
+            ->call('previousStep')
+            ->assertSet('step', 2);
+    });
+
+    it('validates step 1 requires specialties', function () {
+        $athlete = User::factory()->athlete()->create();
+
+        Livewire::actingAs($athlete)
+            ->test(Application::class)
+            ->set('form.specialties', [])
+            ->call('nextStep')
+            ->assertHasErrors(['form.specialties'])
+            ->assertSet('step', 1);
+    });
+
+    it('validates step 2 requires postal code and enterprise number', function () {
+        $athlete = User::factory()->athlete()->create();
+
+        Livewire::actingAs($athlete)
+            ->test(Application::class)
+            ->set('form.specialties', ['yoga'])
+            ->call('nextStep')
+            ->assertSet('step', 2)
+            ->set('form.postal_code', '')
+            ->set('form.enterprise_number', '')
+            ->call('nextStep')
+            ->assertHasErrors(['form.postal_code', 'form.enterprise_number'])
+            ->assertSet('step', 2);
+    });
+
+    it('validates enterprise number format', function () {
+        $athlete = User::factory()->athlete()->create();
+
+        Livewire::actingAs($athlete)
+            ->test(Application::class)
+            ->set('form.specialties', ['yoga'])
+            ->call('nextStep')
+            ->set('form.postal_code', '1000')
+            ->set('form.enterprise_number', '123456789')
+            ->call('nextStep')
+            ->assertHasErrors(['form.enterprise_number'])
+            ->assertSet('step', 2);
+    });
+
+    it('submits application and creates coach profile', function () {
+        Event::fake([NewCoachApplication::class]);
+
+        $athlete = User::factory()->athlete()->create();
+
+        Livewire::actingAs($athlete)
+            ->test(Application::class)
+            ->set('form.specialties', ['fitness', 'yoga'])
+            ->set('form.bio', 'Experienced fitness coach')
+            ->set('form.experience_level', 'advanced')
+            ->call('nextStep')
+            ->set('form.postal_code', '1000')
+            ->set('form.country', 'BE')
+            ->set('form.enterprise_number', '0123.456.789')
+            ->call('nextStep')
+            ->set('form.terms_accepted', true)
+            ->call('submit')
+            ->assertRedirect(route('home'));
+
+        $profile = CoachProfile::where('user_id', $athlete->id)->first();
+        expect($profile)->not->toBeNull();
+        expect($profile->status)->toBe(CoachProfileStatus::Pending);
+        expect($profile->specialties)->toBe(['fitness', 'yoga']);
+        expect($profile->bio)->toBe('Experienced fitness coach');
+        expect($profile->experience_level)->toBe('advanced');
+        expect($profile->postal_code)->toBe('1000');
+        expect($profile->country)->toBe('BE');
+        expect($profile->enterprise_number)->toBe('0123.456.789');
+
+        Event::assertDispatched(NewCoachApplication::class, function ($event) use ($profile) {
+            return $event->coachProfileId === $profile->id;
+        });
+    });
+
+    it('requires terms acceptance to submit', function () {
+        $athlete = User::factory()->athlete()->create();
+
+        Livewire::actingAs($athlete)
+            ->test(Application::class)
+            ->set('form.specialties', ['fitness'])
+            ->call('nextStep')
+            ->set('form.postal_code', '1000')
+            ->set('form.country', 'BE')
+            ->set('form.enterprise_number', '0123.456.789')
+            ->call('nextStep')
+            ->set('form.terms_accepted', false)
+            ->call('submit')
+            ->assertHasErrors(['form.terms_accepted']);
+    });
+
+});


### PR DESCRIPTION
## Summary

Implements the coach application form as a 3-step Livewire wizard allowing athletes to apply as coaches.

Resolves #32

## Changes

### New files
- `app/Enums/CoachProfileStatus.php` — Backed enum: pending, approved, rejected
- `app/Events/NewCoachApplication.php` — Event dispatched on application submission
- `app/Livewire/Coach/Application.php` — 3-step wizard Livewire component
- `app/Livewire/Forms/CoachApplicationForm.php` — Form object with validation
- `app/Models/CoachProfile.php` — Eloquent model with casts and user relationship
- `app/Services/CoachApplicationService.php` — Business logic for creating applications
- `database/factories/CoachProfileFactory.php` — Factory with pending/approved/rejected states
- `database/migrations/2026_04_08_100000_create_coach_profiles_table.php`
- `resources/views/livewire/coach/application.blade.php` — Mobile-first Blade view
- `lang/{fr,en,nl}/coach.php` — Translation files for all three locales
- `tests/Feature/Livewire/Coach/ApplicationTest.php` — 11 tests covering all steps

### Modified files
- `app/Models/User.php` — Added `coachProfile()` HasOne relationship
- `routes/web.php` — Added `/coach/apply` route (auth + verified)
- `lang/{fr,en,nl}/common.php` — Added `next` and `previous` keys

## Acceptance Criteria

- [x] `app/Livewire/Coach/Application.php` + `CoachApplicationForm.php`
- [x] Step 1: Specialties, bio, experience level
- [x] Step 2: Geographic zone (postal code, country), enterprise number (Belgian BCE/KBO)
- [x] Step 3: Confirmation + terms acceptance
- [x] On submit: creates coach profile record with status `pending`; dispatches `NewCoachApplication` event
- [x] Only athletes can apply (policy check)
- [x] All strings localized
- [x] Livewire component test for each step + submission