### PR TITLE
fix: Docker test failures, Vite dev server, and Livewire routing

### DIFF
--- a/.docker/nginx/default.conf
+++ b/.docker/nginx/default.conf
@@ -18,6 +18,7 @@ server {
     }
 
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff2?)$ {
+        try_files $uri /index.php?$query_string;
         expires 1d;
         log_not_found off;
     }

--- a/.env.testing
+++ b/.env.testing
@@ -1,0 +1,14 @@
+# Testing environment overrides for Docker
+# Laravel loads .env.testing when APP_ENV=testing (set by phpunit.xml)
+# These override the Docker container's OS env vars.
+
+APP_ENV=testing
+DB_CONNECTION=sqlite
+DB_DATABASE=:memory:
+DB_URL=
+
+CACHE_STORE=array
+SESSION_DRIVER=array
+QUEUE_CONNECTION=sync
+MAIL_MAILER=array
+BROADCAST_CONNECTION=null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - .:/var/www/html
       - .docker/php/php.ini:/usr/local/etc/php/conf.d/99-dev.ini
     env_file: .docker/.env.docker
+    ports:
+      - "127.0.0.1:5173:5173"
     environment:
       APP_NAME: Motivya
       APP_ENV: local

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,20 +18,29 @@
         </include>
     </source>
     <php>
-        <env name="APP_ENV" value="testing"/>
+        <env name="APP_ENV" value="testing" force="true"/>
         <env name="APP_KEY" value="base64:2fl+Ktvkfl+Fuz4Qp/A75G2RTiWVA/ZoKZvp6fiiM10="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>
-        <env name="CACHE_STORE" value="array"/>
-        <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
-        <env name="DB_URL" value=""/>
-        <env name="MAIL_MAILER" value="array"/>
-        <env name="QUEUE_CONNECTION" value="sync"/>
-        <env name="SESSION_DRIVER" value="array"/>
+        <env name="CACHE_STORE" value="array" force="true"/>
+        <env name="DB_CONNECTION" value="sqlite" force="true"/>
+        <env name="DB_DATABASE" value=":memory:" force="true"/>
+        <env name="DB_URL" value="" force="true"/>
+        <env name="MAIL_MAILER" value="array" force="true"/>
+        <env name="QUEUE_CONNECTION" value="sync" force="true"/>
+        <env name="SESSION_DRIVER" value="array" force="true"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
         <env name="NIGHTWATCH_ENABLED" value="false"/>
+        <server name="APP_ENV" value="testing" force="true"/>
+        <server name="DB_CONNECTION" value="sqlite" force="true"/>
+        <server name="DB_DATABASE" value=":memory:" force="true"/>
+        <server name="DB_URL" value="" force="true"/>
+        <server name="CACHE_STORE" value="array" force="true"/>
+        <server name="SESSION_DRIVER" value="array" force="true"/>
+        <server name="QUEUE_CONNECTION" value="sync" force="true"/>
+        <server name="MAIL_MAILER" value="array" force="true"/>
+        <server name="REDIS_HOST" value="127.0.0.1" force="true"/>
     </php>
 </phpunit>

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,6 +11,12 @@ export default defineConfig({
         tailwindcss(),
     ],
     server: {
+        host: '0.0.0.0',
+        port: 5173,
+        strictPort: true,
+        hmr: {
+            host: 'localhost',
+        },
         watch: {
             ignored: ['**/storage/framework/views/**'],
         },


### PR DESCRIPTION
Fixes three Docker local dev issues:

1. **Tests failing (80%)** — Docker OS env vars override phpunit.xml. Added \<server force=true>\ directives and \.env.testing\ so tests use SQLite/:memory: regardless of Docker env.
2. **Vite 404s** — Dev server bound to localhost inside container. Set \host: 0.0.0.0\ in vite.config.js, exposed port 5173 in docker-compose.yml.
3. **Livewire.js 404** — Nginx static asset block intercepted \/livewire/livewire.js\ (a PHP route). Added \	ry_files\ fallback to PHP.

All 240 tests pass in both Docker and local environments.