### PR TITLE
E2-S08 · Session publishing (draft → published)

### DIFF
--- a/app/Services/SessionService.php
+++ b/app/Services/SessionService.php
@@ -8,6 +8,7 @@ use App\Enums\SessionStatus;
 use App\Events\SessionCancelled;
 use App\Models\SportSession;
 use App\Models\User;
+use Illuminate\Validation\ValidationException;
 use InvalidArgumentException;
 
 final class SessionService
@@ -93,5 +94,54 @@ final class SessionService
         if ($wasConfirmed) {
             SessionCancelled::dispatch($session);
         }
+    }
+
+    /**
+     * Publish a draft session (make it visible to athletes).
+     *
+     * @throws ValidationException if required fields are missing
+     * @throws InvalidArgumentException if session is not in draft status
+     */
+    public function publish(SportSession $session): void
+    {
+        if ($session->status !== SessionStatus::Draft) {
+            throw new InvalidArgumentException('Only draft sessions can be published.');
+        }
+
+        $missing = [];
+
+        if (empty($session->title)) {
+            $missing['title'] = [__('validation.required', ['attribute' => __('sessions.title_label')])];
+        }
+        if (empty($session->location)) {
+            $missing['location'] = [__('validation.required', ['attribute' => __('sessions.location_label')])];
+        }
+        if (empty($session->postal_code)) {
+            $missing['postal_code'] = [__('validation.required', ['attribute' => __('sessions.postal_code_label')])];
+        }
+        if ($session->date === null) {
+            $missing['date'] = [__('validation.required', ['attribute' => __('sessions.date_label')])];
+        }
+        if (empty($session->start_time)) {
+            $missing['start_time'] = [__('validation.required', ['attribute' => __('sessions.start_time_label')])];
+        }
+        if (empty($session->end_time)) {
+            $missing['end_time'] = [__('validation.required', ['attribute' => __('sessions.end_time_label')])];
+        }
+        if ($session->price_per_person <= 0) {
+            $missing['price_per_person'] = [__('validation.required', ['attribute' => __('sessions.price_label')])];
+        }
+        if ($session->min_participants < 1) {
+            $missing['min_participants'] = [__('validation.required', ['attribute' => __('sessions.min_participants_label')])];
+        }
+        if ($session->max_participants < 1) {
+            $missing['max_participants'] = [__('validation.required', ['attribute' => __('sessions.max_participants_label')])];
+        }
+
+        if ($missing !== []) {
+            throw ValidationException::withMessages($missing);
+        }
+
+        $session->update(['status' => SessionStatus::Published->value]);
     }
 }

--- a/tests/Feature/Session/SessionPublishTest.php
+++ b/tests/Feature/Session/SessionPublishTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\SessionStatus;
+use App\Models\SportSession;
+use App\Services\SessionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
+
+uses(RefreshDatabase::class);
+
+describe('session publishing', function () {
+    it('publishes a complete draft session', function () {
+        $session = SportSession::factory()->draft()->create();
+
+        $service = app(SessionService::class);
+        $service->publish($session);
+
+        $session->refresh();
+        expect($session->status)->toBe(SessionStatus::Published);
+    });
+
+    it('refuses to publish a non-draft session', function () {
+        $session = SportSession::factory()->published()->create();
+
+        $service = app(SessionService::class);
+
+        expect(fn () => $service->publish($session))
+            ->toThrow(InvalidArgumentException::class, 'Only draft sessions can be published.');
+    });
+
+    it('refuses to publish a confirmed session', function () {
+        $session = SportSession::factory()->confirmed()->create();
+
+        $service = app(SessionService::class);
+
+        expect(fn () => $service->publish($session))
+            ->toThrow(InvalidArgumentException::class, 'Only draft sessions can be published.');
+    });
+
+    it('refuses to publish a completed session', function () {
+        $session = SportSession::factory()->completed()->create();
+
+        $service = app(SessionService::class);
+
+        expect(fn () => $service->publish($session))
+            ->toThrow(InvalidArgumentException::class, 'Only draft sessions can be published.');
+    });
+
+    it('refuses to publish a session with missing title', function () {
+        $session = SportSession::factory()->draft()->create(['title' => '']);
+
+        $service = app(SessionService::class);
+
+        expect(fn () => $service->publish($session))
+            ->toThrow(ValidationException::class);
+    });
+
+    it('refuses to publish a session with missing location', function () {
+        $session = SportSession::factory()->draft()->create(['location' => '']);
+
+        $service = app(SessionService::class);
+
+        expect(fn () => $service->publish($session))
+            ->toThrow(ValidationException::class);
+    });
+
+    it('refuses to publish a session with zero price', function () {
+        $session = SportSession::factory()->draft()->create(['price_per_person' => 0]);
+
+        $service = app(SessionService::class);
+
+        expect(fn () => $service->publish($session))
+            ->toThrow(ValidationException::class);
+    });
+
+    it('refuses to publish a session with zero min participants', function () {
+        $session = SportSession::factory()->draft()->create(['min_participants' => 0]);
+
+        $service = app(SessionService::class);
+
+        expect(fn () => $service->publish($session))
+            ->toThrow(ValidationException::class);
+    });
+});


### PR DESCRIPTION
## Summary

Implements the session publishing logic — validates completeness and transitions draft → published.

### Changes

- **`app/Services/SessionService.php`** — Added `publish()` method:
  - Validates the session is in `draft` status (throws `InvalidArgumentException` otherwise)
  - Validates all required fields are filled: title, location, postal_code, date, start_time, end_time, price_per_person (> 0), min_participants (≥ 1), max_participants (≥ 1)
  - Throws `ValidationException` with specific field messages if validation fails
  - Transitions status to `published` on success
- **`tests/Feature/Session/SessionPublishTest.php`** — 8 tests:
  - Successful publish of complete draft
  - Non-draft rejection (published, confirmed, completed)
  - Validation failures (missing title, missing location, zero price, zero min_participants)

### Testing

All 8 new tests pass. Full suite (425 tests) passes.

Resolves #60