### PR TITLE
feat: MFA-required alert banner on profile page (E1-S26)

### DIFF
--- a/lang/en/profile.php
+++ b/lang/en/profile.php
@@ -99,4 +99,13 @@ return [
     'delete_heading' => 'Delete Account',
     'delete_description' => 'Once your account is deleted, all of its resources and data will be permanently deleted.',
 
+    /*
+    |--------------------------------------------------------------------------
+    | MFA Required Alert
+    |--------------------------------------------------------------------------
+    */
+
+    'mfa_required_title' => 'Two-factor authentication required',
+    'mfa_required_description' => 'Your role requires two-factor authentication to be enabled. Please set up 2FA below before accessing protected features.',
+
 ];

--- a/lang/fr/profile.php
+++ b/lang/fr/profile.php
@@ -98,5 +98,12 @@ return [
 
     'delete_heading' => 'Supprimer le compte',
     'delete_description' => 'Une fois que votre compte est supprimé, toutes ses ressources et données seront définitivement supprimées.',
+    /*
+    |--------------------------------------------------------------------------
+    | MFA Required Alert
+    |--------------------------------------------------------------------------
+    */
 
+    'mfa_required_title' => 'Authentification à deux facteurs requise',
+    'mfa_required_description' => 'Votre rôle nécessite l\'activation de l\'authentification à deux facteurs. Veuillez configurer la 2FA ci-dessous avant d\'accéder aux fonctionnalités protégées.',
 ];

--- a/lang/nl/profile.php
+++ b/lang/nl/profile.php
@@ -98,5 +98,12 @@ return [
 
     'delete_heading' => 'Account verwijderen',
     'delete_description' => 'Zodra uw account is verwijderd, worden alle bronnen en gegevens permanent verwijderd.',
+    /*
+    |--------------------------------------------------------------------------
+    | MFA Required Alert
+    |--------------------------------------------------------------------------
+    */
 
+    'mfa_required_title' => 'Tweefactorauthenticatie vereist',
+    'mfa_required_description' => 'Uw rol vereist dat tweefactorauthenticatie is ingeschakeld. Stel hieronder 2FA in voordat u toegang krijgt tot beschermde functies.',
 ];

--- a/resources/views/livewire/profile/edit.blade.php
+++ b/resources/views/livewire/profile/edit.blade.php
@@ -3,6 +3,26 @@
         {{ __('profile.heading') }}
     </h1>
 
+    @if(in_array(auth()->user()->role, [\App\Enums\UserRole::Admin, \App\Enums\UserRole::Accountant]) && auth()->user()->two_factor_confirmed_at === null)
+        <div class="rounded-md border border-amber-300 bg-amber-50 p-4 dark:border-amber-600 dark:bg-amber-900/20">
+            <div class="flex">
+                <div class="shrink-0">
+                    <svg class="h-5 w-5 text-amber-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 6a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 6zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" />
+                    </svg>
+                </div>
+                <div class="ml-3">
+                    <h3 class="text-sm font-medium text-amber-800 dark:text-amber-200">
+                        {{ __('profile.mfa_required_title') }}
+                    </h3>
+                    <p class="mt-1 text-sm text-amber-700 dark:text-amber-300">
+                        {{ __('profile.mfa_required_description') }}
+                    </p>
+                </div>
+            </div>
+        </div>
+    @endif
+
     {{-- Personal Information --}}
     <section class="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
         <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
@@ -186,5 +206,11 @@
     </section>
 
     {{-- Two-Factor Authentication --}}
-    <livewire:profile.two-factor-authentication />
+    <div id="two-factor-section">
+        <livewire:profile.two-factor-authentication />
+    </div>
+
+    @if(session('status') === __('auth.two_factor_required'))
+        <script>document.getElementById('two-factor-section')?.scrollIntoView({ behavior: 'smooth' });</script>
+    @endif
 </div>

--- a/tests/Feature/Livewire/Profile/EditTest.php
+++ b/tests/Feature/Livewire/Profile/EditTest.php
@@ -133,6 +133,53 @@ describe('Profile Edit — Locale Preference', function () {
 
 });
 
+describe('Profile Edit — MFA Required Banner', function () {
+
+    it('shows MFA alert banner for admin without 2FA', function () {
+        $admin = User::factory()->admin()->create([
+            'two_factor_confirmed_at' => null,
+        ]);
+
+        $this->actingAs($admin)
+            ->get(route('profile.edit'))
+            ->assertOk()
+            ->assertSee(__('profile.mfa_required_title'))
+            ->assertSee(__('profile.mfa_required_description'));
+    });
+
+    it('shows MFA alert banner for accountant without 2FA', function () {
+        $accountant = User::factory()->accountant()->create([
+            'two_factor_confirmed_at' => null,
+        ]);
+
+        $this->actingAs($accountant)
+            ->get(route('profile.edit'))
+            ->assertOk()
+            ->assertSee(__('profile.mfa_required_title'));
+    });
+
+    it('does not show MFA alert banner for admin with 2FA enabled', function () {
+        $admin = User::factory()->admin()->withTwoFactor()->create();
+
+        $this->actingAs($admin)
+            ->get(route('profile.edit'))
+            ->assertOk()
+            ->assertDontSee(__('profile.mfa_required_title'));
+    });
+
+    it('does not show MFA alert banner for athlete', function () {
+        $athlete = User::factory()->athlete()->create([
+            'two_factor_confirmed_at' => null,
+        ]);
+
+        $this->actingAs($athlete)
+            ->get(route('profile.edit'))
+            ->assertOk()
+            ->assertDontSee(__('profile.mfa_required_title'));
+    });
+
+});
+
 describe('Profile Edit — Fortify Profile Information Update', function () {
 
     it('updates the user name', function () {


### PR DESCRIPTION
## Summary

Adds a prominent MFA-required alert banner on the profile page for admin and accountant users who haven't enabled two-factor authentication.

## Problem

When the `2fa` middleware redirects an admin/accountant to the profile page, there was no visible indication of **why** they were redirected or that MFA setup is mandatory for their role.

## Changes

### Banner
- **`resources/views/livewire/profile/edit.blade.php`**:
  - Add amber/warning alert banner at the top of the page, displayed when:
    - User role is Admin or Accountant, AND
    - `two_factor_confirmed_at` is null
  - Non-dismissible — persists until 2FA is enabled
  - Mobile-responsive (full-width, Tailwind styles)
  - Add `id="two-factor-section"` anchor to 2FA component wrapper
  - Auto-scroll to 2FA section when redirected by `2fa` middleware (via flash message)

### Translations
- **`lang/{en,fr,nl}/profile.php`** — Add `mfa_required_title` and `mfa_required_description` keys

### Tests (4 new)
- **`tests/Feature/Livewire/Profile/EditTest.php`**:
  - Admin without 2FA sees the alert banner
  - Accountant without 2FA sees the alert banner
  - Admin with 2FA does NOT see the banner
  - Athlete does NOT see the banner

## Behavior

- Banner appears for admin/accountant without 2FA on every visit to the profile page
- After enabling 2FA, the banner disappears automatically (Livewire re-render or page reload)
- When redirected by `2fa` middleware, the page auto-scrolls to the 2FA setup section

## Test results

319 tests pass (4 new, 0 regressions)

Closes #136