### PR TITLE
feat: E2-S03 · Session model + migration

### DIFF
--- a/app/Models/SportSession.php
+++ b/app/Models/SportSession.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\ActivityType;
+use App\Enums\SessionLevel;
+use App\Enums\SessionStatus;
+use Database\Factories\SportSessionFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SportSession extends Model
+{
+    /** @use HasFactory<SportSessionFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'coach_id',
+        'activity_type',
+        'level',
+        'title',
+        'description',
+        'location',
+        'postal_code',
+        'latitude',
+        'longitude',
+        'date',
+        'start_time',
+        'end_time',
+        'price_per_person',
+        'min_participants',
+        'max_participants',
+        'current_participants',
+        'status',
+        'cover_image_id',
+        'recurrence_group_id',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'activity_type' => ActivityType::class,
+            'level' => SessionLevel::class,
+            'status' => SessionStatus::class,
+            'date' => 'date',
+            'price_per_person' => 'integer',
+            'min_participants' => 'integer',
+            'max_participants' => 'integer',
+            'current_participants' => 'integer',
+            'latitude' => 'decimal:7',
+            'longitude' => 'decimal:7',
+            'cover_image_id' => 'integer',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function coach(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'coach_id');
+    }
+}

--- a/database/factories/SportSessionFactory.php
+++ b/database/factories/SportSessionFactory.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\ActivityType;
+use App\Enums\SessionLevel;
+use App\Enums\SessionStatus;
+use App\Models\SportSession;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SportSession>
+ */
+class SportSessionFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $date = $this->faker->dateTimeBetween('+1 day', '+30 days');
+        $startHour = $this->faker->numberBetween(8, 18);
+
+        return [
+            'coach_id' => User::factory()->coach(),
+            'activity_type' => $this->faker->randomElement(ActivityType::cases())->value,
+            'level' => $this->faker->randomElement(SessionLevel::cases())->value,
+            'title' => $this->faker->sentence(4),
+            'description' => $this->faker->paragraph(),
+            'location' => $this->faker->address(),
+            'postal_code' => (string) $this->faker->numberBetween(1000, 9999),
+            'date' => $date->format('Y-m-d'),
+            'start_time' => sprintf('%02d:00:00', $startHour),
+            'end_time' => sprintf('%02d:00:00', $startHour + 1),
+            'price_per_person' => $this->faker->numberBetween(500, 5000),
+            'min_participants' => 3,
+            'max_participants' => 15,
+            'current_participants' => 0,
+            'status' => SessionStatus::Draft->value,
+        ];
+    }
+
+    public function draft(): static
+    {
+        return $this->state(['status' => SessionStatus::Draft->value]);
+    }
+
+    public function published(): static
+    {
+        return $this->state(['status' => SessionStatus::Published->value]);
+    }
+
+    public function confirmed(): static
+    {
+        return $this->state(['status' => SessionStatus::Confirmed->value]);
+    }
+
+    public function completed(): static
+    {
+        return $this->state(['status' => SessionStatus::Completed->value]);
+    }
+
+    public function cancelled(): static
+    {
+        return $this->state(['status' => SessionStatus::Cancelled->value]);
+    }
+
+    public function withCoordinates(): static
+    {
+        return $this->state([
+            'latitude' => $this->faker->latitude(50.7, 50.9),
+            'longitude' => $this->faker->longitude(4.2, 4.5),
+        ]);
+    }
+}

--- a/database/migrations/2026_04_08_191957_create_sport_sessions_table.php
+++ b/database/migrations/2026_04_08_191957_create_sport_sessions_table.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('sport_sessions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('coach_id')->constrained('users')->cascadeOnDelete();
+            $table->string('activity_type');
+            $table->string('level');
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->string('location');
+            $table->string('postal_code');
+            $table->decimal('latitude', 10, 7)->nullable();
+            $table->decimal('longitude', 10, 7)->nullable();
+            $table->date('date');
+            $table->time('start_time');
+            $table->time('end_time');
+            $table->unsignedInteger('price_per_person');
+            $table->unsignedInteger('min_participants')->default(1);
+            $table->unsignedInteger('max_participants');
+            $table->unsignedInteger('current_participants')->default(0);
+            $table->string('status')->default('draft');
+            $table->unsignedBigInteger('cover_image_id')->nullable();
+            $table->uuid('recurrence_group_id')->nullable();
+            $table->timestamps();
+
+            $table->index('status');
+            $table->index('date');
+            $table->index('postal_code');
+            $table->index(['latitude', 'longitude']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('sport_sessions');
+    }
+};

--- a/tests/Unit/Models/SportSessionTest.php
+++ b/tests/Unit/Models/SportSessionTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ActivityType;
+use App\Enums\SessionLevel;
+use App\Enums\SessionStatus;
+use App\Enums\UserRole;
+use App\Models\SportSession;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+
+uses(RefreshDatabase::class);
+
+describe('SportSession', function () {
+
+    it('belongs to a coach user', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->create(['coach_id' => $coach->id]);
+
+        expect($session->coach)->toBeInstanceOf(User::class);
+        expect($session->coach->id)->toBe($coach->id);
+        expect($session->coach->role)->toBe(UserRole::Coach);
+    });
+
+    it('casts activity_type to ActivityType enum', function () {
+        $session = SportSession::factory()->create(['activity_type' => ActivityType::Yoga->value]);
+
+        expect($session->activity_type)->toBeInstanceOf(ActivityType::class);
+        expect($session->activity_type)->toBe(ActivityType::Yoga);
+    });
+
+    it('casts level to SessionLevel enum', function () {
+        $session = SportSession::factory()->create(['level' => SessionLevel::Beginner->value]);
+
+        expect($session->level)->toBeInstanceOf(SessionLevel::class);
+        expect($session->level)->toBe(SessionLevel::Beginner);
+    });
+
+    it('casts status to SessionStatus enum', function () {
+        $session = SportSession::factory()->create(['status' => SessionStatus::Published->value]);
+
+        expect($session->status)->toBeInstanceOf(SessionStatus::class);
+        expect($session->status)->toBe(SessionStatus::Published);
+    });
+
+    it('casts date to a date instance', function () {
+        $session = SportSession::factory()->create(['date' => '2026-05-01']);
+
+        expect($session->date)->toBeInstanceOf(Carbon::class);
+        expect($session->date->format('Y-m-d'))->toBe('2026-05-01');
+    });
+
+    it('casts price_per_person to integer', function () {
+        $session = SportSession::factory()->create(['price_per_person' => 1250]);
+
+        expect($session->price_per_person)->toBeInt();
+        expect($session->price_per_person)->toBe(1250);
+    });
+
+    it('casts participant counts to integers', function () {
+        $session = SportSession::factory()->create([
+            'min_participants' => 3,
+            'max_participants' => 15,
+            'current_participants' => 5,
+        ]);
+
+        expect($session->min_participants)->toBeInt();
+        expect($session->max_participants)->toBeInt();
+        expect($session->current_participants)->toBeInt();
+    });
+
+    it('stores nullable latitude and longitude', function () {
+        $session = SportSession::factory()->create([
+            'latitude' => null,
+            'longitude' => null,
+        ]);
+
+        expect($session->latitude)->toBeNull();
+        expect($session->longitude)->toBeNull();
+    });
+
+    it('stores coordinates when provided', function () {
+        $session = SportSession::factory()->withCoordinates()->create();
+
+        expect($session->latitude)->not()->toBeNull();
+        expect($session->longitude)->not()->toBeNull();
+    });
+
+    it('stores nullable cover_image_id', function () {
+        $session = SportSession::factory()->create(['cover_image_id' => null]);
+
+        expect($session->cover_image_id)->toBeNull();
+    });
+
+    it('stores nullable recurrence_group_id', function () {
+        $session = SportSession::factory()->create(['recurrence_group_id' => null]);
+
+        expect($session->recurrence_group_id)->toBeNull();
+    });
+
+    it('defaults status to draft', function () {
+        $session = SportSession::factory()->create();
+        $session->refresh();
+
+        expect($session->status)->toBe(SessionStatus::Draft);
+    });
+
+    it('defaults current_participants to 0', function () {
+        $session = SportSession::factory()->create();
+        $session->refresh();
+
+        expect($session->current_participants)->toBe(0);
+    });
+});
+
+describe('SportSessionFactory', function () {
+
+    it('creates a draft session by default', function () {
+        $session = SportSession::factory()->create();
+
+        expect($session->status)->toBe(SessionStatus::Draft);
+    });
+
+    it('creates a published session', function () {
+        $session = SportSession::factory()->published()->create();
+
+        expect($session->status)->toBe(SessionStatus::Published);
+    });
+
+    it('creates a confirmed session', function () {
+        $session = SportSession::factory()->confirmed()->create();
+
+        expect($session->status)->toBe(SessionStatus::Confirmed);
+    });
+
+    it('creates a completed session', function () {
+        $session = SportSession::factory()->completed()->create();
+
+        expect($session->status)->toBe(SessionStatus::Completed);
+    });
+
+    it('creates a cancelled session', function () {
+        $session = SportSession::factory()->cancelled()->create();
+
+        expect($session->status)->toBe(SessionStatus::Cancelled);
+    });
+
+    it('associates with a coach user by default', function () {
+        $session = SportSession::factory()->create();
+
+        expect($session->coach->role)->toBe(UserRole::Coach);
+    });
+
+    it('creates session with coordinates', function () {
+        $session = SportSession::factory()->withCoordinates()->create();
+
+        expect($session->latitude)->not()->toBeNull();
+        expect($session->longitude)->not()->toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

Add the core \SportSession\ model (named to avoid collision with Laravel's \sessions\ table) with full migration, factory, and unit tests.

## Changes

### Migration: \sport_sessions\ table
- \coach_id\ (FK → users, cascade on delete)
- \ctivity_type\, \level\, \	itle\, \description\, \location\, \postal_code\
- \latitude\/\longitude\ (decimal 10,7, nullable)
- \date\, \start_time\, \nd_time\
- \price_per_person\ (unsigned integer, cents)
- \min_participants\ (default 1), \max_participants\, \current_participants\ (default 0)
- \status\ (string, default \draft\)
- \cover_image_id\ (nullable, FK will be added when activity_images table is created in E2-S10)
- \ecurrence_group_id\ (nullable UUID)
- Indexes on: \status\, \date\, \postal_code\, \(latitude, longitude)\

### Model: \SportSession\
- Casts: \ActivityType\, \SessionLevel\, \SessionStatus\ enums; date, integer, decimal
- Relationship: \elongsTo(User, 'coach_id')\

### Factory: \SportSessionFactory\
- States: \draft()\, \published()\, \confirmed()\, \completed()\, \cancelled()\, \withCoordinates()\

### Tests
- 20 unit tests covering model casts, relationships, database defaults, and all factory states

## Tests

All 300 tests pass (681 assertions). Pint lint clean.

Resolves #55