### PR TITLE
E2-S06 · Session editing (reuses SessionForm + SessionService::update)

### DIFF
--- a/app/Livewire/Forms/SessionForm.php
+++ b/app/Livewire/Forms/SessionForm.php
@@ -94,8 +94,8 @@ final class SessionForm extends Form
         $this->location = $session->location;
         $this->postalCode = $session->postal_code;
         $this->date = $session->date->format('Y-m-d');
-        $this->startTime = $session->start_time;
-        $this->endTime = $session->end_time;
+        $this->startTime = substr((string) $session->start_time, 0, 5);
+        $this->endTime = substr((string) $session->end_time, 0, 5);
         $this->priceEuros = number_format($session->price_per_person / 100, 2, '.', '');
         $this->minParticipants = $session->min_participants;
         $this->maxParticipants = $session->max_participants;

--- a/app/Livewire/Session/Edit.php
+++ b/app/Livewire/Session/Edit.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Session;
+
+use App\Enums\ActivityType;
+use App\Enums\SessionLevel;
+use App\Livewire\Forms\SessionForm;
+use App\Models\ActivityImage;
+use App\Models\SportSession;
+use App\Services\SessionService;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+
+final class Edit extends Component
+{
+    public SessionForm $form;
+
+    public SportSession $sportSession;
+
+    public function mount(SportSession $sportSession): void
+    {
+        Gate::authorize('update', $sportSession);
+
+        $this->sportSession = $sportSession;
+        $this->form->setFromModel($sportSession);
+    }
+
+    public function save(SessionService $service): void
+    {
+        Gate::authorize('update', $this->sportSession);
+
+        $this->form->validate();
+
+        $service->update($this->sportSession, $this->form->toServiceArray());
+
+        $this->dispatch('notify', type: 'success', message: __('sessions.updated'));
+        $this->redirect(route('sessions.show', $this->sportSession), navigate: true);
+    }
+
+    public function render(): View
+    {
+        $coverImages = $this->form->activityType
+            ? ActivityImage::where('activity_type', $this->form->activityType)->get()
+            : collect();
+
+        return view('livewire.session.edit', [
+            'activityTypes' => ActivityType::cases(),
+            'levels' => SessionLevel::cases(),
+            'coverImages' => $coverImages,
+        ])->title(__('sessions.edit_title'));
+    }
+}

--- a/app/Services/SessionService.php
+++ b/app/Services/SessionService.php
@@ -36,4 +36,30 @@ final class SessionService
             'current_participants' => 0,
         ]);
     }
+
+    /**
+     * Update an existing session.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function update(SportSession $session, array $data): SportSession
+    {
+        $session->update([
+            'activity_type' => $data['activity_type'],
+            'level' => $data['level'],
+            'title' => $data['title'],
+            'description' => $data['description'] ?? null,
+            'location' => $data['location'],
+            'postal_code' => $data['postal_code'],
+            'date' => $data['date'],
+            'start_time' => $data['start_time'],
+            'end_time' => $data['end_time'],
+            'price_per_person' => $data['price_per_person'],
+            'min_participants' => $data['min_participants'],
+            'max_participants' => $data['max_participants'],
+            'cover_image_id' => $data['cover_image_id'] ?? null,
+        ]);
+
+        return $session->refresh();
+    }
 }

--- a/resources/views/livewire/session/edit.blade.php
+++ b/resources/views/livewire/session/edit.blade.php
@@ -1,0 +1,208 @@
+<div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
+        {{ __('sessions.edit_heading') }}
+    </h1>
+
+    <form wire:submit="save" class="mt-6 space-y-6">
+        {{-- Activity type + level --}}
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+                <label for="activityType" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.activity_type_label') }}
+                </label>
+                <select wire:model.live="form.activityType" id="activityType"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm">
+                    <option value="">{{ __('sessions.select_activity_type') }}</option>
+                    @foreach ($activityTypes as $type)
+                        <option value="{{ $type->value }}">{{ $type->label() }}</option>
+                    @endforeach
+                </select>
+                @error('form.activityType')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div>
+                <label for="level" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.level_label') }}
+                </label>
+                <select wire:model="form.level" id="level"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm">
+                    <option value="">{{ __('sessions.select_level') }}</option>
+                    @foreach ($levels as $lvl)
+                        <option value="{{ $lvl->value }}">{{ $lvl->label() }}</option>
+                    @endforeach
+                </select>
+                @error('form.level')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+        </div>
+
+        {{-- Title --}}
+        <div>
+            <label for="title" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                {{ __('sessions.title_label') }}
+            </label>
+            <input type="text" wire:model="form.title" id="title"
+                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                placeholder="{{ __('sessions.title_placeholder') }}">
+            @error('form.title')
+                <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+            @enderror
+        </div>
+
+        {{-- Description --}}
+        <div>
+            <label for="description" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                {{ __('sessions.description_label') }}
+            </label>
+            <textarea wire:model="form.description" id="description" rows="4"
+                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                placeholder="{{ __('sessions.description_placeholder') }}"></textarea>
+            @error('form.description')
+                <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+            @enderror
+        </div>
+
+        {{-- Location + Postal code --}}
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+                <label for="location" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.location_label') }}
+                </label>
+                <input type="text" wire:model="form.location" id="location"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                    placeholder="{{ __('sessions.location_placeholder') }}">
+                @error('form.location')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div>
+                <label for="postalCode" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.postal_code_label') }}
+                </label>
+                <input type="text" wire:model="form.postalCode" id="postalCode"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                    placeholder="1000">
+                @error('form.postalCode')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+        </div>
+
+        {{-- Date + Times (locked when session has bookings) --}}
+        @php $hasBookings = $sportSession->current_participants > 0; @endphp
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div>
+                <label for="date" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.date_label') }}
+                </label>
+                <input type="date" wire:model="form.date" id="date"
+                    @if ($hasBookings) disabled @endif
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm disabled:cursor-not-allowed disabled:opacity-50">
+                @error('form.date')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div>
+                <label for="startTime" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.start_time_label') }}
+                </label>
+                <input type="time" wire:model="form.startTime" id="startTime"
+                    @if ($hasBookings) disabled @endif
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm disabled:cursor-not-allowed disabled:opacity-50">
+                @error('form.startTime')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div>
+                <label for="endTime" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.end_time_label') }}
+                </label>
+                <input type="time" wire:model="form.endTime" id="endTime"
+                    @if ($hasBookings) disabled @endif
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm disabled:cursor-not-allowed disabled:opacity-50">
+                @error('form.endTime')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+        </div>
+
+        {{-- Price + Participants --}}
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div>
+                <label for="priceEuros" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.price_label') }}
+                </label>
+                <div class="relative mt-1">
+                    <span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-gray-500">€</span>
+                    <input type="number" wire:model="form.priceEuros" id="priceEuros" step="0.01" min="0.01"
+                        class="block w-full rounded-md border-gray-300 pl-7 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm"
+                        placeholder="15.00">
+                </div>
+                @error('form.priceEuros')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div>
+                <label for="minParticipants" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.min_participants_label') }}
+                </label>
+                <input type="number" wire:model="form.minParticipants" id="minParticipants" min="1"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm">
+                @error('form.minParticipants')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div>
+                <label for="maxParticipants" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.max_participants_label') }}
+                </label>
+                <input type="number" wire:model="form.maxParticipants" id="maxParticipants" min="1"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm">
+                @error('form.maxParticipants')
+                    <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+        </div>
+
+        {{-- Cover image picker --}}
+        @if ($coverImages->isNotEmpty())
+            <div>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.cover_image_label') }}
+                </label>
+                <div class="mt-2 grid grid-cols-3 gap-3 sm:grid-cols-4">
+                    @foreach ($coverImages as $img)
+                        <label class="cursor-pointer" wire:key="cover-{{ $img->id }}">
+                            <input type="radio" wire:model="form.coverImageId" value="{{ $img->id }}" class="peer sr-only">
+                            <div class="overflow-hidden rounded-lg border-2 border-transparent ring-offset-2 peer-checked:border-indigo-500 peer-checked:ring-2 peer-checked:ring-indigo-500">
+                                <img src="{{ Storage::disk('public')->url($img->path) }}"
+                                    alt="{{ $img->alt_text }}"
+                                    class="h-24 w-full object-cover">
+                            </div>
+                        </label>
+                    @endforeach
+                </div>
+            </div>
+        @endif
+
+        {{-- Submit --}}
+        <div class="flex justify-end gap-3">
+            <a href="{{ route('sessions.show', $sportSession) }}"
+                class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600">
+                {{ __('common.cancel') }}
+            </a>
+            <button type="submit"
+                class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+                {{ __('sessions.update_button') }}
+            </button>
+        </div>
+    </form>
+</div>

--- a/routes/web/coach.php
+++ b/routes/web/coach.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use App\Livewire\Session\Create as SessionCreate;
+use App\Livewire\Session\Edit as SessionEdit;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/sessions/create', SessionCreate::class)->name('sessions.create');
+Route::get('/sessions/{sportSession}/edit', SessionEdit::class)->name('sessions.edit');

--- a/tests/Feature/Livewire/Session/EditTest.php
+++ b/tests/Feature/Livewire/Session/EditTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ActivityType;
+use App\Enums\SessionLevel;
+use App\Enums\SessionStatus;
+use App\Livewire\Session\Edit;
+use App\Models\SportSession;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+describe('session editing', function () {
+    it('renders the edit form for the owning coach', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->draft()->create(['coach_id' => $coach->id]);
+
+        $this->actingAs($coach)
+            ->get(route('coach.sessions.edit', $session))
+            ->assertOk();
+    });
+
+    it('pre-fills the form with existing session data', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->draft()->create([
+            'coach_id' => $coach->id,
+            'activity_type' => ActivityType::Yoga->value,
+            'level' => SessionLevel::Beginner->value,
+            'title' => 'My Session',
+            'price_per_person' => 1500,
+        ]);
+
+        Livewire::actingAs($coach)
+            ->test(Edit::class, ['sportSession' => $session])
+            ->assertSet('form.activityType', ActivityType::Yoga->value)
+            ->assertSet('form.level', SessionLevel::Beginner->value)
+            ->assertSet('form.title', 'My Session')
+            ->assertSet('form.priceEuros', '15.00');
+    });
+
+    it('denies access to a different coach', function () {
+        $coach = User::factory()->coach()->create();
+        $otherCoach = User::factory()->coach()->create();
+        $session = SportSession::factory()->draft()->create(['coach_id' => $coach->id]);
+
+        $this->actingAs($otherCoach)
+            ->get(route('coach.sessions.edit', $session))
+            ->assertForbidden();
+    });
+
+    it('denies access to athletes', function () {
+        $athlete = User::factory()->athlete()->create();
+        $session = SportSession::factory()->draft()->create();
+
+        $this->actingAs($athlete)
+            ->get(route('coach.sessions.edit', $session))
+            ->assertForbidden();
+    });
+
+    it('denies editing a completed session', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->completed()->create(['coach_id' => $coach->id]);
+
+        $this->actingAs($coach)
+            ->get(route('coach.sessions.edit', $session))
+            ->assertForbidden();
+    });
+
+    it('denies editing a cancelled session', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->cancelled()->create(['coach_id' => $coach->id]);
+
+        $this->actingAs($coach)
+            ->get(route('coach.sessions.edit', $session))
+            ->assertForbidden();
+    });
+
+    it('updates a draft session', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->draft()->create([
+            'coach_id' => $coach->id,
+            'title' => 'Old Title',
+            'date' => now()->addDays(7)->format('Y-m-d'),
+        ]);
+
+        $futureDate = now()->addDays(14)->format('Y-m-d');
+
+        Livewire::actingAs($coach)
+            ->test(Edit::class, ['sportSession' => $session])
+            ->set('form.activityType', ActivityType::Running->value)
+            ->set('form.level', SessionLevel::Advanced->value)
+            ->set('form.title', 'Updated Title')
+            ->set('form.location', 'New Location')
+            ->set('form.postalCode', '1050')
+            ->set('form.date', $futureDate)
+            ->set('form.startTime', '08:00')
+            ->set('form.endTime', '09:30')
+            ->set('form.priceEuros', '20.00')
+            ->set('form.minParticipants', 2)
+            ->set('form.maxParticipants', 12)
+            ->call('save')
+            ->assertDispatched('notify')
+            ->assertRedirect();
+
+        $session->refresh();
+        expect($session->title)->toBe('Updated Title');
+        expect($session->activity_type)->toBe(ActivityType::Running);
+        expect($session->price_per_person)->toBe(2000);
+        expect($session->status)->toBe(SessionStatus::Draft);
+    });
+
+    it('updates a published session', function () {
+        $coach = User::factory()->coach()->create();
+        $futureDate = now()->addDays(14)->format('Y-m-d');
+        $session = SportSession::factory()->published()->create([
+            'coach_id' => $coach->id,
+            'title' => 'Published Session',
+            'date' => $futureDate,
+        ]);
+
+        Livewire::actingAs($coach)
+            ->test(Edit::class, ['sportSession' => $session])
+            ->set('form.title', 'Updated Published')
+            ->call('save')
+            ->assertDispatched('notify')
+            ->assertRedirect();
+
+        $session->refresh();
+        expect($session->title)->toBe('Updated Published');
+        expect($session->status)->toBe(SessionStatus::Published);
+    });
+
+    it('allows admin to edit any session', function () {
+        $admin = User::factory()->admin()->create();
+        $session = SportSession::factory()->draft()->create([
+            'date' => now()->addDays(7)->format('Y-m-d'),
+        ]);
+
+        Livewire::actingAs($admin)
+            ->test(Edit::class, ['sportSession' => $session])
+            ->set('form.title', 'Admin Edit')
+            ->call('save')
+            ->assertDispatched('notify')
+            ->assertRedirect();
+
+        expect($session->refresh()->title)->toBe('Admin Edit');
+    });
+
+    it('validates required fields on update', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->draft()->create(['coach_id' => $coach->id]);
+
+        Livewire::actingAs($coach)
+            ->test(Edit::class, ['sportSession' => $session])
+            ->set('form.title', '')
+            ->set('form.location', '')
+            ->set('form.postalCode', '')
+            ->call('save')
+            ->assertHasErrors(['form.title', 'form.location', 'form.postalCode']);
+    });
+});


### PR DESCRIPTION
## Summary

Implements session editing for coaches, reusing the SessionForm from E2-S05.

### Changes

- **`app/Livewire/Session/Edit.php`** — Mounts with policy check (`authorize('update')`), pre-fills form via `SessionForm::setFromModel()`, delegates save to `SessionService::update()`
- **`app/Services/SessionService.php`** — Added `update()` method that updates all editable fields on an existing session
- **`resources/views/livewire/session/edit.blade.php`** — Mobile-first edit form matching create layout; date/time fields are `disabled` when session has bookings (`current_participants > 0`)
- **`routes/web/coach.php`** — `GET /coach/sessions/{sportSession}/edit`
- **`app/Livewire/Forms/SessionForm.php`** — Fixed `setFromModel()` to truncate time values from `H:i:s` to `H:i` for form validation consistency
- **`tests/Feature/Livewire/Session/EditTest.php`** — 10 tests:
  - Renders form for owning coach
  - Pre-fills form data correctly
  - Denies access to different coach / athlete
  - Denies editing completed / cancelled sessions (policy)
  - Updates draft session with field changes
  - Updates published session
  - Admin can edit any session
  - Validates required fields on update

### Testing

All 10 new tests pass. Full suite (407 tests) passes.

Resolves #58