### PR TITLE
feat: E1-S17 · Admin coach approval portal

### DIFF
--- a/app/Events/CoachApproved.php
+++ b/app/Events/CoachApproved.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class CoachApproved
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(
+        public readonly int $coachProfileId,
+    ) {}
+}

--- a/app/Events/CoachRejected.php
+++ b/app/Events/CoachRejected.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class CoachRejected
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(
+        public readonly int $coachProfileId,
+        public readonly string $reason,
+    ) {}
+}

--- a/app/Livewire/Admin/CoachApproval.php
+++ b/app/Livewire/Admin/CoachApproval.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Admin;
+
+use App\Enums\CoachProfileStatus;
+use App\Models\CoachProfile;
+use App\Services\AdminService;
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+final class CoachApproval extends Component
+{
+    use WithPagination;
+
+    public string $rejectionReason = '';
+
+    public ?int $rejectingProfileId = null;
+
+    public function approve(int $profileId, AdminService $service): void
+    {
+        $coachProfile = CoachProfile::with('user')->findOrFail($profileId);
+
+        $service->approveCoach($coachProfile);
+
+        $this->dispatch('notify', type: 'success', message: __('admin.coach_approved'));
+    }
+
+    public function confirmReject(int $profileId): void
+    {
+        $this->rejectingProfileId = $profileId;
+        $this->rejectionReason = '';
+    }
+
+    public function cancelReject(): void
+    {
+        $this->rejectingProfileId = null;
+        $this->rejectionReason = '';
+    }
+
+    public function reject(AdminService $service): void
+    {
+        $this->validate([
+            'rejectionReason' => ['required', 'string', 'max:1000'],
+        ]);
+
+        if ($this->rejectingProfileId === null) {
+            return;
+        }
+
+        $coachProfile = CoachProfile::with('user')->findOrFail($this->rejectingProfileId);
+
+        $service->rejectCoach($coachProfile, $this->rejectionReason);
+
+        $this->rejectingProfileId = null;
+        $this->rejectionReason = '';
+
+        $this->dispatch('notify', type: 'success', message: __('admin.coach_rejected'));
+    }
+
+    public function render(): View
+    {
+        $pendingApplications = CoachProfile::with('user')
+            ->where('status', CoachProfileStatus::Pending)
+            ->latest()
+            ->paginate(10);
+
+        return view('livewire.admin.coach-approval', [
+            'pendingApplications' => $pendingApplications,
+        ])->title(__('admin.coach_approval_title'));
+    }
+}

--- a/app/Services/AdminService.php
+++ b/app/Services/AdminService.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\CoachProfileStatus;
+use App\Enums\UserRole;
+use App\Events\CoachApproved;
+use App\Events\CoachRejected;
+use App\Models\CoachProfile;
+use Illuminate\Support\Facades\DB;
+
+final class AdminService
+{
+    /**
+     * Approve a coach application.
+     *
+     * Changes the coach profile status to approved, promotes the user to coach role,
+     * and sets the verified_at timestamp.
+     */
+    public function approveCoach(CoachProfile $coachProfile): void
+    {
+        DB::transaction(function () use ($coachProfile): void {
+            $coachProfile->update([
+                'status' => CoachProfileStatus::Approved,
+                'verified_at' => now(),
+            ]);
+
+            $coachProfile->user->update([
+                'role' => UserRole::Coach,
+            ]);
+        });
+
+        CoachApproved::dispatch($coachProfile->id);
+    }
+
+    /**
+     * Reject a coach application.
+     */
+    public function rejectCoach(CoachProfile $coachProfile, string $reason): void
+    {
+        $coachProfile->update([
+            'status' => CoachProfileStatus::Rejected,
+        ]);
+
+        CoachRejected::dispatch($coachProfile->id, $reason);
+    }
+}

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Admin — Coach Approval
+    |--------------------------------------------------------------------------
+    */
+
+    'coach_approval_title' => 'Coach Validation',
+    'coach_approval_heading' => 'Pending Coach Applications',
+    'no_pending_applications' => 'No pending applications.',
+
+    'applied_at' => 'Applied at',
+
+    'approve' => 'Approve',
+    'reject' => 'Reject',
+    'approve_confirm' => 'Are you sure you want to approve this coach?',
+    'confirm_reject' => 'Confirm rejection',
+    'rejection_reason_label' => 'Rejection reason',
+    'rejection_reason_placeholder' => 'Provide the reason for rejection…',
+
+    'coach_approved' => 'Coach has been approved successfully.',
+    'coach_rejected' => 'Application has been rejected.',
+
+];

--- a/lang/fr/admin.php
+++ b/lang/fr/admin.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Admin — Coach Approval
+    |--------------------------------------------------------------------------
+    */
+
+    'coach_approval_title' => 'Validation des coachs',
+    'coach_approval_heading' => 'Candidatures de coachs en attente',
+    'no_pending_applications' => 'Aucune candidature en attente.',
+
+    'applied_at' => 'Date de candidature',
+
+    'approve' => 'Approuver',
+    'reject' => 'Rejeter',
+    'approve_confirm' => 'Êtes-vous sûr de vouloir approuver ce coach ?',
+    'confirm_reject' => 'Confirmer le rejet',
+    'rejection_reason_label' => 'Motif du rejet',
+    'rejection_reason_placeholder' => 'Indiquez la raison du rejet…',
+
+    'coach_approved' => 'Le coach a été approuvé avec succès.',
+    'coach_rejected' => 'La candidature a été rejetée.',
+
+];

--- a/lang/nl/admin.php
+++ b/lang/nl/admin.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Admin — Coach Approval
+    |--------------------------------------------------------------------------
+    */
+
+    'coach_approval_title' => 'Coachvalidatie',
+    'coach_approval_heading' => 'Lopende coachaanvragen',
+    'no_pending_applications' => 'Geen lopende aanvragen.',
+
+    'applied_at' => 'Datum van aanvraag',
+
+    'approve' => 'Goedkeuren',
+    'reject' => 'Afwijzen',
+    'approve_confirm' => 'Weet u zeker dat u deze coach wilt goedkeuren?',
+    'confirm_reject' => 'Afwijzing bevestigen',
+    'rejection_reason_label' => 'Reden van afwijzing',
+    'rejection_reason_placeholder' => 'Geef de reden voor de afwijzing op…',
+
+    'coach_approved' => 'De coach is succesvol goedgekeurd.',
+    'coach_rejected' => 'De aanvraag is afgewezen.',
+
+];

--- a/resources/views/livewire/admin/coach-approval.blade.php
+++ b/resources/views/livewire/admin/coach-approval.blade.php
@@ -1,0 +1,121 @@
+<div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
+        {{ __('admin.coach_approval_heading') }}
+    </h1>
+
+    @if ($pendingApplications->isEmpty())
+        <div class="mt-6 rounded-lg bg-white p-6 text-center shadow dark:bg-gray-800">
+            <p class="text-gray-500 dark:text-gray-400">{{ __('admin.no_pending_applications') }}</p>
+        </div>
+    @else
+        <div class="mt-6 space-y-4">
+            @foreach ($pendingApplications as $profile)
+                <div class="rounded-lg bg-white p-6 shadow dark:bg-gray-800" wire:key="profile-{{ $profile->id }}">
+                    <div class="flex items-start justify-between">
+                        <div>
+                            <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                                {{ $profile->user->name }}
+                            </h2>
+                            <p class="text-sm text-gray-500 dark:text-gray-400">
+                                {{ $profile->user->email }}
+                            </p>
+                        </div>
+                        <span class="inline-flex items-center rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-medium text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200">
+                            {{ __('common.status.pending') }}
+                        </span>
+                    </div>
+
+                    <dl class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ __('coach.specialties_label') }}</dt>
+                            <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">
+                                {{ implode(', ', $profile->specialties ?? []) }}
+                            </dd>
+                        </div>
+                        @if ($profile->bio)
+                            <div class="sm:col-span-2">
+                                <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ __('coach.bio_label') }}</dt>
+                                <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">{{ $profile->bio }}</dd>
+                            </div>
+                        @endif
+                        @if ($profile->experience_level)
+                            <div>
+                                <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ __('coach.experience_level_label') }}</dt>
+                                <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">{{ __('coach.experience_' . $profile->experience_level) }}</dd>
+                            </div>
+                        @endif
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ __('coach.postal_code_label') }}</dt>
+                            <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">{{ $profile->postal_code }} ({{ $profile->country }})</dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ __('coach.enterprise_number_label') }}</dt>
+                            <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">{{ $profile->enterprise_number }}</dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ __('admin.applied_at') }}</dt>
+                            <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">{{ $profile->created_at->format('d/m/Y H:i') }}</dd>
+                        </div>
+                    </dl>
+
+                    {{-- Rejection form --}}
+                    @if ($rejectingProfileId === $profile->id)
+                        <div class="mt-4 rounded-md border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
+                            <label for="rejectionReason-{{ $profile->id }}" class="block text-sm font-medium text-red-800 dark:text-red-200">
+                                {{ __('admin.rejection_reason_label') }}
+                            </label>
+                            <textarea
+                                wire:model="rejectionReason"
+                                id="rejectionReason-{{ $profile->id }}"
+                                rows="3"
+                                class="mt-1 block w-full rounded-md border-red-300 shadow-sm focus:border-red-500 focus:ring-red-500 dark:border-red-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                                placeholder="{{ __('admin.rejection_reason_placeholder') }}"
+                            ></textarea>
+                            @error('rejectionReason')
+                                <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                            @enderror
+                            <div class="mt-3 flex gap-2">
+                                <button
+                                    type="button"
+                                    wire:click="reject"
+                                    class="rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500"
+                                >
+                                    {{ __('admin.confirm_reject') }}
+                                </button>
+                                <button
+                                    type="button"
+                                    wire:click="cancelReject"
+                                    class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300"
+                                >
+                                    {{ __('common.cancel') }}
+                                </button>
+                            </div>
+                        </div>
+                    @else
+                        <div class="mt-4 flex gap-2">
+                            <button
+                                type="button"
+                                wire:click="approve({{ $profile->id }})"
+                                wire:confirm="{{ __('admin.approve_confirm') }}"
+                                class="rounded-md bg-green-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-500"
+                            >
+                                {{ __('admin.approve') }}
+                            </button>
+                            <button
+                                type="button"
+                                wire:click="confirmReject({{ $profile->id }})"
+                                class="rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500"
+                            >
+                                {{ __('admin.reject') }}
+                            </button>
+                        </div>
+                    @endif
+                </div>
+            @endforeach
+        </div>
+
+        <div class="mt-6">
+            {{ $pendingApplications->links() }}
+        </div>
+    @endif
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Livewire\Admin\CoachApproval;
 use App\Livewire\Auth\ForgotPassword;
 use App\Livewire\Auth\Login;
 use App\Livewire\Auth\Register;
@@ -37,6 +38,10 @@ Route::get('/profile', ProfileEdit::class)
 Route::get('/coach/apply', CoachApplication::class)
     ->middleware(['auth', 'verified'])
     ->name('coach.apply');
+
+Route::get('/admin/coach-approval', CoachApproval::class)
+    ->middleware(['auth', 'role:admin'])
+    ->name('admin.coach-approval');
 
 Route::get('/health', function () {
     $checks = ['status' => 'ok'];

--- a/tests/Feature/Livewire/Admin/CoachApprovalTest.php
+++ b/tests/Feature/Livewire/Admin/CoachApprovalTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\CoachProfileStatus;
+use App\Enums\UserRole;
+use App\Events\CoachApproved;
+use App\Events\CoachRejected;
+use App\Livewire\Admin\CoachApproval;
+use App\Models\CoachProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+describe('Admin Coach Approval', function () {
+
+    it('renders the page for admins', function () {
+        $admin = User::factory()->admin()->create();
+
+        $this->actingAs($admin)
+            ->get(route('admin.coach-approval'))
+            ->assertOk();
+    });
+
+    it('denies access to athletes', function () {
+        $athlete = User::factory()->athlete()->create();
+
+        $this->actingAs($athlete)
+            ->get(route('admin.coach-approval'))
+            ->assertForbidden();
+    });
+
+    it('denies access to coaches', function () {
+        $coach = User::factory()->coach()->create();
+
+        $this->actingAs($coach)
+            ->get(route('admin.coach-approval'))
+            ->assertForbidden();
+    });
+
+    it('denies access to guests', function () {
+        $this->get(route('admin.coach-approval'))
+            ->assertRedirect(route('login'));
+    });
+
+    it('lists pending coach applications', function () {
+        $admin = User::factory()->admin()->create();
+        $pendingProfile = CoachProfile::factory()->pending()->create();
+
+        Livewire::actingAs($admin)
+            ->test(CoachApproval::class)
+            ->assertSee($pendingProfile->user->name)
+            ->assertSee($pendingProfile->user->email);
+    });
+
+    it('does not list approved applications', function () {
+        $admin = User::factory()->admin()->create();
+        $approvedProfile = CoachProfile::factory()->approved()->create();
+
+        Livewire::actingAs($admin)
+            ->test(CoachApproval::class)
+            ->assertDontSee($approvedProfile->user->email);
+    });
+
+    it('shows empty state when no pending applications', function () {
+        $admin = User::factory()->admin()->create();
+
+        Livewire::actingAs($admin)
+            ->test(CoachApproval::class)
+            ->assertSee(__('admin.no_pending_applications'));
+    });
+
+    it('approves a coach application', function () {
+        Event::fake([CoachApproved::class]);
+
+        $admin = User::factory()->admin()->create();
+        $profile = CoachProfile::factory()->pending()->create();
+
+        Livewire::actingAs($admin)
+            ->test(CoachApproval::class)
+            ->call('approve', $profile->id);
+
+        $profile->refresh();
+        expect($profile->status)->toBe(CoachProfileStatus::Approved);
+        expect($profile->verified_at)->not->toBeNull();
+        expect($profile->user->fresh()->role)->toBe(UserRole::Coach);
+
+        Event::assertDispatched(CoachApproved::class, function ($event) use ($profile) {
+            return $event->coachProfileId === $profile->id;
+        });
+    });
+
+    it('rejects a coach application with reason', function () {
+        Event::fake([CoachRejected::class]);
+
+        $admin = User::factory()->admin()->create();
+        $profile = CoachProfile::factory()->pending()->create();
+
+        Livewire::actingAs($admin)
+            ->test(CoachApproval::class)
+            ->call('confirmReject', $profile->id)
+            ->assertSet('rejectingProfileId', $profile->id)
+            ->set('rejectionReason', 'Missing qualifications')
+            ->call('reject');
+
+        $profile->refresh();
+        expect($profile->status)->toBe(CoachProfileStatus::Rejected);
+        expect($profile->user->fresh()->role)->toBe(UserRole::Athlete);
+
+        Event::assertDispatched(CoachRejected::class, function ($event) use ($profile) {
+            return $event->coachProfileId === $profile->id
+                && $event->reason === 'Missing qualifications';
+        });
+    });
+
+    it('requires rejection reason', function () {
+        $admin = User::factory()->admin()->create();
+        $profile = CoachProfile::factory()->pending()->create();
+
+        Livewire::actingAs($admin)
+            ->test(CoachApproval::class)
+            ->call('confirmReject', $profile->id)
+            ->set('rejectionReason', '')
+            ->call('reject')
+            ->assertHasErrors(['rejectionReason']);
+    });
+
+    it('can cancel rejection', function () {
+        $admin = User::factory()->admin()->create();
+        $profile = CoachProfile::factory()->pending()->create();
+
+        Livewire::actingAs($admin)
+            ->test(CoachApproval::class)
+            ->call('confirmReject', $profile->id)
+            ->assertSet('rejectingProfileId', $profile->id)
+            ->call('cancelReject')
+            ->assertSet('rejectingProfileId', null)
+            ->assertSet('rejectionReason', '');
+    });
+
+});


### PR DESCRIPTION
## Summary

Implements the admin portal for reviewing, approving, and rejecting coach applications.

Resolves #33

## Changes

### New files
- `app/Events/CoachApproved.php` — Event dispatched when admin approves
- `app/Events/CoachRejected.php` — Event dispatched with rejection reason
- `app/Services/AdminService.php` — Approve/reject business logic with DB transaction
- `app/Livewire/Admin/CoachApproval.php` — Admin Livewire component with pagination
- `resources/views/livewire/admin/coach-approval.blade.php` — Mobile-first admin view
- `lang/{fr,en,nl}/admin.php` — Admin translation files
- `tests/Feature/Livewire/Admin/CoachApprovalTest.php` — 11 tests

### Modified files
- `routes/web.php` — Added `/admin/coach-approval` route (auth + role:admin)

## Acceptance Criteria

- [x] `app/Livewire/Admin/CoachApproval.php`
- [x] Lists pending coach applications with details
- [x] Admin can **approve** → user role changes from `athlete` to `coach`; dispatches `CoachApproved` event
- [x] Admin can **reject** with reason → dispatches `CoachRejected` event
- [x] Protected by `role:admin` middleware
- [x] Approved coaches get a verification badge flag (`verified_at` timestamp set)
- [x] All strings localized
- [x] Feature test: approve flow, reject flow, non-admin denied