### PR TITLE
E2-S09 · Recurring weekly sessions

### DIFF
--- a/app/Livewire/Forms/SessionForm.php
+++ b/app/Livewire/Forms/SessionForm.php
@@ -52,6 +52,12 @@ final class SessionForm extends Form
     #[Validate('nullable|integer|exists:activity_images,id')]
     public ?int $coverImageId = null;
 
+    #[Validate('boolean')]
+    public bool $isRecurring = false;
+
+    #[Validate('required_if:isRecurring,true|integer|min:2|max:12')]
+    public int $numberOfWeeks = 2;
+
     /**
      * @return array<string, mixed>
      */

--- a/app/Livewire/Session/Create.php
+++ b/app/Livewire/Session/Create.php
@@ -24,9 +24,21 @@ final class Create extends Component
 
         $this->form->validate();
 
-        $session = $service->create(auth()->user(), $this->form->toServiceArray());
+        if ($this->form->isRecurring) {
+            $sessions = $service->createRecurring(
+                auth()->user(),
+                $this->form->toServiceArray(),
+                $this->form->numberOfWeeks,
+            );
+            $session = $sessions->first();
 
-        $this->dispatch('notify', type: 'success', message: __('sessions.created'));
+            $this->dispatch('notify', type: 'success', message: __('sessions.recurring_created', ['count' => $sessions->count()]));
+        } else {
+            $session = $service->create(auth()->user(), $this->form->toServiceArray());
+
+            $this->dispatch('notify', type: 'success', message: __('sessions.created'));
+        }
+
         $this->redirect(route('sessions.show', $session), navigate: true);
     }
 

--- a/app/Services/SessionService.php
+++ b/app/Services/SessionService.php
@@ -8,6 +8,9 @@ use App\Enums\SessionStatus;
 use App\Events\SessionCancelled;
 use App\Models\SportSession;
 use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use InvalidArgumentException;
 
@@ -38,6 +41,48 @@ final class SessionService
             'status' => SessionStatus::Draft->value,
             'current_participants' => 0,
         ]);
+    }
+
+    /**
+     * Create recurring weekly sessions sharing a recurrence group.
+     *
+     * @param  array<string, mixed>  $data
+     * @return Collection<int, SportSession>
+     */
+    public function createRecurring(User $coach, array $data, int $numberOfWeeks): Collection
+    {
+        $groupId = Str::uuid()->toString();
+        $baseDate = Carbon::parse($data['date']);
+
+        $sessions = collect();
+
+        for ($i = 0; $i < $numberOfWeeks; $i++) {
+            $sessionDate = $baseDate->copy()->addWeeks($i);
+
+            $session = SportSession::create([
+                'coach_id' => $coach->id,
+                'activity_type' => $data['activity_type'],
+                'level' => $data['level'],
+                'title' => $data['title'],
+                'description' => $data['description'] ?? null,
+                'location' => $data['location'],
+                'postal_code' => $data['postal_code'],
+                'date' => $sessionDate->format('Y-m-d'),
+                'start_time' => $data['start_time'],
+                'end_time' => $data['end_time'],
+                'price_per_person' => $data['price_per_person'],
+                'min_participants' => $data['min_participants'],
+                'max_participants' => $data['max_participants'],
+                'cover_image_id' => $data['cover_image_id'] ?? null,
+                'status' => SessionStatus::Draft->value,
+                'current_participants' => 0,
+                'recurrence_group_id' => $groupId,
+            ]);
+
+            $sessions->push($session);
+        }
+
+        return $sessions;
     }
 
     /**

--- a/lang/en/sessions.php
+++ b/lang/en/sessions.php
@@ -97,5 +97,9 @@ return [
     'deleted' => 'Session deleted.',
     'cancelled' => 'Session cancelled.',
     'published' => 'Session published.',
+    'repeat_weekly' => 'Repeat weekly',
+    'number_of_weeks' => 'Number of weeks',
+    'recurring_hint' => 'Creates individual sessions for each week (max 12 weeks).',
+    'recurring_created' => ':count recurring sessions created successfully.',
 
 ];

--- a/lang/fr/sessions.php
+++ b/lang/fr/sessions.php
@@ -97,5 +97,9 @@ return [
     'deleted' => 'Séance supprimée.',
     'cancelled' => 'Séance annulée.',
     'published' => 'Séance publiée.',
+    'repeat_weekly' => 'Répéter chaque semaine',
+    'number_of_weeks' => 'Nombre de semaines',
+    'recurring_hint' => 'Crée des séances individuelles pour chaque semaine (max 12 semaines).',
+    'recurring_created' => ':count séances récurrentes créées avec succès.',
 
 ];

--- a/lang/nl/sessions.php
+++ b/lang/nl/sessions.php
@@ -97,5 +97,9 @@ return [
     'deleted' => 'Sessie verwijderd.',
     'cancelled' => 'Sessie geannuleerd.',
     'published' => 'Sessie gepubliceerd.',
+    'repeat_weekly' => 'Wekelijks herhalen',
+    'number_of_weeks' => 'Aantal weken',
+    'recurring_hint' => 'Maakt individuele sessies aan voor elke week (max 12 weken).',
+    'recurring_created' => ':count terugkerende sessies succesvol aangemaakt.',
 
 ];

--- a/resources/views/livewire/session/create.blade.php
+++ b/resources/views/livewire/session/create.blade.php
@@ -189,6 +189,31 @@
             </div>
         @endif
 
+        {{-- Recurring options --}}
+        <div class="rounded-lg border border-gray-200 p-4 dark:border-gray-600">
+            <div class="flex items-center">
+                <input type="checkbox" wire:model.live="form.isRecurring" id="isRecurring"
+                    class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700">
+                <label for="isRecurring" class="ml-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ __('sessions.repeat_weekly') }}
+                </label>
+            </div>
+
+            @if ($this->form->isRecurring)
+                <div class="mt-4">
+                    <label for="numberOfWeeks" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                        {{ __('sessions.number_of_weeks') }}
+                    </label>
+                    <input type="number" wire:model="form.numberOfWeeks" id="numberOfWeeks" min="2" max="12"
+                        class="mt-1 block w-32 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 sm:text-sm">
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ __('sessions.recurring_hint') }}</p>
+                    @error('form.numberOfWeeks')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+            @endif
+        </div>
+
         {{-- Submit --}}
         <div class="flex justify-end gap-3">
             <a href="{{ url()->previous() }}"

--- a/tests/Feature/Session/RecurringSessionTest.php
+++ b/tests/Feature/Session/RecurringSessionTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ActivityType;
+use App\Enums\SessionLevel;
+use App\Enums\SessionStatus;
+use App\Livewire\Session\Create;
+use App\Models\SportSession;
+use App\Models\User;
+use App\Services\SessionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+describe('recurring session creation via service', function () {
+    it('creates the correct number of sessions', function () {
+        $coach = User::factory()->coach()->create();
+        $service = app(SessionService::class);
+        $futureDate = now()->addDays(7)->format('Y-m-d');
+
+        $sessions = $service->createRecurring($coach, [
+            'activity_type' => ActivityType::Yoga->value,
+            'level' => SessionLevel::Beginner->value,
+            'title' => 'Weekly Yoga',
+            'description' => null,
+            'location' => 'Park',
+            'postal_code' => '1000',
+            'date' => $futureDate,
+            'start_time' => '09:00',
+            'end_time' => '10:00',
+            'price_per_person' => 1500,
+            'min_participants' => 3,
+            'max_participants' => 15,
+            'cover_image_id' => null,
+        ], 4);
+
+        expect($sessions)->toHaveCount(4);
+        expect(SportSession::count())->toBe(4);
+    });
+
+    it('generates correct weekly dates', function () {
+        $coach = User::factory()->coach()->create();
+        $service = app(SessionService::class);
+        $baseDate = now()->addDays(7);
+
+        $sessions = $service->createRecurring($coach, [
+            'activity_type' => ActivityType::Running->value,
+            'level' => SessionLevel::Advanced->value,
+            'title' => 'Weekly Run',
+            'location' => 'Forest',
+            'postal_code' => '1170',
+            'date' => $baseDate->format('Y-m-d'),
+            'start_time' => '07:00',
+            'end_time' => '08:30',
+            'price_per_person' => 1000,
+            'min_participants' => 2,
+            'max_participants' => 10,
+        ], 3);
+
+        expect($sessions[0]->date->format('Y-m-d'))->toBe($baseDate->format('Y-m-d'));
+        expect($sessions[1]->date->format('Y-m-d'))->toBe($baseDate->copy()->addWeek()->format('Y-m-d'));
+        expect($sessions[2]->date->format('Y-m-d'))->toBe($baseDate->copy()->addWeeks(2)->format('Y-m-d'));
+    });
+
+    it('shares a recurrence group id', function () {
+        $coach = User::factory()->coach()->create();
+        $service = app(SessionService::class);
+
+        $sessions = $service->createRecurring($coach, [
+            'activity_type' => ActivityType::Cardio->value,
+            'level' => SessionLevel::Intermediate->value,
+            'title' => 'Weekly Cardio',
+            'location' => 'Gym',
+            'postal_code' => '1050',
+            'date' => now()->addDays(7)->format('Y-m-d'),
+            'start_time' => '18:00',
+            'end_time' => '19:00',
+            'price_per_person' => 2000,
+            'min_participants' => 5,
+            'max_participants' => 20,
+        ], 5);
+
+        $groupId = $sessions->first()->recurrence_group_id;
+        expect($groupId)->not->toBeNull();
+
+        foreach ($sessions as $session) {
+            expect($session->recurrence_group_id)->toBe($groupId);
+        }
+    });
+
+    it('creates each session in draft status', function () {
+        $coach = User::factory()->coach()->create();
+        $service = app(SessionService::class);
+
+        $sessions = $service->createRecurring($coach, [
+            'activity_type' => ActivityType::Tennis->value,
+            'level' => SessionLevel::Beginner->value,
+            'title' => 'Tennis',
+            'location' => 'Court',
+            'postal_code' => '1200',
+            'date' => now()->addDays(7)->format('Y-m-d'),
+            'start_time' => '14:00',
+            'end_time' => '15:00',
+            'price_per_person' => 3000,
+            'min_participants' => 2,
+            'max_participants' => 4,
+        ], 3);
+
+        foreach ($sessions as $session) {
+            expect($session->status)->toBe(SessionStatus::Draft);
+            expect($session->current_participants)->toBe(0);
+        }
+    });
+
+    it('creates each session as independent (own id)', function () {
+        $coach = User::factory()->coach()->create();
+        $service = app(SessionService::class);
+
+        $sessions = $service->createRecurring($coach, [
+            'activity_type' => ActivityType::Dance->value,
+            'level' => SessionLevel::Intermediate->value,
+            'title' => 'Dance',
+            'location' => 'Studio',
+            'postal_code' => '1000',
+            'date' => now()->addDays(7)->format('Y-m-d'),
+            'start_time' => '20:00',
+            'end_time' => '21:30',
+            'price_per_person' => 1800,
+            'min_participants' => 4,
+            'max_participants' => 16,
+        ], 4);
+
+        $ids = $sessions->pluck('id')->unique();
+        expect($ids)->toHaveCount(4);
+    });
+});
+
+describe('recurring session creation via Livewire', function () {
+    it('creates recurring sessions via the form', function () {
+        $coach = User::factory()->coach()->create();
+        $futureDate = now()->addDays(7)->format('Y-m-d');
+
+        Livewire::actingAs($coach)
+            ->test(Create::class)
+            ->set('form.activityType', ActivityType::Yoga->value)
+            ->set('form.level', SessionLevel::Beginner->value)
+            ->set('form.title', 'Weekly Yoga')
+            ->set('form.location', 'Park')
+            ->set('form.postalCode', '1000')
+            ->set('form.date', $futureDate)
+            ->set('form.startTime', '09:00')
+            ->set('form.endTime', '10:00')
+            ->set('form.priceEuros', '15.00')
+            ->set('form.minParticipants', 3)
+            ->set('form.maxParticipants', 15)
+            ->set('form.isRecurring', true)
+            ->set('form.numberOfWeeks', 4)
+            ->call('save')
+            ->assertDispatched('notify')
+            ->assertRedirect();
+
+        expect(SportSession::count())->toBe(4);
+
+        $groupId = SportSession::first()->recurrence_group_id;
+        expect($groupId)->not->toBeNull();
+        expect(SportSession::where('recurrence_group_id', $groupId)->count())->toBe(4);
+    });
+
+    it('creates a single session when recurring is unchecked', function () {
+        $coach = User::factory()->coach()->create();
+        $futureDate = now()->addDays(7)->format('Y-m-d');
+
+        Livewire::actingAs($coach)
+            ->test(Create::class)
+            ->set('form.activityType', ActivityType::Yoga->value)
+            ->set('form.level', SessionLevel::Beginner->value)
+            ->set('form.title', 'One-off Yoga')
+            ->set('form.location', 'Park')
+            ->set('form.postalCode', '1000')
+            ->set('form.date', $futureDate)
+            ->set('form.startTime', '09:00')
+            ->set('form.endTime', '10:00')
+            ->set('form.priceEuros', '15.00')
+            ->set('form.minParticipants', 3)
+            ->set('form.maxParticipants', 15)
+            ->set('form.isRecurring', false)
+            ->call('save')
+            ->assertRedirect();
+
+        expect(SportSession::count())->toBe(1);
+        expect(SportSession::first()->recurrence_group_id)->toBeNull();
+    });
+
+    it('shows the recurring options when checkbox is checked', function () {
+        $coach = User::factory()->coach()->create();
+
+        Livewire::actingAs($coach)
+            ->test(Create::class)
+            ->assertDontSee(__('sessions.number_of_weeks'))
+            ->set('form.isRecurring', true)
+            ->assertSee(__('sessions.number_of_weeks'));
+    });
+});


### PR DESCRIPTION
## Summary

Implements recurring weekly session creation — coaches can create 2-12 weekly sessions in one action, sharing a `recurrence_group_id`.

### Changes

- **`app/Livewire/Forms/SessionForm.php`** — Added `isRecurring` (bool) and `numberOfWeeks` (2-12, validated) properties
- **`app/Services/SessionService.php`** — Added `createRecurring()`: generates N individual draft sessions with weekly date increments, all linked via a shared `recurrence_group_id` (UUID). Each session is a fully independent entity with its own status, bookings, and lifecycle
- **`app/Livewire/Session/Create.php`** — Updated `save()` to branch: calls `createRecurring()` if `isRecurring` is true, otherwise `create()`. Different success messages
- **`resources/views/livewire/session/create.blade.php`** — Added recurring section: checkbox ("Repeat weekly") toggling a number-of-weeks input (min 2, max 12) with hint text
- **`lang/{en,fr,nl}/sessions.php`** — Added recurring i18n keys: `repeat_weekly`, `number_of_weeks`, `recurring_hint`, `recurring_created`
- **`tests/Feature/Session/RecurringSessionTest.php`** — 8 tests:
  - Service: correct count, correct weekly dates, shared group ID, draft status, independent IDs
  - Livewire: recurring creation (4 sessions), non-recurring creates 1, UI toggle for recurring options

### Testing

All 8 new tests pass. Full suite (433 tests) passes.

Resolves #61