### PR TITLE
feat: E1-S19 · New coach application notification to admin

### DIFF
--- a/app/Listeners/NotifyAdminsOfNewApplication.php
+++ b/app/Listeners/NotifyAdminsOfNewApplication.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Enums\UserRole;
+use App\Events\NewCoachApplication;
+use App\Models\User;
+use App\Notifications\NewCoachApplicationNotification;
+use Illuminate\Support\Facades\Notification;
+
+class NotifyAdminsOfNewApplication
+{
+    public function handle(NewCoachApplication $event): void
+    {
+        $admins = User::where('role', UserRole::Admin)->get();
+
+        Notification::send($admins, new NewCoachApplicationNotification($event->coachProfileId));
+    }
+}

--- a/app/Notifications/NewCoachApplicationNotification.php
+++ b/app/Notifications/NewCoachApplicationNotification.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\CoachProfile;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class NewCoachApplicationNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        private readonly int $coachProfileId,
+    ) {}
+
+    /**
+     * @return list<string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $profile = CoachProfile::with('user')->findOrFail($this->coachProfileId);
+
+        return (new MailMessage)
+            ->subject(__('notifications.new_coach_application_subject'))
+            ->greeting(__('notifications.greeting', ['name' => $notifiable->name]))
+            ->line(__('notifications.new_coach_application_body', [
+                'name' => $profile->user->name,
+                'email' => $profile->user->email,
+            ]))
+            ->line(__('notifications.new_coach_application_specialties', [
+                'specialties' => implode(', ', $profile->specialties ?? []),
+            ]))
+            ->action(__('notifications.new_coach_application_action'), url(route('admin.coach-approval')))
+            ->line(__('notifications.thanks'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'type' => 'new_coach_application',
+            'coach_profile_id' => $this->coachProfileId,
+            'message' => __('notifications.new_coach_application_body_short'),
+        ];
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -6,6 +6,8 @@ namespace App\Providers;
 
 use App\Events\CoachApproved;
 use App\Events\CoachRejected;
+use App\Events\NewCoachApplication;
+use App\Listeners\NotifyAdminsOfNewApplication;
 use App\Listeners\SendCoachApprovedNotification;
 use App\Listeners\SendCoachRejectedNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -21,6 +23,9 @@ class EventServiceProvider extends ServiceProvider
         ],
         CoachRejected::class => [
             SendCoachRejectedNotification::class,
+        ],
+        NewCoachApplication::class => [
+            NotifyAdminsOfNewApplication::class,
         ],
     ];
 }

--- a/lang/en/notifications.php
+++ b/lang/en/notifications.php
@@ -39,4 +39,16 @@ return [
     'coach_rejected_body' => 'We are sorry, your coach application on Motivya was not accepted.',
     'coach_rejected_reason' => 'Reason: :reason',
 
+    /*
+    |--------------------------------------------------------------------------
+    | New Application (admin)
+    |--------------------------------------------------------------------------
+    */
+
+    'new_coach_application_subject' => 'New coach application',
+    'new_coach_application_body' => ':name (:email) has submitted a coach application.',
+    'new_coach_application_specialties' => 'Specialties: :specialties.',
+    'new_coach_application_action' => 'View applications',
+    'new_coach_application_body_short' => 'A new coach application has been submitted.',
+
 ];

--- a/lang/fr/notifications.php
+++ b/lang/fr/notifications.php
@@ -39,4 +39,16 @@ return [
     'coach_rejected_body' => 'Nous sommes désolés, votre candidature de coach sur Motivya n\'a pas été retenue.',
     'coach_rejected_reason' => 'Motif : :reason',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Nouvelle candidature (admin)
+    |--------------------------------------------------------------------------
+    */
+
+    'new_coach_application_subject' => 'Nouvelle candidature de coach',
+    'new_coach_application_body' => ':name (:email) a soumis une candidature de coach.',
+    'new_coach_application_specialties' => 'Spécialités : :specialties.',
+    'new_coach_application_action' => 'Voir les candidatures',
+    'new_coach_application_body_short' => 'Une nouvelle candidature de coach a été soumise.',
+
 ];

--- a/lang/nl/notifications.php
+++ b/lang/nl/notifications.php
@@ -39,4 +39,16 @@ return [
     'coach_rejected_body' => 'Het spijt ons, uw coachaanvraag op Motivya is niet aanvaard.',
     'coach_rejected_reason' => 'Reden: :reason',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Nieuwe aanvraag (admin)
+    |--------------------------------------------------------------------------
+    */
+
+    'new_coach_application_subject' => 'Nieuwe coachaanvraag',
+    'new_coach_application_body' => ':name (:email) heeft een coachaanvraag ingediend.',
+    'new_coach_application_specialties' => 'Specialiteiten: :specialties.',
+    'new_coach_application_action' => 'Aanvragen bekijken',
+    'new_coach_application_body_short' => 'Er is een nieuwe coachaanvraag ingediend.',
+
 ];

--- a/tests/Feature/Notifications/NewCoachApplicationNotificationTest.php
+++ b/tests/Feature/Notifications/NewCoachApplicationNotificationTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Events\NewCoachApplication;
+use App\Listeners\NotifyAdminsOfNewApplication;
+use App\Livewire\Coach\Application;
+use App\Models\CoachProfile;
+use App\Models\User;
+use App\Notifications\NewCoachApplicationNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+describe('New Coach Application Admin Notification', function () {
+
+    it('sends notification to all admin users when listener handles event', function () {
+        Notification::fake();
+
+        $admin1 = User::factory()->admin()->create();
+        $admin2 = User::factory()->admin()->create();
+        User::factory()->athlete()->create(); // should not receive
+        User::factory()->coach()->create();   // should not receive
+
+        $profile = CoachProfile::factory()->pending()->create();
+
+        $listener = new NotifyAdminsOfNewApplication;
+        $listener->handle(new NewCoachApplication($profile->id));
+
+        Notification::assertSentTo($admin1, NewCoachApplicationNotification::class);
+        Notification::assertSentTo($admin2, NewCoachApplicationNotification::class);
+        Notification::assertCount(2);
+    });
+
+    it('does not send notification when no admin users exist', function () {
+        Notification::fake();
+
+        User::factory()->athlete()->create();
+
+        $profile = CoachProfile::factory()->pending()->create();
+
+        $listener = new NotifyAdminsOfNewApplication;
+        $listener->handle(new NewCoachApplication($profile->id));
+
+        Notification::assertNothingSent();
+    });
+
+    it('notification uses mail and database channels', function () {
+        Notification::fake();
+
+        $admin = User::factory()->admin()->create();
+        $profile = CoachProfile::factory()->pending()->create();
+
+        $listener = new NotifyAdminsOfNewApplication;
+        $listener->handle(new NewCoachApplication($profile->id));
+
+        Notification::assertSentTo(
+            $admin,
+            NewCoachApplicationNotification::class,
+            function ($notification, $channels) {
+                return $channels === ['mail', 'database'];
+            },
+        );
+    });
+
+    it('notification mail contains applicant name and email', function () {
+        $profile = CoachProfile::factory()->pending()->create();
+        $admin = User::factory()->admin()->create();
+
+        $notification = new NewCoachApplicationNotification($profile->id);
+        $mail = $notification->toMail($admin);
+
+        expect($mail->subject)->toBe(__('notifications.new_coach_application_subject'));
+
+        $bodyText = collect($mail->introLines)->implode(' ');
+        expect($bodyText)->toContain($profile->user->name);
+        expect($bodyText)->toContain($profile->user->email);
+    });
+
+    it('notification toArray contains coach_profile_id', function () {
+        $profile = CoachProfile::factory()->pending()->create();
+        $admin = User::factory()->admin()->create();
+
+        $notification = new NewCoachApplicationNotification($profile->id);
+        $data = $notification->toArray($admin);
+
+        expect($data['type'])->toBe('new_coach_application');
+        expect($data['coach_profile_id'])->toBe($profile->id);
+    });
+
+    it('submitting coach application dispatches NewCoachApplication event', function () {
+        Event::fake([NewCoachApplication::class]);
+
+        $athlete = User::factory()->athlete()->create();
+
+        Livewire::actingAs($athlete)
+            ->test(Application::class)
+            ->set('form.specialties', ['fitness'])
+            ->set('form.bio', 'Test bio')
+            ->set('form.experience_level', 'beginner')
+            ->call('nextStep')
+            ->set('form.postal_code', '1000')
+            ->set('form.country', 'BE')
+            ->set('form.enterprise_number', '0123.456.789')
+            ->call('nextStep')
+            ->set('form.terms_accepted', true)
+            ->call('submit')
+            ->assertRedirect(route('home'));
+
+        Event::assertDispatched(NewCoachApplication::class);
+    });
+
+});


### PR DESCRIPTION
## Summary

Sends localized email notifications to all admin users when a new coach application is submitted.

Resolves #35

## Changes

### New files
- `app/Notifications/NewCoachApplicationNotification.php` — Email to all admins (mail + database, queued)
- `app/Listeners/NotifyAdminsOfNewApplication.php` — Listens to `NewCoachApplication` event
- `tests/Feature/Notifications/NewCoachApplicationNotificationTest.php` — 6 tests

### Modified files
- `app/Providers/EventServiceProvider.php` — Added `NewCoachApplication` → `NotifyAdminsOfNewApplication` mapping
- `lang/{fr,en,nl}/notifications.php` — Added admin notification strings

## Acceptance Criteria

- [x] `app/Notifications/NewCoachApplicationNotification.php` — email to all admin users
- [x] `app/Listeners/NotifyAdminsOfNewApplication.php` — listens to `NewCoachApplication`
- [x] Notification content localized (fr/en/nl)
- [x] Feature test: submitting application triggers admin notification