### PR TITLE
E2-S14 · Session detail page (public view + share)

### DIFF
--- a/app/Livewire/Session/Show.php
+++ b/app/Livewire/Session/Show.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Session;
+
+use App\Models\SportSession;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+
+final class Show extends Component
+{
+    public SportSession $sportSession;
+
+    public function mount(SportSession $sportSession): void
+    {
+        Gate::authorize('view', $sportSession);
+
+        $this->sportSession = $sportSession->load(['coach', 'coverImage']);
+    }
+
+    public function render(): View
+    {
+        $spotsRemaining = $this->sportSession->max_participants - $this->sportSession->current_participants;
+
+        return view('livewire.session.show', [
+            'spotsRemaining' => $spotsRemaining,
+        ])->title($this->sportSession->title);
+    }
+}

--- a/app/Models/SportSession.php
+++ b/app/Models/SportSession.php
@@ -66,4 +66,12 @@ class SportSession extends Model
     {
         return $this->belongsTo(User::class, 'coach_id');
     }
+
+    /**
+     * @return BelongsTo<ActivityImage, $this>
+     */
+    public function coverImage(): BelongsTo
+    {
+        return $this->belongsTo(ActivityImage::class, 'cover_image_id');
+    }
 }

--- a/lang/en/sessions.php
+++ b/lang/en/sessions.php
@@ -43,4 +43,23 @@ return [
     'activity_padel' => 'Padel',
     'activity_tennis' => 'Tennis',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Session Detail Page
+    |--------------------------------------------------------------------------
+    */
+
+    'by_coach' => 'By',
+    'date' => 'Date',
+    'time' => 'Time',
+    'location' => 'Location',
+    'price' => 'Price',
+    'per_person' => 'per person',
+    'spots' => 'Spots',
+    'spots_remaining' => '{0} No spots remaining|{1} :count spot remaining|[2,*] :count spots remaining',
+    'description' => 'Description',
+    'share_whatsapp' => 'Share on WhatsApp',
+    'copy_link' => 'Copy link',
+    'link_copied' => 'Link copied to clipboard!',
+
 ];

--- a/lang/fr/sessions.php
+++ b/lang/fr/sessions.php
@@ -43,4 +43,23 @@ return [
     'activity_padel' => 'Padel',
     'activity_tennis' => 'Tennis',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Session Detail Page
+    |--------------------------------------------------------------------------
+    */
+
+    'by_coach' => 'Par',
+    'date' => 'Date',
+    'time' => 'Heure',
+    'location' => 'Lieu',
+    'price' => 'Prix',
+    'per_person' => 'par personne',
+    'spots' => 'Places',
+    'spots_remaining' => '{0} Aucune place disponible|{1} :count place disponible|[2,*] :count places disponibles',
+    'description' => 'Description',
+    'share_whatsapp' => 'Partager sur WhatsApp',
+    'copy_link' => 'Copier le lien',
+    'link_copied' => 'Lien copi\u00e9 dans le presse-papiers !',
+
 ];

--- a/lang/nl/sessions.php
+++ b/lang/nl/sessions.php
@@ -43,4 +43,23 @@ return [
     'activity_padel' => 'Padel',
     'activity_tennis' => 'Tennis',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Session Detail Page
+    |--------------------------------------------------------------------------
+    */
+
+    'by_coach' => 'Door',
+    'date' => 'Datum',
+    'time' => 'Tijd',
+    'location' => 'Locatie',
+    'price' => 'Prijs',
+    'per_person' => 'per persoon',
+    'spots' => 'Plaatsen',
+    'spots_remaining' => '{0} Geen plaatsen meer beschikbaar|{1} :count plaats beschikbaar|[2,*] :count plaatsen beschikbaar',
+    'description' => 'Beschrijving',
+    'share_whatsapp' => 'Delen via WhatsApp',
+    'copy_link' => 'Link kopi\u00ebren',
+    'link_copied' => 'Link gekopieerd naar klembord!',
+
 ];

--- a/resources/views/livewire/session/show.blade.php
+++ b/resources/views/livewire/session/show.blade.php
@@ -1,0 +1,123 @@
+<div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+    {{-- Cover image --}}
+    @if ($sportSession->coverImage)
+        <div class="overflow-hidden rounded-lg">
+            <img src="{{ Storage::disk('public')->url($sportSession->coverImage->path) }}"
+                alt="{{ $sportSession->coverImage->alt_text }}"
+                class="h-64 w-full object-cover sm:h-80">
+        </div>
+    @endif
+
+    {{-- Header --}}
+    <div class="mt-6">
+        <div class="flex flex-wrap items-center gap-2">
+            <span class="inline-flex items-center rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                {{ $sportSession->activity_type->label() }}
+            </span>
+            <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-200">
+                {{ $sportSession->level->label() }}
+            </span>
+            <span @class([
+                'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
+                'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' => $sportSession->status === \App\Enums\SessionStatus::Published,
+                'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200' => $sportSession->status === \App\Enums\SessionStatus::Confirmed,
+            ])>
+                {{ $sportSession->status->label() }}
+            </span>
+        </div>
+
+        <h1 class="mt-3 text-2xl font-bold text-gray-900 dark:text-gray-100 sm:text-3xl">
+            {{ $sportSession->title }}
+        </h1>
+
+        <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+            {{ __('sessions.by_coach') }}
+            <a href="#" class="font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400">
+                {{ $sportSession->coach->name }}
+            </a>
+        </p>
+    </div>
+
+    {{-- Details grid --}}
+    <div class="mt-8 rounded-lg bg-white p-6 shadow dark:bg-gray-800">
+        <dl class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+            <div>
+                <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ __('sessions.date') }}</dt>
+                <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">
+                    {{ $sportSession->date->translatedFormat('l j F Y') }}
+                </dd>
+            </div>
+
+            <div>
+                <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ __('sessions.time') }}</dt>
+                <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">
+                    {{ \Carbon\Carbon::parse($sportSession->start_time)->format('H:i') }}
+                    –
+                    {{ \Carbon\Carbon::parse($sportSession->end_time)->format('H:i') }}
+                </dd>
+            </div>
+
+            <div>
+                <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ __('sessions.location') }}</dt>
+                <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">
+                    {{ $sportSession->location }}
+                    @if ($sportSession->postal_code)
+                        <span class="text-gray-500 dark:text-gray-400">({{ $sportSession->postal_code }})</span>
+                    @endif
+                </dd>
+            </div>
+
+            <div>
+                <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ __('sessions.price') }}</dt>
+                <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">
+                    <x-money :cents="$sportSession->price_per_person" class="text-lg font-semibold" />
+                    <span class="text-gray-500 dark:text-gray-400">/ {{ __('sessions.per_person') }}</span>
+                </dd>
+            </div>
+
+            <div>
+                <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ __('sessions.spots') }}</dt>
+                <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">
+                    {{ trans_choice('sessions.spots_remaining', $spotsRemaining, ['count' => $spotsRemaining]) }}
+                    <span class="text-gray-500 dark:text-gray-400">
+                        ({{ $sportSession->current_participants }}/{{ $sportSession->max_participants }})
+                    </span>
+                </dd>
+            </div>
+        </dl>
+    </div>
+
+    {{-- Description --}}
+    @if ($sportSession->description)
+        <div class="mt-6 rounded-lg bg-white p-6 shadow dark:bg-gray-800">
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">{{ __('sessions.description') }}</h2>
+            <div class="prose dark:prose-invert mt-3 max-w-none text-sm text-gray-700 dark:text-gray-300">
+                {!! nl2br(e($sportSession->description)) !!}
+            </div>
+        </div>
+    @endif
+
+    {{-- Share buttons --}}
+    <div class="mt-6 flex flex-wrap gap-3">
+        <a href="https://wa.me/?text={{ urlencode($sportSession->title . ' — ' . request()->url()) }}"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-2 rounded-md bg-green-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-500">
+            <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
+            </svg>
+            {{ __('sessions.share_whatsapp') }}
+        </a>
+
+        <button
+            x-data
+            x-on:click="navigator.clipboard.writeText('{{ request()->url() }}').then(() => $dispatch('notify', { type: 'success', message: '{{ __('sessions.link_copied') }}' }))"
+            type="button"
+            class="inline-flex items-center gap-2 rounded-md bg-gray-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-500">
+            <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
+            </svg>
+            {{ __('sessions.copy_link') }}
+        </button>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,7 @@ use App\Livewire\Auth\TwoFactorChallenge;
 use App\Livewire\Auth\VerifyEmail;
 use App\Livewire\Coach\Application as CoachApplication;
 use App\Livewire\Profile\Edit as ProfileEdit;
+use App\Livewire\Session\Show as SessionShow;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
 
@@ -41,6 +42,10 @@ Route::get('/profile', ProfileEdit::class)
 Route::get('/coach/apply', CoachApplication::class)
     ->middleware(['auth', 'verified'])
     ->name('coach.apply');
+
+Route::get('/sessions/{sportSession}', SessionShow::class)
+    ->middleware('auth')
+    ->name('sessions.show');
 
 Route::get('/health', function () {
     $checks = ['status' => 'ok'];

--- a/tests/Feature/Livewire/Session/ShowTest.php
+++ b/tests/Feature/Livewire/Session/ShowTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Session\Show;
+use App\Models\SportSession;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+describe('session detail page', function () {
+    it('renders correctly for a published session', function () {
+        $athlete = User::factory()->athlete()->create();
+        $session = SportSession::factory()->published()->create([
+            'title' => 'Morning Yoga Flow',
+        ]);
+
+        Livewire::actingAs($athlete)
+            ->test(Show::class, ['sportSession' => $session])
+            ->assertOk()
+            ->assertSee('Morning Yoga Flow')
+            ->assertSee($session->coach->name)
+            ->assertSeeHtml('wa.me');
+    });
+
+    it('renders correctly for a confirmed session', function () {
+        $athlete = User::factory()->athlete()->create();
+        $session = SportSession::factory()->confirmed()->create([
+            'title' => 'Boxing Bootcamp',
+        ]);
+
+        Livewire::actingAs($athlete)
+            ->test(Show::class, ['sportSession' => $session])
+            ->assertOk()
+            ->assertSee('Boxing Bootcamp');
+    });
+
+    it('returns 403 for draft session when accessed by athlete', function () {
+        $athlete = User::factory()->athlete()->create();
+        $session = SportSession::factory()->draft()->create();
+
+        $this->actingAs($athlete)
+            ->get(route('sessions.show', $session))
+            ->assertForbidden();
+    });
+
+    it('allows the owning coach to view their draft session', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->draft()->create([
+            'coach_id' => $coach->id,
+            'title' => 'My Draft Session',
+        ]);
+
+        Livewire::actingAs($coach)
+            ->test(Show::class, ['sportSession' => $session])
+            ->assertOk()
+            ->assertSee('My Draft Session');
+    });
+
+    it('allows admin to view any draft session', function () {
+        $admin = User::factory()->admin()->create();
+        $session = SportSession::factory()->draft()->create([
+            'title' => 'Secret Draft',
+        ]);
+
+        Livewire::actingAs($admin)
+            ->test(Show::class, ['sportSession' => $session])
+            ->assertOk()
+            ->assertSee('Secret Draft');
+    });
+
+    it('denies another coach from viewing a draft session', function () {
+        $otherCoach = User::factory()->coach()->create();
+        $session = SportSession::factory()->draft()->create();
+
+        $this->actingAs($otherCoach)
+            ->get(route('sessions.show', $session))
+            ->assertForbidden();
+    });
+
+    it('shows session details correctly', function () {
+        $athlete = User::factory()->athlete()->create();
+        $session = SportSession::factory()->published()->create([
+            'title' => 'Pilates in the Park',
+            'location' => 'Parc du Cinquantenaire',
+            'postal_code' => '1000',
+            'price_per_person' => 1500,
+            'max_participants' => 10,
+            'current_participants' => 3,
+        ]);
+
+        Livewire::actingAs($athlete)
+            ->test(Show::class, ['sportSession' => $session])
+            ->assertSee('Pilates in the Park')
+            ->assertSee('Parc du Cinquantenaire')
+            ->assertSee('1000');
+    });
+
+    it('shows spots remaining', function () {
+        $athlete = User::factory()->athlete()->create();
+        $session = SportSession::factory()->published()->create([
+            'max_participants' => 10,
+            'current_participants' => 7,
+        ]);
+
+        Livewire::actingAs($athlete)
+            ->test(Show::class, ['sportSession' => $session])
+            ->assertViewHas('spotsRemaining', 3);
+    });
+
+    it('requires authentication', function () {
+        $session = SportSession::factory()->published()->create();
+
+        $this->get(route('sessions.show', $session))
+            ->assertRedirect(route('login'));
+    });
+});


### PR DESCRIPTION
## Summary

Implements the public session detail page where any authenticated user can view published/confirmed sessions.

### Changes

- **`app/Livewire/Session/Show.php`** — Livewire component that loads a `SportSession` with its coach and cover image, computes remaining spots, and uses `SessionPolicy` to authorize access
- **`resources/views/livewire/session/show.blade.php`** — Mobile-first detail page showing:
  - Cover image (from ActivityImage if set)
  - Activity type, level, and status badges
  - Title, coach name
  - Date, time, location (with postal code), price (`<x-money>` component)
  - Spots remaining with pluralized translation
  - Session description
  - WhatsApp share button + copy-link button
- **`app/Models/SportSession.php`** — Added `coverImage()` BelongsTo relationship to `ActivityImage`
- **`routes/web.php`** — `GET /sessions/{sportSession}` route (auth required)
- **`lang/{en,fr,nl}/sessions.php`** — Tri-lingual translations for all detail page labels
- **`tests/Feature/Livewire/Session/ShowTest.php`** — 9 feature tests covering:
  - Published + confirmed session rendering
  - Authorization: denied for athlete/other coach on drafts, allowed for own coach + admin
  - Details rendering (location, postal code, spots calculation)
  - Authentication requirement

### Testing

All 9 new tests pass. Full suite (385 tests) passes.

Resolves #66