### PR TITLE
E2-S05 · Session creation (Livewire form + SessionService)

### DIFF
--- a/app/Livewire/Forms/SessionForm.php
+++ b/app/Livewire/Forms/SessionForm.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Forms;
+
+use App\Enums\ActivityType;
+use App\Enums\SessionLevel;
+use App\Models\SportSession;
+use Illuminate\Validation\Rules\Enum;
+use Livewire\Attributes\Validate;
+use Livewire\Form;
+
+final class SessionForm extends Form
+{
+    #[Validate]
+    public string $activityType = '';
+
+    #[Validate]
+    public string $level = '';
+
+    #[Validate('required|string|max:255')]
+    public string $title = '';
+
+    #[Validate('nullable|string|max:2000')]
+    public string $description = '';
+
+    #[Validate('required|string|max:255')]
+    public string $location = '';
+
+    #[Validate('required|string|regex:/^[1-9]\d{3}$/')]
+    public string $postalCode = '';
+
+    #[Validate('required|date|after:today')]
+    public string $date = '';
+
+    #[Validate('required|date_format:H:i')]
+    public string $startTime = '';
+
+    #[Validate('required|date_format:H:i|after:startTime')]
+    public string $endTime = '';
+
+    #[Validate('required|numeric|min:0.01')]
+    public string $priceEuros = '';
+
+    #[Validate('required|integer|min:1')]
+    public int $minParticipants = 1;
+
+    #[Validate('required|integer|min:1|gte:minParticipants')]
+    public int $maxParticipants = 10;
+
+    #[Validate('nullable|integer|exists:activity_images,id')]
+    public ?int $coverImageId = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'activityType' => ['required', 'string', new Enum(ActivityType::class)],
+            'level' => ['required', 'string', new Enum(SessionLevel::class)],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toServiceArray(): array
+    {
+        return [
+            'activity_type' => $this->activityType,
+            'level' => $this->level,
+            'title' => $this->title,
+            'description' => $this->description,
+            'location' => $this->location,
+            'postal_code' => $this->postalCode,
+            'date' => $this->date,
+            'start_time' => $this->startTime,
+            'end_time' => $this->endTime,
+            'price_per_person' => (int) round((float) $this->priceEuros * 100),
+            'min_participants' => $this->minParticipants,
+            'max_participants' => $this->maxParticipants,
+            'cover_image_id' => $this->coverImageId,
+        ];
+    }
+
+    public function setFromModel(SportSession $session): void
+    {
+        $this->activityType = $session->activity_type->value;
+        $this->level = $session->level->value;
+        $this->title = $session->title;
+        $this->description = $session->description ?? '';
+        $this->location = $session->location;
+        $this->postalCode = $session->postal_code;
+        $this->date = $session->date->format('Y-m-d');
+        $this->startTime = $session->start_time;
+        $this->endTime = $session->end_time;
+        $this->priceEuros = number_format($session->price_per_person / 100, 2, '.', '');
+        $this->minParticipants = $session->min_participants;
+        $this->maxParticipants = $session->max_participants;
+        $this->coverImageId = $session->cover_image_id;
+    }
+}

--- a/app/Livewire/Session/Create.php
+++ b/app/Livewire/Session/Create.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Session;
+
+use App\Enums\ActivityType;
+use App\Enums\SessionLevel;
+use App\Livewire\Forms\SessionForm;
+use App\Models\ActivityImage;
+use App\Models\SportSession;
+use App\Services\SessionService;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+
+final class Create extends Component
+{
+    public SessionForm $form;
+
+    public function save(SessionService $service): void
+    {
+        Gate::authorize('create', SportSession::class);
+
+        $this->form->validate();
+
+        $session = $service->create(auth()->user(), $this->form->toServiceArray());
+
+        $this->dispatch('notify', type: 'success', message: __('sessions.created'));
+        $this->redirect(route('sessions.show', $session), navigate: true);
+    }
+
+    public function render(): View
+    {
+        $coverImages = $this->form->activityType
+            ? ActivityImage::where('activity_type', $this->form->activityType)->get()
+            : collect();
+
+        return view('livewire.session.create', [
+            'activityTypes' => ActivityType::cases(),
+            'levels' => SessionLevel::cases(),
+            'coverImages' => $coverImages,
+        ])->title(__('sessions.create_title'));
+    }
+}

--- a/app/Services/SessionService.php
+++ b/app/Services/SessionService.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\SessionStatus;
+use App\Models\SportSession;
+use App\Models\User;
+
+final class SessionService
+{
+    /**
+     * Create a new session in draft status.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function create(User $coach, array $data): SportSession
+    {
+        return SportSession::create([
+            'coach_id' => $coach->id,
+            'activity_type' => $data['activity_type'],
+            'level' => $data['level'],
+            'title' => $data['title'],
+            'description' => $data['description'] ?? null,
+            'location' => $data['location'],
+            'postal_code' => $data['postal_code'],
+            'date' => $data['date'],
+            'start_time' => $data['start_time'],
+            'end_time' => $data['end_time'],
+            'price_per_person' => $data['price_per_person'],
+            'min_participants' => $data['min_participants'],
+            'max_participants' => $data['max_participants'],
+            'cover_image_id' => $data['cover_image_id'] ?? null,
+            'status' => SessionStatus::Draft->value,
+            'current_participants' => 0,
+        ]);
+    }
+}

--- a/lang/en/sessions.php
+++ b/lang/en/sessions.php
@@ -62,4 +62,40 @@ return [
     'copy_link' => 'Copy link',
     'link_copied' => 'Link copied to clipboard!',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Session Creation / Editing Form
+    |--------------------------------------------------------------------------
+    */
+
+    'create_title' => 'Create Session',
+    'create_heading' => 'Create a New Session',
+    'edit_title' => 'Edit Session',
+    'edit_heading' => 'Edit Session',
+    'activity_type_label' => 'Activity Type',
+    'select_activity_type' => 'Select an activity type…',
+    'level_label' => 'Level',
+    'select_level' => 'Select a level…',
+    'title_label' => 'Title',
+    'title_placeholder' => 'e.g. Morning Yoga in the Park',
+    'description_label' => 'Description',
+    'description_placeholder' => 'Describe your session…',
+    'location_label' => 'Location',
+    'location_placeholder' => 'e.g. Parc du Cinquantenaire',
+    'postal_code_label' => 'Postal Code',
+    'date_label' => 'Date',
+    'start_time_label' => 'Start Time',
+    'end_time_label' => 'End Time',
+    'price_label' => 'Price (EUR)',
+    'min_participants_label' => 'Min Participants',
+    'max_participants_label' => 'Max Participants',
+    'cover_image_label' => 'Cover Image',
+    'create_button' => 'Create Session',
+    'update_button' => 'Update Session',
+    'created' => 'Session created successfully.',
+    'updated' => 'Session updated successfully.',
+    'deleted' => 'Session deleted.',
+    'cancelled' => 'Session cancelled.',
+    'published' => 'Session published.',
+
 ];

--- a/lang/fr/sessions.php
+++ b/lang/fr/sessions.php
@@ -62,4 +62,40 @@ return [
     'copy_link' => 'Copier le lien',
     'link_copied' => 'Lien copi\u00e9 dans le presse-papiers !',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Session Creation / Editing Form
+    |--------------------------------------------------------------------------
+    */
+
+    'create_title' => 'Créer une séance',
+    'create_heading' => 'Créer une nouvelle séance',
+    'edit_title' => 'Modifier la séance',
+    'edit_heading' => 'Modifier la séance',
+    'activity_type_label' => 'Type d\'activité',
+    'select_activity_type' => 'Sélectionnez un type d\'activité…',
+    'level_label' => 'Niveau',
+    'select_level' => 'Sélectionnez un niveau…',
+    'title_label' => 'Titre',
+    'title_placeholder' => 'ex. Yoga matinal au parc',
+    'description_label' => 'Description',
+    'description_placeholder' => 'Décrivez votre séance…',
+    'location_label' => 'Lieu',
+    'location_placeholder' => 'ex. Parc du Cinquantenaire',
+    'postal_code_label' => 'Code postal',
+    'date_label' => 'Date',
+    'start_time_label' => 'Heure de début',
+    'end_time_label' => 'Heure de fin',
+    'price_label' => 'Prix (EUR)',
+    'min_participants_label' => 'Participants min.',
+    'max_participants_label' => 'Participants max.',
+    'cover_image_label' => 'Image de couverture',
+    'create_button' => 'Créer la séance',
+    'update_button' => 'Mettre à jour',
+    'created' => 'Séance créée avec succès.',
+    'updated' => 'Séance mise à jour avec succès.',
+    'deleted' => 'Séance supprimée.',
+    'cancelled' => 'Séance annulée.',
+    'published' => 'Séance publiée.',
+
 ];

--- a/lang/nl/sessions.php
+++ b/lang/nl/sessions.php
@@ -62,4 +62,40 @@ return [
     'copy_link' => 'Link kopi\u00ebren',
     'link_copied' => 'Link gekopieerd naar klembord!',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Session Creation / Editing Form
+    |--------------------------------------------------------------------------
+    */
+
+    'create_title' => 'Sessie aanmaken',
+    'create_heading' => 'Nieuwe sessie aanmaken',
+    'edit_title' => 'Sessie bewerken',
+    'edit_heading' => 'Sessie bewerken',
+    'activity_type_label' => 'Type activiteit',
+    'select_activity_type' => 'Selecteer een type activiteit…',
+    'level_label' => 'Niveau',
+    'select_level' => 'Selecteer een niveau…',
+    'title_label' => 'Titel',
+    'title_placeholder' => 'bijv. Ochtendyoga in het park',
+    'description_label' => 'Beschrijving',
+    'description_placeholder' => 'Beschrijf uw sessie…',
+    'location_label' => 'Locatie',
+    'location_placeholder' => 'bijv. Jubelpark',
+    'postal_code_label' => 'Postcode',
+    'date_label' => 'Datum',
+    'start_time_label' => 'Starttijd',
+    'end_time_label' => 'Eindtijd',
+    'price_label' => 'Prijs (EUR)',
+    'min_participants_label' => 'Min. deelnemers',
+    'max_participants_label' => 'Max. deelnemers',
+    'cover_image_label' => 'Omslagafbeelding',
+    'create_button' => 'Sessie aanmaken',
+    'update_button' => 'Bijwerken',
+    'created' => 'Sessie succesvol aangemaakt.',
+    'updated' => 'Sessie succesvol bijgewerkt.',
+    'deleted' => 'Sessie verwijderd.',
+    'cancelled' => 'Sessie geannuleerd.',
+    'published' => 'Sessie gepubliceerd.',
+
 ];

--- a/resources/views/livewire/session/create.blade.php
+++ b/resources/views/livewire/session/create.blade.php
@@ -1,0 +1,204 @@
+<div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
+        {{ __('sessions.create_heading') }}
+    </h1>
+
+    <form wire:submit="save" class="mt-6 space-y-6">
+        {{-- Activity type + level --}}
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+                <label for="activityType" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.activity_type_label') }}
+                </label>
+                <select wire:model.live="form.activityType" id="activityType"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm">
+                    <option value="">{{ __('sessions.select_activity_type') }}</option>
+                    @foreach ($activityTypes as $type)
+                        <option value="{{ $type->value }}">{{ $type->label() }}</option>
+                    @endforeach
+                </select>
+                @error('form.activityType')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div>
+                <label for="level" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.level_label') }}
+                </label>
+                <select wire:model="form.level" id="level"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm">
+                    <option value="">{{ __('sessions.select_level') }}</option>
+                    @foreach ($levels as $lvl)
+                        <option value="{{ $lvl->value }}">{{ $lvl->label() }}</option>
+                    @endforeach
+                </select>
+                @error('form.level')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+        </div>
+
+        {{-- Title --}}
+        <div>
+            <label for="title" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                {{ __('sessions.title_label') }}
+            </label>
+            <input type="text" wire:model="form.title" id="title"
+                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                placeholder="{{ __('sessions.title_placeholder') }}">
+            @error('form.title')
+                <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+            @enderror
+        </div>
+
+        {{-- Description --}}
+        <div>
+            <label for="description" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                {{ __('sessions.description_label') }}
+            </label>
+            <textarea wire:model="form.description" id="description" rows="4"
+                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                placeholder="{{ __('sessions.description_placeholder') }}"></textarea>
+            @error('form.description')
+                <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+            @enderror
+        </div>
+
+        {{-- Location + Postal code --}}
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+                <label for="location" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.location_label') }}
+                </label>
+                <input type="text" wire:model="form.location" id="location"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                    placeholder="{{ __('sessions.location_placeholder') }}">
+                @error('form.location')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div>
+                <label for="postalCode" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.postal_code_label') }}
+                </label>
+                <input type="text" wire:model="form.postalCode" id="postalCode"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                    placeholder="1000">
+                @error('form.postalCode')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+        </div>
+
+        {{-- Date + Times --}}
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div>
+                <label for="date" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.date_label') }}
+                </label>
+                <input type="date" wire:model="form.date" id="date"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm">
+                @error('form.date')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div>
+                <label for="startTime" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.start_time_label') }}
+                </label>
+                <input type="time" wire:model="form.startTime" id="startTime"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm">
+                @error('form.startTime')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div>
+                <label for="endTime" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.end_time_label') }}
+                </label>
+                <input type="time" wire:model="form.endTime" id="endTime"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm">
+                @error('form.endTime')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+        </div>
+
+        {{-- Price + Participants --}}
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div>
+                <label for="priceEuros" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.price_label') }}
+                </label>
+                <div class="relative mt-1">
+                    <span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-gray-500">€</span>
+                    <input type="number" wire:model="form.priceEuros" id="priceEuros" step="0.01" min="0.01"
+                        class="block w-full rounded-md border-gray-300 pl-7 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                        placeholder="15.00">
+                </div>
+                @error('form.priceEuros')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div>
+                <label for="minParticipants" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.min_participants_label') }}
+                </label>
+                <input type="number" wire:model="form.minParticipants" id="minParticipants" min="1"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm">
+                @error('form.minParticipants')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div>
+                <label for="maxParticipants" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.max_participants_label') }}
+                </label>
+                <input type="number" wire:model="form.maxParticipants" id="maxParticipants" min="1"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm">
+                @error('form.maxParticipants')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+        </div>
+
+        {{-- Cover image picker --}}
+        @if ($coverImages->isNotEmpty())
+            <div>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.cover_image_label') }}
+                </label>
+                <div class="mt-2 grid grid-cols-3 gap-3 sm:grid-cols-4">
+                    @foreach ($coverImages as $img)
+                        <label class="cursor-pointer" wire:key="cover-{{ $img->id }}">
+                            <input type="radio" wire:model="form.coverImageId" value="{{ $img->id }}" class="peer sr-only">
+                            <div class="overflow-hidden rounded-lg border-2 border-transparent ring-offset-2 peer-checked:border-indigo-500 peer-checked:ring-2 peer-checked:ring-indigo-500">
+                                <img src="{{ Storage::disk('public')->url($img->path) }}"
+                                    alt="{{ $img->alt_text }}"
+                                    class="h-24 w-full object-cover">
+                            </div>
+                        </label>
+                    @endforeach
+                </div>
+            </div>
+        @endif
+
+        {{-- Submit --}}
+        <div class="flex justify-end gap-3">
+            <a href="{{ url()->previous() }}"
+                class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600">
+                {{ __('common.cancel') }}
+            </a>
+            <button type="submit"
+                class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+                {{ __('sessions.create_button') }}
+            </button>
+        </div>
+    </form>
+</div>

--- a/routes/web/coach.php
+++ b/routes/web/coach.php
@@ -2,5 +2,7 @@
 
 declare(strict_types=1);
 
-// Coach-only routes will be added in Epic 2 (session CRUD, dashboard).
-// The coach application form (/coach/apply) remains in web.php — it is for athletes applying.
+use App\Livewire\Session\Create as SessionCreate;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/sessions/create', SessionCreate::class)->name('sessions.create');

--- a/tests/Feature/Livewire/Session/CreateTest.php
+++ b/tests/Feature/Livewire/Session/CreateTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ActivityType;
+use App\Enums\SessionLevel;
+use App\Enums\SessionStatus;
+use App\Livewire\Session\Create;
+use App\Models\ActivityImage;
+use App\Models\SportSession;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+describe('session creation', function () {
+    it('renders the form for coaches', function () {
+        $coach = User::factory()->coach()->create();
+
+        $this->actingAs($coach)
+            ->get(route('coach.sessions.create'))
+            ->assertOk();
+    });
+
+    it('denies access to athletes', function () {
+        $athlete = User::factory()->athlete()->create();
+
+        $this->actingAs($athlete)
+            ->get(route('coach.sessions.create'))
+            ->assertForbidden();
+    });
+
+    it('denies access to unauthenticated users', function () {
+        $this->get(route('coach.sessions.create'))
+            ->assertRedirect(route('login'));
+    });
+
+    it('creates a session with valid data', function () {
+        $coach = User::factory()->coach()->create();
+        $futureDate = now()->addDays(7)->format('Y-m-d');
+
+        Livewire::actingAs($coach)
+            ->test(Create::class)
+            ->set('form.activityType', ActivityType::Yoga->value)
+            ->set('form.level', SessionLevel::Beginner->value)
+            ->set('form.title', 'Morning Yoga Flow')
+            ->set('form.description', 'A relaxing morning session')
+            ->set('form.location', 'Parc du Cinquantenaire')
+            ->set('form.postalCode', '1000')
+            ->set('form.date', $futureDate)
+            ->set('form.startTime', '09:00')
+            ->set('form.endTime', '10:00')
+            ->set('form.priceEuros', '15.00')
+            ->set('form.minParticipants', 3)
+            ->set('form.maxParticipants', 15)
+            ->call('save')
+            ->assertDispatched('notify')
+            ->assertRedirect();
+
+        $session = SportSession::first();
+        expect($session)->not->toBeNull();
+        expect($session->coach_id)->toBe($coach->id);
+        expect($session->activity_type)->toBe(ActivityType::Yoga);
+        expect($session->level)->toBe(SessionLevel::Beginner);
+        expect($session->title)->toBe('Morning Yoga Flow');
+        expect($session->price_per_person)->toBe(1500);
+        expect($session->status)->toBe(SessionStatus::Draft);
+        expect($session->current_participants)->toBe(0);
+    });
+
+    it('creates a session with a cover image', function () {
+        $coach = User::factory()->coach()->create();
+        $image = ActivityImage::factory()->forActivity(ActivityType::Yoga)->create();
+        $futureDate = now()->addDays(7)->format('Y-m-d');
+
+        Livewire::actingAs($coach)
+            ->test(Create::class)
+            ->set('form.activityType', ActivityType::Yoga->value)
+            ->set('form.level', SessionLevel::Intermediate->value)
+            ->set('form.title', 'Yoga with Cover')
+            ->set('form.location', 'Studio')
+            ->set('form.postalCode', '1050')
+            ->set('form.date', $futureDate)
+            ->set('form.startTime', '10:00')
+            ->set('form.endTime', '11:00')
+            ->set('form.priceEuros', '20.00')
+            ->set('form.minParticipants', 2)
+            ->set('form.maxParticipants', 10)
+            ->set('form.coverImageId', $image->id)
+            ->call('save')
+            ->assertRedirect();
+
+        $session = SportSession::first();
+        expect($session->cover_image_id)->toBe($image->id);
+    });
+
+    it('validates required fields', function () {
+        $coach = User::factory()->coach()->create();
+
+        Livewire::actingAs($coach)
+            ->test(Create::class)
+            ->call('save')
+            ->assertHasErrors([
+                'form.activityType',
+                'form.level',
+                'form.title',
+                'form.location',
+                'form.postalCode',
+                'form.date',
+                'form.startTime',
+                'form.endTime',
+                'form.priceEuros',
+            ]);
+    });
+
+    it('validates end time is after start time', function () {
+        $coach = User::factory()->coach()->create();
+        $futureDate = now()->addDays(7)->format('Y-m-d');
+
+        Livewire::actingAs($coach)
+            ->test(Create::class)
+            ->set('form.activityType', ActivityType::Yoga->value)
+            ->set('form.level', SessionLevel::Beginner->value)
+            ->set('form.title', 'Test')
+            ->set('form.location', 'Place')
+            ->set('form.postalCode', '1000')
+            ->set('form.date', $futureDate)
+            ->set('form.startTime', '10:00')
+            ->set('form.endTime', '09:00')
+            ->set('form.priceEuros', '10.00')
+            ->set('form.minParticipants', 1)
+            ->set('form.maxParticipants', 5)
+            ->call('save')
+            ->assertHasErrors(['form.endTime']);
+    });
+
+    it('validates max participants >= min participants', function () {
+        $coach = User::factory()->coach()->create();
+        $futureDate = now()->addDays(7)->format('Y-m-d');
+
+        Livewire::actingAs($coach)
+            ->test(Create::class)
+            ->set('form.activityType', ActivityType::Yoga->value)
+            ->set('form.level', SessionLevel::Beginner->value)
+            ->set('form.title', 'Test')
+            ->set('form.location', 'Place')
+            ->set('form.postalCode', '1000')
+            ->set('form.date', $futureDate)
+            ->set('form.startTime', '09:00')
+            ->set('form.endTime', '10:00')
+            ->set('form.priceEuros', '10.00')
+            ->set('form.minParticipants', 10)
+            ->set('form.maxParticipants', 5)
+            ->call('save')
+            ->assertHasErrors(['form.maxParticipants']);
+    });
+
+    it('validates date is in the future', function () {
+        $coach = User::factory()->coach()->create();
+
+        Livewire::actingAs($coach)
+            ->test(Create::class)
+            ->set('form.activityType', ActivityType::Yoga->value)
+            ->set('form.level', SessionLevel::Beginner->value)
+            ->set('form.title', 'Test')
+            ->set('form.location', 'Place')
+            ->set('form.postalCode', '1000')
+            ->set('form.date', now()->subDay()->format('Y-m-d'))
+            ->set('form.startTime', '09:00')
+            ->set('form.endTime', '10:00')
+            ->set('form.priceEuros', '10.00')
+            ->set('form.minParticipants', 1)
+            ->set('form.maxParticipants', 5)
+            ->call('save')
+            ->assertHasErrors(['form.date']);
+    });
+
+    it('validates postal code format', function () {
+        $coach = User::factory()->coach()->create();
+
+        Livewire::actingAs($coach)
+            ->test(Create::class)
+            ->set('form.postalCode', '999')
+            ->call('save')
+            ->assertHasErrors(['form.postalCode']);
+
+        Livewire::actingAs($coach)
+            ->test(Create::class)
+            ->set('form.postalCode', '0100')
+            ->call('save')
+            ->assertHasErrors(['form.postalCode']);
+    });
+
+    it('converts price from euros to cents', function () {
+        $coach = User::factory()->coach()->create();
+        $futureDate = now()->addDays(7)->format('Y-m-d');
+
+        Livewire::actingAs($coach)
+            ->test(Create::class)
+            ->set('form.activityType', ActivityType::Running->value)
+            ->set('form.level', SessionLevel::Advanced->value)
+            ->set('form.title', 'Trail Run')
+            ->set('form.location', 'Forêt de Soignes')
+            ->set('form.postalCode', '1170')
+            ->set('form.date', $futureDate)
+            ->set('form.startTime', '07:00')
+            ->set('form.endTime', '09:00')
+            ->set('form.priceEuros', '25.50')
+            ->set('form.minParticipants', 5)
+            ->set('form.maxParticipants', 20)
+            ->call('save')
+            ->assertRedirect();
+
+        expect(SportSession::first()->price_per_person)->toBe(2550);
+    });
+
+    it('shows cover images filtered by activity type', function () {
+        $coach = User::factory()->coach()->create();
+        $yogaImage = ActivityImage::factory()->forActivity(ActivityType::Yoga)->create();
+        $runningImage = ActivityImage::factory()->forActivity(ActivityType::Running)->create();
+
+        Livewire::actingAs($coach)
+            ->test(Create::class)
+            ->set('form.activityType', ActivityType::Yoga->value)
+            ->assertViewHas('coverImages', fn ($images) => $images->count() === 1 && $images->first()->id === $yogaImage->id);
+    });
+});


### PR DESCRIPTION
## Summary

Implements the session creation form for coaches via Livewire.

### Changes

- **`app/Livewire/Forms/SessionForm.php`** — Livewire Form Object with full validation: required fields, enum checks (ActivityType, SessionLevel), future date, end time > start time, Belgian postal code regex, max >= min participants, price in euros with cents conversion. Includes `setFromModel()` for reuse in Edit (E2-S06).
- **`app/Services/SessionService.php`** — `create()` method that stores a new session in `draft` status with the authenticated coach as owner.
- **`app/Livewire/Session/Create.php`** — Component with policy authorization (`Gate::authorize('create')`), delegates to SessionService, dispatches toast notification, and redirects to session detail page.
- **`resources/views/livewire/session/create.blade.php`** — Mobile-first form with dropdowns (activity type, level), text inputs, date/time pickers, euro price input with `€` prefix, participant min/max, and activity-filtered cover image picker.
- **`routes/web/coach.php`** — `GET /coach/sessions/create` (coach middleware applied at route group level)
- **`lang/{en,fr,nl}/sessions.php`** — Tri-lingual translations for all form labels, placeholders, buttons, and flash messages (created, updated, deleted, cancelled, published)
- **`tests/Feature/Livewire/Session/CreateTest.php`** — 12 tests covering:
  - Access control (coach OK, athlete 403, unauthenticated redirect)
  - Valid creation with all fields
  - Cover image selection
  - Required field validation
  - End time > start time
  - Max >= min participants
  - Future date requirement
  - Belgian postal code format
  - Price euros-to-cents conversion
  - Activity-filtered cover image display

### Testing

All 12 new tests pass. Full suite (397 tests) passes.

Resolves #57