### PR TITLE
feat: E2-S01 · Session-related enums (SessionStatus, SessionLevel, ActivityType)

### DIFF
--- a/app/Enums/ActivityType.php
+++ b/app/Enums/ActivityType.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum ActivityType: string
+{
+    case Yoga = 'yoga';
+    case Strength = 'strength';
+    case Running = 'running';
+    case Cardio = 'cardio';
+    case Pilates = 'pilates';
+    case Outdoor = 'outdoor';
+    case Boxing = 'boxing';
+    case Dance = 'dance';
+    case Padel = 'padel';
+    case Tennis = 'tennis';
+
+    public function label(): string
+    {
+        return __('sessions.activity_'.$this->value);
+    }
+}

--- a/app/Enums/SessionLevel.php
+++ b/app/Enums/SessionLevel.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum SessionLevel: string
+{
+    case Beginner = 'beginner';
+    case Intermediate = 'intermediate';
+    case Advanced = 'advanced';
+
+    public function label(): string
+    {
+        return __('sessions.level_'.$this->value);
+    }
+}

--- a/app/Enums/SessionStatus.php
+++ b/app/Enums/SessionStatus.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum SessionStatus: string
+{
+    case Draft = 'draft';
+    case Published = 'published';
+    case Confirmed = 'confirmed';
+    case Completed = 'completed';
+    case Cancelled = 'cancelled';
+
+    public function label(): string
+    {
+        return __('sessions.status_'.$this->value);
+    }
+}

--- a/lang/en/sessions.php
+++ b/lang/en/sessions.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Status Labels
+    |--------------------------------------------------------------------------
+    */
+
+    'status_draft' => 'Draft',
+    'status_published' => 'Published',
+    'status_confirmed' => 'Confirmed',
+    'status_completed' => 'Completed',
+    'status_cancelled' => 'Cancelled',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Level Labels
+    |--------------------------------------------------------------------------
+    */
+
+    'level_beginner' => 'Beginner',
+    'level_intermediate' => 'Intermediate',
+    'level_advanced' => 'Advanced',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Activity Type Labels
+    |--------------------------------------------------------------------------
+    */
+
+    'activity_yoga' => 'Yoga',
+    'activity_strength' => 'Strength',
+    'activity_running' => 'Running',
+    'activity_cardio' => 'Cardio',
+    'activity_pilates' => 'Pilates',
+    'activity_outdoor' => 'Outdoor',
+    'activity_boxing' => 'Boxing',
+    'activity_dance' => 'Dance',
+    'activity_padel' => 'Padel',
+    'activity_tennis' => 'Tennis',
+
+];

--- a/lang/fr/sessions.php
+++ b/lang/fr/sessions.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Status Labels
+    |--------------------------------------------------------------------------
+    */
+
+    'status_draft' => 'Brouillon',
+    'status_published' => 'Publiée',
+    'status_confirmed' => 'Confirmée',
+    'status_completed' => 'Terminée',
+    'status_cancelled' => 'Annulée',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Level Labels
+    |--------------------------------------------------------------------------
+    */
+
+    'level_beginner' => 'Débutant',
+    'level_intermediate' => 'Intermédiaire',
+    'level_advanced' => 'Avancé',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Activity Type Labels
+    |--------------------------------------------------------------------------
+    */
+
+    'activity_yoga' => 'Yoga',
+    'activity_strength' => 'Musculation',
+    'activity_running' => 'Course à pied',
+    'activity_cardio' => 'Cardio',
+    'activity_pilates' => 'Pilates',
+    'activity_outdoor' => 'Outdoor',
+    'activity_boxing' => 'Boxe',
+    'activity_dance' => 'Danse',
+    'activity_padel' => 'Padel',
+    'activity_tennis' => 'Tennis',
+
+];

--- a/lang/nl/sessions.php
+++ b/lang/nl/sessions.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Status Labels
+    |--------------------------------------------------------------------------
+    */
+
+    'status_draft' => 'Concept',
+    'status_published' => 'Gepubliceerd',
+    'status_confirmed' => 'Bevestigd',
+    'status_completed' => 'Voltooid',
+    'status_cancelled' => 'Geannuleerd',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Level Labels
+    |--------------------------------------------------------------------------
+    */
+
+    'level_beginner' => 'Beginner',
+    'level_intermediate' => 'Gemiddeld',
+    'level_advanced' => 'Gevorderd',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Activity Type Labels
+    |--------------------------------------------------------------------------
+    */
+
+    'activity_yoga' => 'Yoga',
+    'activity_strength' => 'Krachttraining',
+    'activity_running' => 'Hardlopen',
+    'activity_cardio' => 'Cardio',
+    'activity_pilates' => 'Pilates',
+    'activity_outdoor' => 'Outdoor',
+    'activity_boxing' => 'Boksen',
+    'activity_dance' => 'Dans',
+    'activity_padel' => 'Padel',
+    'activity_tennis' => 'Tennis',
+
+];

--- a/tests/Unit/Enums/ActivityTypeTest.php
+++ b/tests/Unit/Enums/ActivityTypeTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ActivityType;
+
+describe('ActivityType', function () {
+
+    it('has the correct backed string values', function () {
+        expect(ActivityType::Yoga->value)->toBe('yoga');
+        expect(ActivityType::Strength->value)->toBe('strength');
+        expect(ActivityType::Running->value)->toBe('running');
+        expect(ActivityType::Cardio->value)->toBe('cardio');
+        expect(ActivityType::Pilates->value)->toBe('pilates');
+        expect(ActivityType::Outdoor->value)->toBe('outdoor');
+        expect(ActivityType::Boxing->value)->toBe('boxing');
+        expect(ActivityType::Dance->value)->toBe('dance');
+        expect(ActivityType::Padel->value)->toBe('padel');
+        expect(ActivityType::Tennis->value)->toBe('tennis');
+    });
+
+    it('can be created from a string value', function () {
+        expect(ActivityType::from('yoga'))->toBe(ActivityType::Yoga);
+        expect(ActivityType::from('strength'))->toBe(ActivityType::Strength);
+        expect(ActivityType::from('running'))->toBe(ActivityType::Running);
+        expect(ActivityType::from('boxing'))->toBe(ActivityType::Boxing);
+        expect(ActivityType::from('padel'))->toBe(ActivityType::Padel);
+        expect(ActivityType::from('tennis'))->toBe(ActivityType::Tennis);
+    });
+
+    it('lists all ten cases', function () {
+        expect(ActivityType::cases())->toHaveCount(10);
+    });
+
+    it('returns a localized label for each case', function () {
+        app()->setLocale('en');
+
+        expect(ActivityType::Yoga->label())->toBe('Yoga');
+        expect(ActivityType::Strength->label())->toBe('Strength');
+        expect(ActivityType::Running->label())->toBe('Running');
+        expect(ActivityType::Cardio->label())->toBe('Cardio');
+        expect(ActivityType::Pilates->label())->toBe('Pilates');
+        expect(ActivityType::Outdoor->label())->toBe('Outdoor');
+        expect(ActivityType::Boxing->label())->toBe('Boxing');
+        expect(ActivityType::Dance->label())->toBe('Dance');
+        expect(ActivityType::Padel->label())->toBe('Padel');
+        expect(ActivityType::Tennis->label())->toBe('Tennis');
+    });
+
+    it('returns French labels when locale is fr', function () {
+        app()->setLocale('fr');
+
+        expect(ActivityType::Yoga->label())->toBe('Yoga');
+        expect(ActivityType::Strength->label())->toBe('Musculation');
+        expect(ActivityType::Running->label())->toBe('Course à pied');
+        expect(ActivityType::Boxing->label())->toBe('Boxe');
+        expect(ActivityType::Dance->label())->toBe('Danse');
+    });
+
+});

--- a/tests/Unit/Enums/SessionLevelTest.php
+++ b/tests/Unit/Enums/SessionLevelTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\SessionLevel;
+
+describe('SessionLevel', function () {
+
+    it('has the correct backed string values', function () {
+        expect(SessionLevel::Beginner->value)->toBe('beginner');
+        expect(SessionLevel::Intermediate->value)->toBe('intermediate');
+        expect(SessionLevel::Advanced->value)->toBe('advanced');
+    });
+
+    it('can be created from a string value', function () {
+        expect(SessionLevel::from('beginner'))->toBe(SessionLevel::Beginner);
+        expect(SessionLevel::from('intermediate'))->toBe(SessionLevel::Intermediate);
+        expect(SessionLevel::from('advanced'))->toBe(SessionLevel::Advanced);
+    });
+
+    it('lists all three cases', function () {
+        expect(SessionLevel::cases())->toHaveCount(3);
+    });
+
+    it('returns a localized label for each case', function () {
+        app()->setLocale('en');
+
+        expect(SessionLevel::Beginner->label())->toBe('Beginner');
+        expect(SessionLevel::Intermediate->label())->toBe('Intermediate');
+        expect(SessionLevel::Advanced->label())->toBe('Advanced');
+    });
+
+    it('returns French labels when locale is fr', function () {
+        app()->setLocale('fr');
+
+        expect(SessionLevel::Beginner->label())->toBe('Débutant');
+        expect(SessionLevel::Intermediate->label())->toBe('Intermédiaire');
+        expect(SessionLevel::Advanced->label())->toBe('Avancé');
+    });
+
+});

--- a/tests/Unit/Enums/SessionStatusTest.php
+++ b/tests/Unit/Enums/SessionStatusTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\SessionStatus;
+
+describe('SessionStatus', function () {
+
+    it('has the correct backed string values', function () {
+        expect(SessionStatus::Draft->value)->toBe('draft');
+        expect(SessionStatus::Published->value)->toBe('published');
+        expect(SessionStatus::Confirmed->value)->toBe('confirmed');
+        expect(SessionStatus::Completed->value)->toBe('completed');
+        expect(SessionStatus::Cancelled->value)->toBe('cancelled');
+    });
+
+    it('can be created from a string value', function () {
+        expect(SessionStatus::from('draft'))->toBe(SessionStatus::Draft);
+        expect(SessionStatus::from('published'))->toBe(SessionStatus::Published);
+        expect(SessionStatus::from('confirmed'))->toBe(SessionStatus::Confirmed);
+        expect(SessionStatus::from('completed'))->toBe(SessionStatus::Completed);
+        expect(SessionStatus::from('cancelled'))->toBe(SessionStatus::Cancelled);
+    });
+
+    it('lists all five cases', function () {
+        expect(SessionStatus::cases())->toHaveCount(5);
+    });
+
+    it('returns a localized label for each case', function () {
+        app()->setLocale('en');
+
+        expect(SessionStatus::Draft->label())->toBe('Draft');
+        expect(SessionStatus::Published->label())->toBe('Published');
+        expect(SessionStatus::Confirmed->label())->toBe('Confirmed');
+        expect(SessionStatus::Completed->label())->toBe('Completed');
+        expect(SessionStatus::Cancelled->label())->toBe('Cancelled');
+    });
+
+    it('returns French labels when locale is fr', function () {
+        app()->setLocale('fr');
+
+        expect(SessionStatus::Draft->label())->toBe('Brouillon');
+        expect(SessionStatus::Published->label())->toBe('Publiée');
+        expect(SessionStatus::Confirmed->label())->toBe('Confirmée');
+        expect(SessionStatus::Completed->label())->toBe('Terminée');
+        expect(SessionStatus::Cancelled->label())->toBe('Annulée');
+    });
+
+});


### PR DESCRIPTION
## Summary

Add the three backed string enums used throughout session management:

- **SessionStatus**: draft, published, confirmed, completed, cancelled
- **SessionLevel**: beginner, intermediate, advanced  
- **ActivityType**: yoga, strength, running, cardio, pilates, outdoor, boxing, dance, padel, tennis

Each enum has a \label(): string\ method returning the localized name via \__()\.

## Changes

- \pp/Enums/SessionStatus.php\ — 5-case backed string enum
- \pp/Enums/SessionLevel.php\ — 3-case backed string enum
- \pp/Enums/ActivityType.php\ — 10-case backed string enum
- \lang/{fr,en,nl}/sessions.php\ — translation files for status, level, and activity labels
- \	ests/Unit/Enums/SessionStatusTest.php\ — 5 tests
- \	ests/Unit/Enums/SessionLevelTest.php\ — 5 tests
- \	ests/Unit/Enums/ActivityTypeTest.php\ — 5 tests

## Tests

All 15 new tests pass. Full suite (263 tests) green.

Resolves #53