### PR TITLE
E2-S04 · SessionPolicy

### DIFF
--- a/app/Policies/SessionPolicy.php
+++ b/app/Policies/SessionPolicy.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Enums\SessionStatus;
+use App\Enums\UserRole;
+use App\Models\SportSession;
+use App\Models\User;
+
+final class SessionPolicy
+{
+    /**
+     * Admin bypass — grants all abilities.
+     */
+    public function before(User $user, string $ability): ?bool
+    {
+        if ($user->role === UserRole::Admin) {
+            return true;
+        }
+
+        return null;
+    }
+
+    /**
+     * Any authenticated user can view the list of sessions.
+     */
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Any authenticated user can view published/confirmed sessions.
+     * Coaches can also view their own drafts.
+     */
+    public function view(User $user, SportSession $session): bool
+    {
+        if (in_array($session->status, [SessionStatus::Published, SessionStatus::Confirmed], true)) {
+            return true;
+        }
+
+        return $user->role === UserRole::Coach && $user->id === $session->coach_id;
+    }
+
+    /**
+     * Only coaches can create sessions.
+     */
+    public function create(User $user): bool
+    {
+        return $user->role === UserRole::Coach;
+    }
+
+    /**
+     * Own coach can update; not allowed if completed or cancelled.
+     */
+    public function update(User $user, SportSession $session): bool
+    {
+        if (in_array($session->status, [SessionStatus::Completed, SessionStatus::Cancelled], true)) {
+            return false;
+        }
+
+        return $user->role === UserRole::Coach && $user->id === $session->coach_id;
+    }
+
+    /**
+     * Own coach can delete; only draft sessions.
+     */
+    public function delete(User $user, SportSession $session): bool
+    {
+        if ($session->status !== SessionStatus::Draft) {
+            return false;
+        }
+
+        return $user->role === UserRole::Coach && $user->id === $session->coach_id;
+    }
+
+    /**
+     * Own coach can cancel; only published or confirmed sessions.
+     */
+    public function cancel(User $user, SportSession $session): bool
+    {
+        if (! in_array($session->status, [SessionStatus::Published, SessionStatus::Confirmed], true)) {
+            return false;
+        }
+
+        return $user->role === UserRole::Coach && $user->id === $session->coach_id;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Providers;
 
 use App\Enums\UserRole;
+use App\Models\SportSession;
 use App\Models\User;
+use App\Policies\SessionPolicy;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 
@@ -24,6 +26,8 @@ final class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        Gate::policy(SportSession::class, SessionPolicy::class);
+
         Gate::define('apply-as-coach', function (User $user): bool {
             return $user->role === UserRole::Athlete
                 && $user->coachProfile === null;

--- a/composer.lock
+++ b/composer.lock
@@ -3249,16 +3249,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.50",
+            "version": "3.0.51",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "aa6ad8321ed103dc3624fb600a25b66ebf78ec7b"
+                "reference": "d59c94077f9c9915abb51ddb52ce85188ece1748"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/aa6ad8321ed103dc3624fb600a25b66ebf78ec7b",
-                "reference": "aa6ad8321ed103dc3624fb600a25b66ebf78ec7b",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/d59c94077f9c9915abb51ddb52ce85188ece1748",
+                "reference": "d59c94077f9c9915abb51ddb52ce85188ece1748",
                 "shasum": ""
             },
             "require": {
@@ -3339,7 +3339,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.50"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.51"
             },
             "funding": [
                 {
@@ -3355,7 +3355,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-19T02:57:58+00:00"
+            "time": "2026-04-10T01:33:53+00:00"
         },
         {
             "name": "pragmarx/google2fa",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-    "name": "html",
+    "name": "motivya-laravel",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
+            "name": "motivya-laravel",
             "devDependencies": {
                 "@tailwindcss/vite": "^4.0.0",
                 "axios": "^1.11.0",
@@ -1232,9 +1233,9 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.14.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-            "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/tests/Feature/Policies/SessionPolicyTest.php
+++ b/tests/Feature/Policies/SessionPolicyTest.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\SessionStatus;
+use App\Enums\UserRole;
+use App\Models\SportSession;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+describe('viewAny', function () {
+    it('allows any authenticated user', function (string $role) {
+        $user = User::factory()->{$role}()->create();
+
+        expect($user->can('viewAny', SportSession::class))->toBeTrue();
+    })->with(['coach', 'athlete', 'accountant', 'admin']);
+});
+
+describe('view', function () {
+    it('allows any authenticated user to view published sessions', function (string $role) {
+        $user = User::factory()->{$role}()->create();
+        $session = SportSession::factory()->published()->create();
+
+        expect($user->can('view', $session))->toBeTrue();
+    })->with(['coach', 'athlete', 'accountant', 'admin']);
+
+    it('allows any authenticated user to view confirmed sessions', function (string $role) {
+        $user = User::factory()->{$role}()->create();
+        $session = SportSession::factory()->confirmed()->create();
+
+        expect($user->can('view', $session))->toBeTrue();
+    })->with(['coach', 'athlete', 'accountant', 'admin']);
+
+    it('allows the owning coach to view their own draft sessions', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->draft()->create(['coach_id' => $coach->id]);
+
+        expect($coach->can('view', $session))->toBeTrue();
+    });
+
+    it('denies other coaches from viewing draft sessions they do not own', function () {
+        $otherCoach = User::factory()->coach()->create();
+        $session = SportSession::factory()->draft()->create();
+
+        expect($otherCoach->can('view', $session))->toBeFalse();
+    });
+
+    it('denies athletes from viewing draft sessions', function () {
+        $athlete = User::factory()->athlete()->create();
+        $session = SportSession::factory()->draft()->create();
+
+        expect($athlete->can('view', $session))->toBeFalse();
+    });
+
+    it('denies accountants from viewing draft sessions', function () {
+        $accountant = User::factory()->accountant()->create();
+        $session = SportSession::factory()->draft()->create();
+
+        expect($accountant->can('view', $session))->toBeFalse();
+    });
+
+    it('allows admin to view draft sessions', function () {
+        $admin = User::factory()->admin()->create();
+        $session = SportSession::factory()->draft()->create();
+
+        expect($admin->can('view', $session))->toBeTrue();
+    });
+
+    it('denies athletes from viewing completed sessions', function () {
+        $athlete = User::factory()->athlete()->create();
+        $session = SportSession::factory()->completed()->create();
+
+        expect($athlete->can('view', $session))->toBeFalse();
+    });
+
+    it('denies athletes from viewing cancelled sessions', function () {
+        $athlete = User::factory()->athlete()->create();
+        $session = SportSession::factory()->cancelled()->create();
+
+        expect($athlete->can('view', $session))->toBeFalse();
+    });
+});
+
+describe('create', function () {
+    it('allows coaches to create sessions', function () {
+        $coach = User::factory()->coach()->create();
+
+        expect($coach->can('create', SportSession::class))->toBeTrue();
+    });
+
+    it('allows admin to create sessions', function () {
+        $admin = User::factory()->admin()->create();
+
+        expect($admin->can('create', SportSession::class))->toBeTrue();
+    });
+
+    it('denies athletes from creating sessions', function () {
+        $athlete = User::factory()->athlete()->create();
+
+        expect($athlete->can('create', SportSession::class))->toBeFalse();
+    });
+
+    it('denies accountants from creating sessions', function () {
+        $accountant = User::factory()->accountant()->create();
+
+        expect($accountant->can('create', SportSession::class))->toBeFalse();
+    });
+});
+
+describe('update', function () {
+    it('allows the owning coach to update their draft session', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->draft()->create(['coach_id' => $coach->id]);
+
+        expect($coach->can('update', $session))->toBeTrue();
+    });
+
+    it('allows the owning coach to update their published session', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->published()->create(['coach_id' => $coach->id]);
+
+        expect($coach->can('update', $session))->toBeTrue();
+    });
+
+    it('denies the owning coach from updating a completed session', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->completed()->create(['coach_id' => $coach->id]);
+
+        expect($coach->can('update', $session))->toBeFalse();
+    });
+
+    it('denies the owning coach from updating a cancelled session', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->cancelled()->create(['coach_id' => $coach->id]);
+
+        expect($coach->can('update', $session))->toBeFalse();
+    });
+
+    it('denies other coaches from updating sessions they do not own', function () {
+        $otherCoach = User::factory()->coach()->create();
+        $session = SportSession::factory()->draft()->create();
+
+        expect($otherCoach->can('update', $session))->toBeFalse();
+    });
+
+    it('denies athletes from updating sessions', function () {
+        $athlete = User::factory()->athlete()->create();
+        $session = SportSession::factory()->draft()->create();
+
+        expect($athlete->can('update', $session))->toBeFalse();
+    });
+
+    it('allows admin to update any draft session', function () {
+        $admin = User::factory()->admin()->create();
+        $session = SportSession::factory()->draft()->create();
+
+        expect($admin->can('update', $session))->toBeTrue();
+    });
+
+    it('allows admin to update even completed sessions (admin bypass)', function () {
+        $admin = User::factory()->admin()->create();
+        $session = SportSession::factory()->completed()->create();
+
+        expect($admin->can('update', $session))->toBeTrue();
+    });
+});
+
+describe('delete', function () {
+    it('allows the owning coach to delete their draft session', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->draft()->create(['coach_id' => $coach->id]);
+
+        expect($coach->can('delete', $session))->toBeTrue();
+    });
+
+    it('denies the owning coach from deleting a published session', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->published()->create(['coach_id' => $coach->id]);
+
+        expect($coach->can('delete', $session))->toBeFalse();
+    });
+
+    it('denies the owning coach from deleting a confirmed session', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->confirmed()->create(['coach_id' => $coach->id]);
+
+        expect($coach->can('delete', $session))->toBeFalse();
+    });
+
+    it('denies the owning coach from deleting a completed session', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->completed()->create(['coach_id' => $coach->id]);
+
+        expect($coach->can('delete', $session))->toBeFalse();
+    });
+
+    it('denies other coaches from deleting sessions they do not own', function () {
+        $otherCoach = User::factory()->coach()->create();
+        $session = SportSession::factory()->draft()->create();
+
+        expect($otherCoach->can('delete', $session))->toBeFalse();
+    });
+
+    it('denies athletes from deleting sessions', function () {
+        $athlete = User::factory()->athlete()->create();
+        $session = SportSession::factory()->draft()->create();
+
+        expect($athlete->can('delete', $session))->toBeFalse();
+    });
+
+    it('allows admin to delete any session (admin bypass)', function () {
+        $admin = User::factory()->admin()->create();
+        $session = SportSession::factory()->published()->create();
+
+        expect($admin->can('delete', $session))->toBeTrue();
+    });
+});
+
+describe('cancel', function () {
+    it('allows the owning coach to cancel their published session', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->published()->create(['coach_id' => $coach->id]);
+
+        expect($coach->can('cancel', $session))->toBeTrue();
+    });
+
+    it('allows the owning coach to cancel their confirmed session', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->confirmed()->create(['coach_id' => $coach->id]);
+
+        expect($coach->can('cancel', $session))->toBeTrue();
+    });
+
+    it('denies the owning coach from cancelling a draft session', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->draft()->create(['coach_id' => $coach->id]);
+
+        expect($coach->can('cancel', $session))->toBeFalse();
+    });
+
+    it('denies the owning coach from cancelling a completed session', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->completed()->create(['coach_id' => $coach->id]);
+
+        expect($coach->can('cancel', $session))->toBeFalse();
+    });
+
+    it('denies the owning coach from cancelling an already cancelled session', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->cancelled()->create(['coach_id' => $coach->id]);
+
+        expect($coach->can('cancel', $session))->toBeFalse();
+    });
+
+    it('denies other coaches from cancelling sessions they do not own', function () {
+        $otherCoach = User::factory()->coach()->create();
+        $session = SportSession::factory()->published()->create();
+
+        expect($otherCoach->can('cancel', $session))->toBeFalse();
+    });
+
+    it('denies athletes from cancelling sessions', function () {
+        $athlete = User::factory()->athlete()->create();
+        $session = SportSession::factory()->published()->create();
+
+        expect($athlete->can('cancel', $session))->toBeFalse();
+    });
+
+    it('allows admin to cancel any session (admin bypass)', function () {
+        $admin = User::factory()->admin()->create();
+        $session = SportSession::factory()->draft()->create();
+
+        expect($admin->can('cancel', $session))->toBeTrue();
+    });
+});

--- a/tests/Feature/Policies/SessionPolicyTest.php
+++ b/tests/Feature/Policies/SessionPolicyTest.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-use App\Enums\SessionStatus;
-use App\Enums\UserRole;
 use App\Models\SportSession;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;


### PR DESCRIPTION
## Summary

Implements authorization rules for sport session CRUD operations via `SessionPolicy`.

### Changes

- **`app/Policies/SessionPolicy.php`** — New policy with:
  - `viewAny`: any authenticated user
  - `view`: any authenticated user (published/confirmed), own coach (drafts), admin bypass
  - `create`: coach or admin
  - `update`: own coach or admin; blocked for completed/cancelled sessions
  - `delete`: own coach or admin; draft sessions only
  - `cancel`: own coach or admin; published/confirmed sessions only
  - `before()`: admin bypass for all abilities
- **`app/Providers/AppServiceProvider.php`** — Registers `SessionPolicy` for `SportSession` model (needed because model name doesn't match policy convention)
- **`tests/Feature/Policies/SessionPolicyTest.php`** — 46 tests covering all 4 roles × all policy methods × key status scenarios

### Testing

All 46 new tests pass. Full suite (365 tests) passes.

Resolves #56