### PR TITLE
E2-S07 · Session deletion + cancellation

### DIFF
--- a/app/Events/SessionCancelled.php
+++ b/app/Events/SessionCancelled.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\SportSession;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class SessionCancelled
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(
+        public readonly SportSession $session,
+    ) {}
+}

--- a/app/Services/SessionService.php
+++ b/app/Services/SessionService.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Enums\SessionStatus;
+use App\Events\SessionCancelled;
 use App\Models\SportSession;
 use App\Models\User;
+use InvalidArgumentException;
 
 final class SessionService
 {
@@ -61,5 +63,35 @@ final class SessionService
         ]);
 
         return $session->refresh();
+    }
+
+    /**
+     * Delete a draft session (hard delete).
+     */
+    public function delete(SportSession $session): void
+    {
+        if ($session->status !== SessionStatus::Draft) {
+            throw new InvalidArgumentException('Only draft sessions can be deleted.');
+        }
+
+        $session->delete();
+    }
+
+    /**
+     * Cancel a published or confirmed session.
+     */
+    public function cancel(SportSession $session): void
+    {
+        if (! in_array($session->status, [SessionStatus::Published, SessionStatus::Confirmed], true)) {
+            throw new InvalidArgumentException('Only published or confirmed sessions can be cancelled.');
+        }
+
+        $wasConfirmed = $session->status === SessionStatus::Confirmed;
+
+        $session->update(['status' => SessionStatus::Cancelled->value]);
+
+        if ($wasConfirmed) {
+            SessionCancelled::dispatch($session);
+        }
     }
 }

--- a/tests/Feature/Session/SessionCancellationTest.php
+++ b/tests/Feature/Session/SessionCancellationTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\SessionStatus;
+use App\Events\SessionCancelled;
+use App\Models\SportSession;
+use App\Services\SessionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+
+uses(RefreshDatabase::class);
+
+describe('session cancellation', function () {
+    it('cancels a published session', function () {
+        Event::fake();
+        $session = SportSession::factory()->published()->create();
+
+        $service = app(SessionService::class);
+        $service->cancel($session);
+
+        $session->refresh();
+        expect($session->status)->toBe(SessionStatus::Cancelled);
+
+        // Published sessions don't dispatch SessionCancelled (no refunds needed)
+        Event::assertNotDispatched(SessionCancelled::class);
+    });
+
+    it('cancels a confirmed session and dispatches event', function () {
+        Event::fake();
+        $session = SportSession::factory()->confirmed()->create();
+
+        $service = app(SessionService::class);
+        $service->cancel($session);
+
+        $session->refresh();
+        expect($session->status)->toBe(SessionStatus::Cancelled);
+
+        Event::assertDispatched(SessionCancelled::class, function (SessionCancelled $event) use ($session) {
+            return $event->session->id === $session->id;
+        });
+    });
+
+    it('refuses to cancel a draft session', function () {
+        $session = SportSession::factory()->draft()->create();
+
+        $service = app(SessionService::class);
+
+        expect(fn () => $service->cancel($session))
+            ->toThrow(InvalidArgumentException::class, 'Only published or confirmed sessions can be cancelled.');
+    });
+
+    it('refuses to cancel a completed session', function () {
+        $session = SportSession::factory()->completed()->create();
+
+        $service = app(SessionService::class);
+
+        expect(fn () => $service->cancel($session))
+            ->toThrow(InvalidArgumentException::class, 'Only published or confirmed sessions can be cancelled.');
+    });
+
+    it('refuses to cancel an already cancelled session', function () {
+        $session = SportSession::factory()->cancelled()->create();
+
+        $service = app(SessionService::class);
+
+        expect(fn () => $service->cancel($session))
+            ->toThrow(InvalidArgumentException::class, 'Only published or confirmed sessions can be cancelled.');
+    });
+});

--- a/tests/Feature/Session/SessionDeletionTest.php
+++ b/tests/Feature/Session/SessionDeletionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\SportSession;
+use App\Services\SessionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+describe('session deletion', function () {
+    it('deletes a draft session', function () {
+        $session = SportSession::factory()->draft()->create();
+
+        $service = app(SessionService::class);
+        $service->delete($session);
+
+        $this->assertDatabaseMissing('sport_sessions', ['id' => $session->id]);
+    });
+
+    it('refuses to delete a published session', function () {
+        $session = SportSession::factory()->published()->create();
+
+        $service = app(SessionService::class);
+
+        expect(fn () => $service->delete($session))
+            ->toThrow(InvalidArgumentException::class, 'Only draft sessions can be deleted.');
+    });
+
+    it('refuses to delete a confirmed session', function () {
+        $session = SportSession::factory()->confirmed()->create();
+
+        $service = app(SessionService::class);
+
+        expect(fn () => $service->delete($session))
+            ->toThrow(InvalidArgumentException::class, 'Only draft sessions can be deleted.');
+    });
+
+    it('refuses to delete a completed session', function () {
+        $session = SportSession::factory()->completed()->create();
+
+        $service = app(SessionService::class);
+
+        expect(fn () => $service->delete($session))
+            ->toThrow(InvalidArgumentException::class, 'Only draft sessions can be deleted.');
+    });
+
+    it('refuses to delete a cancelled session', function () {
+        $session = SportSession::factory()->cancelled()->create();
+
+        $service = app(SessionService::class);
+
+        expect(fn () => $service->delete($session))
+            ->toThrow(InvalidArgumentException::class, 'Only draft sessions can be deleted.');
+    });
+});


### PR DESCRIPTION
## Summary

Implements session deletion (hard delete for drafts) and cancellation (status transition with event dispatch) in `SessionService`.

### Changes

- **`app/Services/SessionService.php`** — Added `delete()` and `cancel()` methods:
  - `delete()`: hard-deletes draft sessions; throws `InvalidArgumentException` for other statuses
  - `cancel()`: transitions published/confirmed → cancelled; dispatches `SessionCancelled` event when cancelling a confirmed session (will trigger refunds in Epic 3)
- **`app/Events/SessionCancelled.php`** — Domain event with serializable `SportSession` payload
- **`tests/Feature/Session/SessionDeletionTest.php`** — 5 tests: draft deletion OK; published/confirmed/completed/cancelled deletion rejected
- **`tests/Feature/Session/SessionCancellationTest.php`** — 5 tests: published cancellation OK (no event); confirmed cancellation dispatches event; draft/completed/already-cancelled rejected

### Testing

All 10 new tests pass. Full suite (417 tests) passes.

Resolves #59