### PR TITLE
feat: E1-S18 · Coach approval / rejection email notifications

### DIFF
--- a/app/Listeners/SendCoachApprovedNotification.php
+++ b/app/Listeners/SendCoachApprovedNotification.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\CoachApproved;
+use App\Models\CoachProfile;
+use App\Notifications\CoachApprovedNotification;
+
+class SendCoachApprovedNotification
+{
+    public function handle(CoachApproved $event): void
+    {
+        $coachProfile = CoachProfile::with('user')->findOrFail($event->coachProfileId);
+
+        $coachProfile->user->notify(new CoachApprovedNotification($event->coachProfileId));
+    }
+}

--- a/app/Listeners/SendCoachRejectedNotification.php
+++ b/app/Listeners/SendCoachRejectedNotification.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\CoachRejected;
+use App\Models\CoachProfile;
+use App\Notifications\CoachRejectedNotification;
+
+class SendCoachRejectedNotification
+{
+    public function handle(CoachRejected $event): void
+    {
+        $coachProfile = CoachProfile::with('user')->findOrFail($event->coachProfileId);
+
+        $coachProfile->user->notify(new CoachRejectedNotification($event->coachProfileId, $event->reason));
+    }
+}

--- a/app/Notifications/CoachApprovedNotification.php
+++ b/app/Notifications/CoachApprovedNotification.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\CoachProfile;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class CoachApprovedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        private readonly int $coachProfileId,
+    ) {}
+
+    /**
+     * @return list<string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $profile = CoachProfile::findOrFail($this->coachProfileId);
+
+        return (new MailMessage)
+            ->subject(__('notifications.coach_approved_subject'))
+            ->greeting(__('notifications.greeting', ['name' => $notifiable->name]))
+            ->line(__('notifications.coach_approved_body'))
+            ->line(__('notifications.coach_approved_specialties', [
+                'specialties' => implode(', ', $profile->specialties ?? []),
+            ]))
+            ->action(__('notifications.coach_approved_action'), url('/'))
+            ->line(__('notifications.thanks'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'type' => 'coach_approved',
+            'coach_profile_id' => $this->coachProfileId,
+            'message' => __('notifications.coach_approved_body'),
+        ];
+    }
+}

--- a/app/Notifications/CoachRejectedNotification.php
+++ b/app/Notifications/CoachRejectedNotification.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class CoachRejectedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        private readonly int $coachProfileId,
+        private readonly string $reason,
+    ) {}
+
+    /**
+     * @return list<string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject(__('notifications.coach_rejected_subject'))
+            ->greeting(__('notifications.greeting', ['name' => $notifiable->name]))
+            ->line(__('notifications.coach_rejected_body'))
+            ->line(__('notifications.coach_rejected_reason', ['reason' => $this->reason]))
+            ->line(__('notifications.thanks'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'type' => 'coach_rejected',
+            'coach_profile_id' => $this->coachProfileId,
+            'reason' => $this->reason,
+            'message' => __('notifications.coach_rejected_body'),
+        ];
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Events\CoachApproved;
+use App\Events\CoachRejected;
+use App\Listeners\SendCoachApprovedNotification;
+use App\Listeners\SendCoachRejectedNotification;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+
+class EventServiceProvider extends ServiceProvider
+{
+    /**
+     * @var array<class-string, list<class-string>>
+     */
+    protected $listen = [
+        CoachApproved::class => [
+            SendCoachApprovedNotification::class,
+        ],
+        CoachRejected::class => [
+            SendCoachRejectedNotification::class,
+        ],
+    ];
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,9 +1,11 @@
 <?php
 
 use App\Providers\AppServiceProvider;
+use App\Providers\EventServiceProvider;
 use App\Providers\FortifyServiceProvider;
 
 return [
     AppServiceProvider::class,
+    EventServiceProvider::class,
     FortifyServiceProvider::class,
 ];

--- a/database/migrations/2026_04_08_122815_create_notifications_table.php
+++ b/database/migrations/2026_04_08_122815_create_notifications_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('type');
+            $table->morphs('notifiable');
+            $table->text('data');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};

--- a/lang/en/notifications.php
+++ b/lang/en/notifications.php
@@ -24,4 +24,19 @@ return [
     'two_factor_code_expiry' => 'This code will expire in 10 minutes.',
     'two_factor_code_ignore' => 'If you did not request this code, please ignore this email.',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Coach Application
+    |--------------------------------------------------------------------------
+    */
+
+    'coach_approved_subject' => 'Your coach application has been approved!',
+    'coach_approved_body' => 'Congratulations! Your coach application on Motivya has been approved.',
+    'coach_approved_specialties' => 'Your specialties: :specialties.',
+    'coach_approved_action' => 'Go to my dashboard',
+
+    'coach_rejected_subject' => 'Your coach application was not accepted',
+    'coach_rejected_body' => 'We are sorry, your coach application on Motivya was not accepted.',
+    'coach_rejected_reason' => 'Reason: :reason',
+
 ];

--- a/lang/fr/notifications.php
+++ b/lang/fr/notifications.php
@@ -24,4 +24,19 @@ return [
     'two_factor_code_expiry' => 'Ce code expirera dans 10 minutes.',
     'two_factor_code_ignore' => 'Si vous n\'avez pas demandé ce code, veuillez ignorer cet e-mail.',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Candidature Coach
+    |--------------------------------------------------------------------------
+    */
+
+    'coach_approved_subject' => 'Votre candidature de coach a été approuvée !',
+    'coach_approved_body' => 'Félicitations ! Votre candidature de coach sur Motivya a été approuvée.',
+    'coach_approved_specialties' => 'Vos spécialités : :specialties.',
+    'coach_approved_action' => 'Accéder à mon tableau de bord',
+
+    'coach_rejected_subject' => 'Votre candidature de coach n\'a pas été retenue',
+    'coach_rejected_body' => 'Nous sommes désolés, votre candidature de coach sur Motivya n\'a pas été retenue.',
+    'coach_rejected_reason' => 'Motif : :reason',
+
 ];

--- a/lang/nl/notifications.php
+++ b/lang/nl/notifications.php
@@ -24,4 +24,19 @@ return [
     'two_factor_code_expiry' => 'Deze code vervalt over 10 minuten.',
     'two_factor_code_ignore' => 'Als u deze code niet heeft aangevraagd, kunt u deze e-mail negeren.',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Coachaanvraag
+    |--------------------------------------------------------------------------
+    */
+
+    'coach_approved_subject' => 'Uw coachaanvraag is goedgekeurd!',
+    'coach_approved_body' => 'Gefeliciteerd! Uw coachaanvraag op Motivya is goedgekeurd.',
+    'coach_approved_specialties' => 'Uw specialiteiten: :specialties.',
+    'coach_approved_action' => 'Ga naar mijn dashboard',
+
+    'coach_rejected_subject' => 'Uw coachaanvraag is niet aanvaard',
+    'coach_rejected_body' => 'Het spijt ons, uw coachaanvraag op Motivya is niet aanvaard.',
+    'coach_rejected_reason' => 'Reden: :reason',
+
 ];

--- a/tests/Feature/Notifications/CoachApprovalNotificationTest.php
+++ b/tests/Feature/Notifications/CoachApprovalNotificationTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Events\CoachApproved;
+use App\Events\CoachRejected;
+use App\Listeners\SendCoachApprovedNotification;
+use App\Listeners\SendCoachRejectedNotification;
+use App\Models\CoachProfile;
+use App\Notifications\CoachApprovedNotification;
+use App\Notifications\CoachRejectedNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+
+uses(RefreshDatabase::class);
+
+describe('Coach Approval Notifications', function () {
+
+    it('sends approved notification when CoachApproved event is dispatched', function () {
+        Notification::fake();
+
+        $profile = CoachProfile::factory()->approved()->create();
+
+        $listener = new SendCoachApprovedNotification;
+        $listener->handle(new CoachApproved($profile->id));
+
+        Notification::assertSentTo(
+            $profile->user,
+            CoachApprovedNotification::class,
+        );
+    });
+
+    it('sends rejected notification when CoachRejected event is dispatched', function () {
+        Notification::fake();
+
+        $profile = CoachProfile::factory()->pending()->create();
+        $reason = 'Missing qualifications';
+
+        $listener = new SendCoachRejectedNotification;
+        $listener->handle(new CoachRejected($profile->id, $reason));
+
+        Notification::assertSentTo(
+            $profile->user,
+            CoachRejectedNotification::class,
+        );
+    });
+
+    it('approved notification uses mail and database channels', function () {
+        Notification::fake();
+
+        $profile = CoachProfile::factory()->approved()->create();
+
+        $listener = new SendCoachApprovedNotification;
+        $listener->handle(new CoachApproved($profile->id));
+
+        Notification::assertSentTo(
+            $profile->user,
+            CoachApprovedNotification::class,
+            function ($notification, $channels) {
+                return $channels === ['mail', 'database'];
+            },
+        );
+    });
+
+    it('rejected notification uses mail and database channels', function () {
+        Notification::fake();
+
+        $profile = CoachProfile::factory()->pending()->create();
+
+        $listener = new SendCoachRejectedNotification;
+        $listener->handle(new CoachRejected($profile->id, 'Incomplete application'));
+
+        Notification::assertSentTo(
+            $profile->user,
+            CoachRejectedNotification::class,
+            function ($notification, $channels) {
+                return $channels === ['mail', 'database'];
+            },
+        );
+    });
+
+    it('approved notification mail contains correct subject', function () {
+        $profile = CoachProfile::factory()->approved()->create();
+
+        $notification = new CoachApprovedNotification($profile->id);
+        $mail = $notification->toMail($profile->user);
+
+        expect($mail->subject)->toBe(__('notifications.coach_approved_subject'));
+    });
+
+    it('rejected notification mail contains rejection reason', function () {
+        $profile = CoachProfile::factory()->pending()->create();
+        $reason = 'Missing documentation';
+
+        $notification = new CoachRejectedNotification($profile->id, $reason);
+        $mail = $notification->toMail($profile->user);
+
+        $bodyText = collect($mail->introLines)->implode(' ');
+        expect($bodyText)->toContain($reason);
+    });
+
+    it('approved notification toArray contains coach_profile_id', function () {
+        $profile = CoachProfile::factory()->approved()->create();
+
+        $notification = new CoachApprovedNotification($profile->id);
+        $data = $notification->toArray($profile->user);
+
+        expect($data['type'])->toBe('coach_approved');
+        expect($data['coach_profile_id'])->toBe($profile->id);
+    });
+
+    it('rejected notification toArray contains reason', function () {
+        $profile = CoachProfile::factory()->pending()->create();
+        $reason = 'Not eligible';
+
+        $notification = new CoachRejectedNotification($profile->id, $reason);
+        $data = $notification->toArray($profile->user);
+
+        expect($data['type'])->toBe('coach_rejected');
+        expect($data['reason'])->toBe($reason);
+    });
+
+});


### PR DESCRIPTION
## Summary

Implements localized email notifications for coach application approval and rejection, wired via event-listener architecture.

Resolves #34

## Changes

### New files
- `app/Notifications/CoachApprovedNotification.php` — Congratulations email (mail + database, queued)
- `app/Notifications/CoachRejectedNotification.php` — Rejection with reason (mail + database, queued)
- `app/Listeners/SendCoachApprovedNotification.php` — Listens to `CoachApproved`
- `app/Listeners/SendCoachRejectedNotification.php` — Listens to `CoachRejected`
- `app/Providers/EventServiceProvider.php` — Event-listener mapping (`$listen` array)
- `database/migrations/2026_04_08_122815_create_notifications_table.php` — For database channel
- `tests/Feature/Notifications/CoachApprovalNotificationTest.php` — 8 tests

### Modified files
- `bootstrap/providers.php` — Registered EventServiceProvider
- `lang/{fr,en,nl}/notifications.php` — Added coach approval/rejection strings

## Acceptance Criteria

- [x] `app/Notifications/CoachApprovedNotification.php` — congratulations email
- [x] `app/Notifications/CoachRejectedNotification.php` — rejection with reason
- [x] `app/Listeners/SendCoachApprovedNotification.php` — listens to `CoachApproved`
- [x] `app/Listeners/SendCoachRejectedNotification.php` — listens to `CoachRejected`
- [x] Listeners registered in `EventServiceProvider`
- [x] Notification content in `lang/{locale}/notifications.php`
- [x] Feature test: approving coach triggers correct notification