### PR TITLE
E2-S10 · Activity cover images (admin upload + coach selection)

### DIFF
--- a/app/Livewire/Admin/ActivityImages.php
+++ b/app/Livewire/Admin/ActivityImages.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Admin;
+
+use App\Enums\ActivityType;
+use App\Models\ActivityImage;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Attributes\Validate;
+use Livewire\Component;
+use Livewire\WithFileUploads;
+use Livewire\WithPagination;
+
+final class ActivityImages extends Component
+{
+    use WithFileUploads, WithPagination;
+
+    #[Validate('required|string')]
+    public string $activityType = '';
+
+    #[Validate('required|image|mimes:jpg,jpeg,png,webp|max:2048')]
+    public $image;
+
+    #[Validate('nullable|string|max:255')]
+    public string $altText = '';
+
+    public function save(): void
+    {
+        Gate::authorize('access-admin-panel');
+
+        $this->validate();
+
+        $path = $this->image->store('activity-images', 'public');
+
+        ActivityImage::create([
+            'activity_type' => $this->activityType,
+            'path' => $path,
+            'alt_text' => $this->altText,
+            'uploaded_by' => auth()->id(),
+        ]);
+
+        $this->reset(['image', 'altText', 'activityType']);
+
+        $this->dispatch('notify', type: 'success', message: __('admin.image_uploaded'));
+    }
+
+    public function deleteImage(int $imageId): void
+    {
+        Gate::authorize('access-admin-panel');
+
+        $image = ActivityImage::findOrFail($imageId);
+
+        Storage::disk('public')->delete($image->path);
+
+        $image->delete();
+
+        $this->dispatch('notify', type: 'success', message: __('admin.image_deleted'));
+    }
+
+    public function render(): View
+    {
+        $images = ActivityImage::with('uploader')
+            ->latest()
+            ->paginate(12);
+
+        return view('livewire.admin.activity-images', [
+            'images' => $images,
+            'activityTypes' => ActivityType::cases(),
+        ])->title(__('admin.activity_images_title'));
+    }
+}

--- a/app/Models/ActivityImage.php
+++ b/app/Models/ActivityImage.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\ActivityType;
+use Database\Factories\ActivityImageFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ActivityImage extends Model
+{
+    /** @use HasFactory<ActivityImageFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'activity_type',
+        'path',
+        'alt_text',
+        'uploaded_by',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'activity_type' => ActivityType::class,
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function uploader(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'uploaded_by');
+    }
+}

--- a/database/factories/ActivityImageFactory.php
+++ b/database/factories/ActivityImageFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\ActivityType;
+use App\Models\ActivityImage;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ActivityImage>
+ */
+class ActivityImageFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'activity_type' => $this->faker->randomElement(ActivityType::cases())->value,
+            'path' => 'activity-images/'.$this->faker->uuid().'.jpg',
+            'alt_text' => $this->faker->sentence(3),
+            'uploaded_by' => User::factory()->admin(),
+        ];
+    }
+
+    public function forActivity(ActivityType $type): static
+    {
+        return $this->state(['activity_type' => $type->value]);
+    }
+}

--- a/database/migrations/2026_04_11_005143_create_activity_images_table.php
+++ b/database/migrations/2026_04_11_005143_create_activity_images_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('activity_images', function (Blueprint $table) {
+            $table->id();
+            $table->string('activity_type');
+            $table->string('path');
+            $table->string('alt_text')->nullable();
+            $table->foreignId('uploaded_by')->constrained('users');
+            $table->timestamps();
+
+            $table->index('activity_type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('activity_images');
+    }
+};

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -26,4 +26,25 @@ return [
     'coach_approved' => 'Coach has been approved successfully.',
     'coach_rejected' => 'Application has been rejected.',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Admin — Activity Images
+    |--------------------------------------------------------------------------
+    */
+
+    'activity_images_title' => 'Activity Images',
+    'activity_images_heading' => 'Activity Cover Images',
+    'upload_image' => 'Upload New Image',
+    'activity_type_label' => 'Activity Type',
+    'select_activity_type' => 'Select an activity type…',
+    'alt_text_label' => 'Alt Text',
+    'alt_text_placeholder' => 'Describe the image…',
+    'image_file_label' => 'Image File (JPG, PNG, WebP — max 2 MB)',
+    'upload_button' => 'Upload',
+    'existing_images' => 'Existing Images',
+    'no_images' => 'No images uploaded yet.',
+    'confirm_delete_image' => 'Are you sure you want to delete this image?',
+    'image_uploaded' => 'Image uploaded successfully.',
+    'image_deleted' => 'Image deleted successfully.',
+
 ];

--- a/lang/fr/admin.php
+++ b/lang/fr/admin.php
@@ -26,4 +26,25 @@ return [
     'coach_approved' => 'Le coach a été approuvé avec succès.',
     'coach_rejected' => 'La candidature a été rejetée.',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Admin — Activity Images
+    |--------------------------------------------------------------------------
+    */
+
+    'activity_images_title' => 'Images d\'activité',
+    'activity_images_heading' => 'Images de couverture des activités',
+    'upload_image' => 'Télécharger une nouvelle image',
+    'activity_type_label' => 'Type d\'activité',
+    'select_activity_type' => 'Sélectionnez un type d\'activité…',
+    'alt_text_label' => 'Texte alternatif',
+    'alt_text_placeholder' => 'Décrivez l\'image…',
+    'image_file_label' => 'Fichier image (JPG, PNG, WebP — max 2 Mo)',
+    'upload_button' => 'Télécharger',
+    'existing_images' => 'Images existantes',
+    'no_images' => 'Aucune image téléchargée.',
+    'confirm_delete_image' => 'Êtes-vous sûr de vouloir supprimer cette image ?',
+    'image_uploaded' => 'Image téléchargée avec succès.',
+    'image_deleted' => 'Image supprimée avec succès.',
+
 ];

--- a/lang/nl/admin.php
+++ b/lang/nl/admin.php
@@ -26,4 +26,25 @@ return [
     'coach_approved' => 'De coach is succesvol goedgekeurd.',
     'coach_rejected' => 'De aanvraag is afgewezen.',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Admin — Activity Images
+    |--------------------------------------------------------------------------
+    */
+
+    'activity_images_title' => 'Activiteitafbeeldingen',
+    'activity_images_heading' => 'Omslagafbeeldingen voor activiteiten',
+    'upload_image' => 'Nieuwe afbeelding uploaden',
+    'activity_type_label' => 'Type activiteit',
+    'select_activity_type' => 'Selecteer een type activiteit…',
+    'alt_text_label' => 'Alternatieve tekst',
+    'alt_text_placeholder' => 'Beschrijf de afbeelding…',
+    'image_file_label' => 'Afbeeldingsbestand (JPG, PNG, WebP — max 2 MB)',
+    'upload_button' => 'Uploaden',
+    'existing_images' => 'Bestaande afbeeldingen',
+    'no_images' => 'Nog geen afbeeldingen geüpload.',
+    'confirm_delete_image' => 'Weet u zeker dat u deze afbeelding wilt verwijderen?',
+    'image_uploaded' => 'Afbeelding succesvol geüpload.',
+    'image_deleted' => 'Afbeelding succesvol verwijderd.',
+
 ];

--- a/resources/views/livewire/admin/activity-images.blade.php
+++ b/resources/views/livewire/admin/activity-images.blade.php
@@ -1,0 +1,102 @@
+<div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
+        {{ __('admin.activity_images_heading') }}
+    </h1>
+
+    {{-- Upload form --}}
+    <form wire:submit="save" class="mt-6 rounded-lg bg-white p-6 shadow dark:bg-gray-800">
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            {{ __('admin.upload_image') }}
+        </h2>
+
+        <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+                <label for="activityType" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('admin.activity_type_label') }}
+                </label>
+                <select wire:model="activityType" id="activityType"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm">
+                    <option value="">{{ __('admin.select_activity_type') }}</option>
+                    @foreach ($activityTypes as $type)
+                        <option value="{{ $type->value }}">{{ $type->label() }}</option>
+                    @endforeach
+                </select>
+                @error('activityType')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div>
+                <label for="altText" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('admin.alt_text_label') }}
+                </label>
+                <input type="text" wire:model="altText" id="altText"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                    placeholder="{{ __('admin.alt_text_placeholder') }}">
+                @error('altText')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div class="sm:col-span-2">
+                <label for="image" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('admin.image_file_label') }}
+                </label>
+                <input type="file" wire:model="image" id="image" accept="image/jpeg,image/png,image/webp"
+                    class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:rounded-md file:border-0 file:bg-indigo-50 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-indigo-700 hover:file:bg-indigo-100 dark:text-gray-400 dark:file:bg-indigo-900 dark:file:text-indigo-300">
+                @error('image')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+        </div>
+
+        <div class="mt-4 flex justify-end">
+            <button type="submit"
+                class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+                {{ __('admin.upload_button') }}
+            </button>
+        </div>
+    </form>
+
+    {{-- Image gallery --}}
+    <div class="mt-8">
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            {{ __('admin.existing_images') }}
+        </h2>
+
+        @if ($images->isEmpty())
+            <div class="mt-4 rounded-lg bg-white p-6 text-center shadow dark:bg-gray-800">
+                <p class="text-gray-500 dark:text-gray-400">{{ __('admin.no_images') }}</p>
+            </div>
+        @else
+            <div class="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+                @foreach ($images as $img)
+                    <div class="group relative overflow-hidden rounded-lg bg-white shadow dark:bg-gray-800" wire:key="image-{{ $img->id }}">
+                        <img src="{{ Storage::disk('public')->url($img->path) }}"
+                            alt="{{ $img->alt_text }}"
+                            class="h-40 w-full object-cover">
+                        <div class="p-3">
+                            <span class="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                                {{ $img->activity_type->label() }}
+                            </span>
+                            @if ($img->alt_text)
+                                <p class="mt-1 truncate text-xs text-gray-500 dark:text-gray-400">{{ $img->alt_text }}</p>
+                            @endif
+                        </div>
+                        <button wire:click="deleteImage({{ $img->id }})"
+                            wire:confirm="{{ __('admin.confirm_delete_image') }}"
+                            class="absolute right-2 top-2 rounded-full bg-red-600 p-1 text-white opacity-0 shadow transition group-hover:opacity-100">
+                            <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                        </button>
+                    </div>
+                @endforeach
+            </div>
+
+            <div class="mt-6">
+                {{ $images->links() }}
+            </div>
+        @endif
+    </div>
+</div>

--- a/routes/web/admin.php
+++ b/routes/web/admin.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use App\Livewire\Admin\ActivityImages;
 use App\Livewire\Admin\CoachApproval;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/coach-approval', CoachApproval::class)->name('coach-approval');
+Route::get('/activity-images', ActivityImages::class)->name('activity-images');

--- a/tests/Feature/Livewire/Admin/ActivityImagesTest.php
+++ b/tests/Feature/Livewire/Admin/ActivityImagesTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ActivityType;
+use App\Livewire\Admin\ActivityImages;
+use App\Models\ActivityImage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Storage::fake('public');
+});
+
+describe('access control', function () {
+    it('allows admin to access the activity images page', function () {
+        $admin = User::factory()->admin()->withTwoFactor()->create();
+
+        $this->actingAs($admin)
+            ->get(route('admin.activity-images'))
+            ->assertOk();
+    });
+
+    it('denies coach access to the activity images page', function () {
+        $coach = User::factory()->coach()->create();
+
+        $this->actingAs($coach)
+            ->get(route('admin.activity-images'))
+            ->assertForbidden();
+    });
+
+    it('denies athlete access to the activity images page', function () {
+        $athlete = User::factory()->athlete()->create();
+
+        $this->actingAs($athlete)
+            ->get(route('admin.activity-images'))
+            ->assertForbidden();
+    });
+
+    it('denies unauthenticated access', function () {
+        $this->get(route('admin.activity-images'))
+            ->assertRedirect(route('login'));
+    });
+});
+
+describe('upload', function () {
+    it('allows admin to upload an image', function () {
+        $admin = User::factory()->admin()->withTwoFactor()->create();
+        $file = UploadedFile::fake()->image('yoga.jpg', 800, 600);
+
+        Livewire::actingAs($admin)
+            ->test(ActivityImages::class)
+            ->set('activityType', ActivityType::Yoga->value)
+            ->set('altText', 'A yoga session in the park')
+            ->set('image', $file)
+            ->call('save')
+            ->assertDispatched('notify');
+
+        $this->assertDatabaseHas('activity_images', [
+            'activity_type' => ActivityType::Yoga->value,
+            'alt_text' => 'A yoga session in the park',
+            'uploaded_by' => $admin->id,
+        ]);
+
+        $image = ActivityImage::first();
+        Storage::disk('public')->assertExists($image->path);
+    });
+
+    it('validates required fields', function () {
+        $admin = User::factory()->admin()->withTwoFactor()->create();
+
+        Livewire::actingAs($admin)
+            ->test(ActivityImages::class)
+            ->call('save')
+            ->assertHasErrors(['activityType', 'image']);
+    });
+
+    it('rejects files larger than 2MB', function () {
+        $admin = User::factory()->admin()->withTwoFactor()->create();
+        $file = UploadedFile::fake()->image('large.jpg')->size(3000);
+
+        Livewire::actingAs($admin)
+            ->test(ActivityImages::class)
+            ->set('activityType', ActivityType::Running->value)
+            ->set('image', $file)
+            ->call('save')
+            ->assertHasErrors(['image']);
+    });
+
+    it('rejects non-image files', function () {
+        $admin = User::factory()->admin()->withTwoFactor()->create();
+        $file = UploadedFile::fake()->create('document.pdf', 500, 'application/pdf');
+
+        Livewire::actingAs($admin)
+            ->test(ActivityImages::class)
+            ->set('activityType', ActivityType::Running->value)
+            ->set('image', $file)
+            ->call('save')
+            ->assertHasErrors(['image']);
+    });
+});
+
+describe('delete', function () {
+    it('allows admin to delete an image', function () {
+        $admin = User::factory()->admin()->withTwoFactor()->create();
+        $file = UploadedFile::fake()->image('test.jpg');
+        $path = $file->store('activity-images', 'public');
+
+        $image = ActivityImage::create([
+            'activity_type' => ActivityType::Yoga->value,
+            'path' => $path,
+            'alt_text' => 'Test image',
+            'uploaded_by' => $admin->id,
+        ]);
+
+        Livewire::actingAs($admin)
+            ->test(ActivityImages::class)
+            ->call('deleteImage', $image->id)
+            ->assertDispatched('notify');
+
+        $this->assertDatabaseMissing('activity_images', ['id' => $image->id]);
+        Storage::disk('public')->assertMissing($path);
+    });
+});
+
+describe('display', function () {
+    it('shows existing images in the gallery', function () {
+        $admin = User::factory()->admin()->withTwoFactor()->create();
+        ActivityImage::factory()->count(3)->create();
+
+        Livewire::actingAs($admin)
+            ->test(ActivityImages::class)
+            ->assertViewHas('images', fn ($images) => $images->count() === 3);
+    });
+
+    it('shows activity type options in the dropdown', function () {
+        $admin = User::factory()->admin()->withTwoFactor()->create();
+
+        Livewire::actingAs($admin)
+            ->test(ActivityImages::class)
+            ->assertViewHas('activityTypes', fn ($types) => count($types) === count(ActivityType::cases()));
+    });
+});


### PR DESCRIPTION
## Summary

Implements the activity cover images feature: admin uploads activity-specific images, which coaches will later select when creating sessions.

### Changes

- **`database/migrations/..._create_activity_images_table.php`** — Table with `id`, `activity_type`, `path`, `alt_text`, `uploaded_by` (FK to users), timestamps, indexed on `activity_type`
- **`app/Models/ActivityImage.php`** — Model with `ActivityType` enum cast, `uploader()` relationship
- **`database/factories/ActivityImageFactory.php`** — Factory with `forActivity()` state
- **`app/Livewire/Admin/ActivityImages.php`** — Admin component with file upload (jpg/png/webp, max 2MB), delete, and gallery display
- **`resources/views/livewire/admin/activity-images.blade.php`** — Upload form + responsive image gallery with delete buttons
- **`routes/web/admin.php`** — Added `GET /admin/activity-images` route
- **`lang/{en,fr,nl}/admin.php`** — Tri-lingual translations for all activity images UI strings
- **`tests/Feature/Livewire/Admin/ActivityImagesTest.php`** — 11 tests covering access control (4 roles), upload + validation, delete, and gallery display

### Testing

All 11 new tests pass. Full suite (376 tests) passes.

Resolves #62