### PR TITLE
E2-S11 · Coach dashboard — upcoming sessions

### DIFF
--- a/app/Livewire/Coach/Dashboard.php
+++ b/app/Livewire/Coach/Dashboard.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Coach;
+
+use App\Enums\SessionStatus;
+use App\Models\SportSession;
+use App\Models\User;
+use App\Services\SessionService;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+
+final class Dashboard extends Component
+{
+    public string $tab = 'upcoming';
+
+    public function publishSession(int $sessionId, SessionService $service): void
+    {
+        $session = SportSession::findOrFail($sessionId);
+        Gate::authorize('update', $session);
+
+        $service->publish($session);
+
+        $this->dispatch('notify', type: 'success', message: __('sessions.published'));
+    }
+
+    public function cancelSession(int $sessionId, SessionService $service): void
+    {
+        $session = SportSession::findOrFail($sessionId);
+        Gate::authorize('cancel', $session);
+
+        $service->cancel($session);
+
+        $this->dispatch('notify', type: 'success', message: __('sessions.cancelled'));
+    }
+
+    public function deleteSession(int $sessionId, SessionService $service): void
+    {
+        $session = SportSession::findOrFail($sessionId);
+        Gate::authorize('delete', $session);
+
+        $service->delete($session);
+
+        $this->dispatch('notify', type: 'success', message: __('sessions.deleted'));
+    }
+
+    public function render(): View
+    {
+        /** @var User $coach */
+        $coach = auth()->user();
+
+        $upcoming = SportSession::where('coach_id', $coach->id)
+            ->whereIn('status', [SessionStatus::Published, SessionStatus::Confirmed])
+            ->where('date', '>=', now()->toDateString())
+            ->orderBy('date')
+            ->orderBy('start_time')
+            ->get();
+
+        $drafts = SportSession::where('coach_id', $coach->id)
+            ->where('status', SessionStatus::Draft)
+            ->orderBy('date')
+            ->orderBy('start_time')
+            ->get();
+
+        $past = SportSession::where('coach_id', $coach->id)
+            ->whereIn('status', [SessionStatus::Completed, SessionStatus::Cancelled])
+            ->orderByDesc('date')
+            ->orderByDesc('start_time')
+            ->limit(20)
+            ->get();
+
+        return view('livewire.coach.dashboard', [
+            'upcoming' => $upcoming,
+            'drafts' => $drafts,
+            'past' => $past,
+        ])->title(__('coach.dashboard_title'));
+    }
+}

--- a/lang/en/coach.php
+++ b/lang/en/coach.php
@@ -60,4 +60,25 @@ return [
     'summary_title' => 'Application summary',
     'submit_application' => 'Submit my application',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Coach Dashboard
+    |--------------------------------------------------------------------------
+    */
+
+    'dashboard_title' => 'Coach Dashboard',
+    'dashboard_heading' => 'My Sessions',
+    'create_session' => 'New Session',
+    'tabs_label' => 'Session tabs',
+    'tab_upcoming' => 'Upcoming',
+    'tab_drafts' => 'Drafts',
+    'tab_past' => 'Past',
+    'no_upcoming' => 'No upcoming sessions. Create one to get started!',
+    'no_drafts' => 'No draft sessions.',
+    'no_past' => 'No past sessions yet.',
+    'publish' => 'Publish',
+    'confirm_publish' => 'Are you sure you want to publish this session?',
+    'confirm_cancel' => 'Are you sure you want to cancel this session?',
+    'confirm_delete' => 'Are you sure you want to delete this draft?',
+
 ];

--- a/lang/fr/coach.php
+++ b/lang/fr/coach.php
@@ -60,4 +60,25 @@ return [
     'summary_title' => 'Résumé de votre candidature',
     'submit_application' => 'Soumettre ma candidature',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Coach Dashboard
+    |--------------------------------------------------------------------------
+    */
+
+    'dashboard_title' => 'Tableau de bord Coach',
+    'dashboard_heading' => 'Mes séances',
+    'create_session' => 'Nouvelle séance',
+    'tabs_label' => 'Onglets de séances',
+    'tab_upcoming' => 'À venir',
+    'tab_drafts' => 'Brouillons',
+    'tab_past' => 'Passées',
+    'no_upcoming' => 'Aucune séance à venir. Créez-en une pour commencer !',
+    'no_drafts' => 'Aucun brouillon.',
+    'no_past' => 'Aucune séance passée.',
+    'publish' => 'Publier',
+    'confirm_publish' => 'Êtes-vous sûr de vouloir publier cette séance ?',
+    'confirm_cancel' => 'Êtes-vous sûr de vouloir annuler cette séance ?',
+    'confirm_delete' => 'Êtes-vous sûr de vouloir supprimer ce brouillon ?',
+
 ];

--- a/lang/nl/coach.php
+++ b/lang/nl/coach.php
@@ -60,4 +60,25 @@ return [
     'summary_title' => 'Samenvatting van uw aanvraag',
     'submit_application' => 'Mijn aanvraag indienen',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Coach Dashboard
+    |--------------------------------------------------------------------------
+    */
+
+    'dashboard_title' => 'Coach Dashboard',
+    'dashboard_heading' => 'Mijn sessies',
+    'create_session' => 'Nieuwe sessie',
+    'tabs_label' => 'Sessie tabs',
+    'tab_upcoming' => 'Aankomende',
+    'tab_drafts' => 'Concepten',
+    'tab_past' => 'Afgelopen',
+    'no_upcoming' => 'Geen aankomende sessies. Maak er een aan om te beginnen!',
+    'no_drafts' => 'Geen concepten.',
+    'no_past' => 'Nog geen afgelopen sessies.',
+    'publish' => 'Publiceren',
+    'confirm_publish' => 'Weet u zeker dat u deze sessie wilt publiceren?',
+    'confirm_cancel' => 'Weet u zeker dat u deze sessie wilt annuleren?',
+    'confirm_delete' => 'Weet u zeker dat u dit concept wilt verwijderen?',
+
 ];

--- a/resources/views/livewire/coach/dashboard.blade.php
+++ b/resources/views/livewire/coach/dashboard.blade.php
@@ -1,0 +1,53 @@
+<div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+    <div class="mb-6 flex items-center justify-between">
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ __('coach.dashboard_heading') }}</h1>
+        <a href="{{ route('coach.sessions.create') }}"
+            class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+            {{ __('coach.create_session') }}
+        </a>
+    </div>
+
+    {{-- Tabs --}}
+    <div class="border-b border-gray-200 dark:border-gray-700">
+        <nav class="-mb-px flex space-x-8" aria-label="{{ __('coach.tabs_label') }}">
+            <button wire:click="$set('tab', 'upcoming')"
+                class="whitespace-nowrap border-b-2 px-1 py-4 text-sm font-medium {{ $tab === 'upcoming' ? 'border-indigo-500 text-indigo-600 dark:text-indigo-400' : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300' }}">
+                {{ __('coach.tab_upcoming') }}
+                <span class="ml-1 rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-600 dark:bg-indigo-900 dark:text-indigo-300">{{ $upcoming->count() }}</span>
+            </button>
+            <button wire:click="$set('tab', 'drafts')"
+                class="whitespace-nowrap border-b-2 px-1 py-4 text-sm font-medium {{ $tab === 'drafts' ? 'border-indigo-500 text-indigo-600 dark:text-indigo-400' : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300' }}">
+                {{ __('coach.tab_drafts') }}
+                <span class="ml-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-300">{{ $drafts->count() }}</span>
+            </button>
+            <button wire:click="$set('tab', 'past')"
+                class="whitespace-nowrap border-b-2 px-1 py-4 text-sm font-medium {{ $tab === 'past' ? 'border-indigo-500 text-indigo-600 dark:text-indigo-400' : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300' }}">
+                {{ __('coach.tab_past') }}
+                <span class="ml-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-300">{{ $past->count() }}</span>
+            </button>
+        </nav>
+    </div>
+
+    {{-- Tab content --}}
+    <div class="mt-6">
+        @if ($tab === 'upcoming')
+            @forelse ($upcoming as $session)
+                @include('livewire.coach.partials.session-card', ['session' => $session, 'showActions' => true])
+            @empty
+                <p class="py-8 text-center text-gray-500 dark:text-gray-400">{{ __('coach.no_upcoming') }}</p>
+            @endforelse
+        @elseif ($tab === 'drafts')
+            @forelse ($drafts as $session)
+                @include('livewire.coach.partials.session-card', ['session' => $session, 'showActions' => true])
+            @empty
+                <p class="py-8 text-center text-gray-500 dark:text-gray-400">{{ __('coach.no_drafts') }}</p>
+            @endforelse
+        @elseif ($tab === 'past')
+            @forelse ($past as $session)
+                @include('livewire.coach.partials.session-card', ['session' => $session, 'showActions' => false])
+            @empty
+                <p class="py-8 text-center text-gray-500 dark:text-gray-400">{{ __('coach.no_past') }}</p>
+            @endforelse
+        @endif
+    </div>
+</div>

--- a/resources/views/livewire/coach/partials/session-card.blade.php
+++ b/resources/views/livewire/coach/partials/session-card.blade.php
@@ -1,0 +1,96 @@
+<div class="mb-4 rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        {{-- Left: session info --}}
+        <div class="flex-1">
+            <div class="flex items-center gap-2">
+                <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                    <a href="{{ route('sessions.show', $session) }}" class="hover:text-indigo-600 dark:hover:text-indigo-400" wire:navigate>
+                        {{ $session->title }}
+                    </a>
+                </h3>
+                {{-- Status badge --}}
+                @php
+                    $badgeColors = match($session->status->value) {
+                        'draft' => 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+                        'published' => 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300',
+                        'confirmed' => 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300',
+                        'completed' => 'bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300',
+                        'cancelled' => 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300',
+                        default => 'bg-gray-100 text-gray-700',
+                    };
+                @endphp
+                <span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium {{ $badgeColors }}">
+                    {{ $session->status->label() }}
+                </span>
+            </div>
+
+            <div class="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-500 dark:text-gray-400">
+                <span>{{ $session->activity_type->label() }}</span>
+                <span>{{ $session->date->translatedFormat('D j M Y') }}</span>
+                <span>{{ substr($session->start_time, 0, 5) }} – {{ substr($session->end_time, 0, 5) }}</span>
+                <span>{{ $session->location }}</span>
+            </div>
+
+            {{-- Participants + fill rate --}}
+            <div class="mt-2 flex items-center gap-3">
+                <span class="text-sm text-gray-600 dark:text-gray-300">
+                    {{ $session->current_participants }} / {{ $session->max_participants }}
+                </span>
+                @php
+                    $fillRate = $session->max_participants > 0
+                        ? round(($session->current_participants / $session->max_participants) * 100)
+                        : 0;
+                @endphp
+                <div class="h-2 w-24 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-600">
+                    <div class="h-full rounded-full {{ $fillRate >= 80 ? 'bg-green-500' : ($fillRate >= 50 ? 'bg-yellow-500' : 'bg-indigo-500') }}"
+                        style="width: {{ $fillRate }}%"></div>
+                </div>
+                <span class="text-xs text-gray-500 dark:text-gray-400">{{ $fillRate }}%</span>
+            </div>
+        </div>
+
+        {{-- Right: price + actions --}}
+        <div class="flex flex-col items-end gap-2">
+            <span class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                <x-money :cents="$session->price_per_person" />
+            </span>
+
+            @if ($showActions)
+                <div class="flex gap-2">
+                    @can('update', $session)
+                        <a href="{{ route('coach.sessions.edit', $session) }}"
+                            class="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                            wire:navigate>
+                            {{ __('common.edit') }}
+                        </a>
+                    @endcan
+
+                    @if ($session->status->value === 'draft')
+                        @can('update', $session)
+                            <button wire:click="publishSession({{ $session->id }})"
+                                wire:confirm="{{ __('coach.confirm_publish') }}"
+                                class="inline-flex items-center rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white shadow-sm hover:bg-blue-500">
+                                {{ __('coach.publish') }}
+                            </button>
+                        @endcan
+                        @can('delete', $session)
+                            <button wire:click="deleteSession({{ $session->id }})"
+                                wire:confirm="{{ __('coach.confirm_delete') }}"
+                                class="inline-flex items-center rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white shadow-sm hover:bg-red-500">
+                                {{ __('common.delete') }}
+                            </button>
+                        @endcan
+                    @endif
+
+                    @can('cancel', $session)
+                        <button wire:click="cancelSession({{ $session->id }})"
+                            wire:confirm="{{ __('coach.confirm_cancel') }}"
+                            class="inline-flex items-center rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white shadow-sm hover:bg-red-500">
+                            {{ __('common.cancel') }}
+                        </button>
+                    @endcan
+                </div>
+            @endif
+        </div>
+    </div>
+</div>

--- a/routes/web/coach.php
+++ b/routes/web/coach.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
+use App\Livewire\Coach\Dashboard as CoachDashboard;
 use App\Livewire\Session\Create as SessionCreate;
 use App\Livewire\Session\Edit as SessionEdit;
 use Illuminate\Support\Facades\Route;
 
+Route::get('/dashboard', CoachDashboard::class)->name('dashboard');
 Route::get('/sessions/create', SessionCreate::class)->name('sessions.create');
 Route::get('/sessions/{sportSession}/edit', SessionEdit::class)->name('sessions.edit');

--- a/tests/Feature/Livewire/Coach/DashboardTest.php
+++ b/tests/Feature/Livewire/Coach/DashboardTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\SessionStatus;
+use App\Livewire\Coach\Dashboard;
+use App\Models\SportSession;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+describe('coach dashboard', function () {
+    it('renders for a coach', function () {
+        $coach = User::factory()->coach()->create();
+
+        $this->actingAs($coach)
+            ->get(route('coach.dashboard'))
+            ->assertOk();
+    });
+
+    it('does not render for an athlete', function () {
+        $athlete = User::factory()->athlete()->create();
+
+        $this->actingAs($athlete)
+            ->get(route('coach.dashboard'))
+            ->assertForbidden();
+    });
+
+    it('shows upcoming published sessions', function () {
+        $coach = User::factory()->coach()->create();
+        $upcoming = SportSession::factory()->published()->create([
+            'coach_id' => $coach->id,
+            'title' => 'Upcoming Yoga',
+            'date' => now()->addDays(3),
+        ]);
+
+        Livewire::actingAs($coach)
+            ->test(Dashboard::class)
+            ->assertSee('Upcoming Yoga');
+    });
+
+    it('shows upcoming confirmed sessions', function () {
+        $coach = User::factory()->coach()->create();
+        SportSession::factory()->confirmed()->create([
+            'coach_id' => $coach->id,
+            'title' => 'Confirmed Run',
+            'date' => now()->addDays(5),
+        ]);
+
+        Livewire::actingAs($coach)
+            ->test(Dashboard::class)
+            ->assertSee('Confirmed Run');
+    });
+
+    it('shows draft sessions in drafts tab', function () {
+        $coach = User::factory()->coach()->create();
+        SportSession::factory()->draft()->create([
+            'coach_id' => $coach->id,
+            'title' => 'My Draft Session',
+        ]);
+
+        Livewire::actingAs($coach)
+            ->test(Dashboard::class)
+            ->set('tab', 'drafts')
+            ->assertSee('My Draft Session');
+    });
+
+    it('shows past completed sessions in past tab', function () {
+        $coach = User::factory()->coach()->create();
+        SportSession::factory()->completed()->create([
+            'coach_id' => $coach->id,
+            'title' => 'Old Completed Session',
+        ]);
+
+        Livewire::actingAs($coach)
+            ->test(Dashboard::class)
+            ->set('tab', 'past')
+            ->assertSee('Old Completed Session');
+    });
+
+    it('shows past cancelled sessions in past tab', function () {
+        $coach = User::factory()->coach()->create();
+        SportSession::factory()->cancelled()->create([
+            'coach_id' => $coach->id,
+            'title' => 'Old Cancelled Session',
+        ]);
+
+        Livewire::actingAs($coach)
+            ->test(Dashboard::class)
+            ->set('tab', 'past')
+            ->assertSee('Old Cancelled Session');
+    });
+
+    it('does not show other coaches sessions', function () {
+        $coach = User::factory()->coach()->create();
+        $otherCoach = User::factory()->coach()->create();
+
+        SportSession::factory()->published()->create([
+            'coach_id' => $otherCoach->id,
+            'title' => 'Not My Session',
+            'date' => now()->addDays(3),
+        ]);
+
+        Livewire::actingAs($coach)
+            ->test(Dashboard::class)
+            ->assertDontSee('Not My Session');
+    });
+
+    it('can publish a draft session', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->draft()->create([
+            'coach_id' => $coach->id,
+        ]);
+
+        Livewire::actingAs($coach)
+            ->test(Dashboard::class)
+            ->call('publishSession', $session->id)
+            ->assertDispatched('notify');
+
+        $session->refresh();
+        expect($session->status)->toBe(SessionStatus::Published);
+    });
+
+    it('can cancel a published session', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->published()->create([
+            'coach_id' => $coach->id,
+            'date' => now()->addDays(3),
+        ]);
+
+        Livewire::actingAs($coach)
+            ->test(Dashboard::class)
+            ->call('cancelSession', $session->id)
+            ->assertDispatched('notify');
+
+        $session->refresh();
+        expect($session->status)->toBe(SessionStatus::Cancelled);
+    });
+
+    it('can delete a draft session', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->draft()->create([
+            'coach_id' => $coach->id,
+        ]);
+
+        Livewire::actingAs($coach)
+            ->test(Dashboard::class)
+            ->call('deleteSession', $session->id)
+            ->assertDispatched('notify');
+
+        $this->assertDatabaseMissing('sport_sessions', ['id' => $session->id]);
+    });
+
+    it('shows empty state for upcoming when no sessions', function () {
+        $coach = User::factory()->coach()->create();
+
+        Livewire::actingAs($coach)
+            ->test(Dashboard::class)
+            ->assertSee(__('coach.no_upcoming'));
+    });
+});


### PR DESCRIPTION
## Summary

Implements the coach dashboard with session management, showing sessions grouped by status with quick actions.

### Changes

- **`app/Livewire/Coach/Dashboard.php`** — Livewire component with:
  - Tab navigation: Upcoming (published + confirmed, future dates), Drafts, Past (completed + cancelled)
  - Quick actions: `publishSession()`, `cancelSession()`, `deleteSession()` — all authorized via Gate and delegated to SessionService
  - Only shows the authenticated coach's own sessions
- **`resources/views/livewire/coach/dashboard.blade.php`** — Tab UI with counts, empty states, and session card rendering
- **`resources/views/livewire/coach/partials/session-card.blade.php`** — Reusable card partial showing:
  - Title (linked to session detail), status badge, activity type, date, time, location
  - Participant count with visual fill rate bar and percentage
  - Price via `<x-money>` component
  - Context-sensitive action buttons (edit, publish, cancel, delete) with confirmation dialogs
- **`routes/web/coach.php`** — Added `GET /coach/dashboard` route (`coach.dashboard`)
- **`lang/{en,fr,nl}/coach.php`** — Dashboard i18n keys (heading, tabs, empty states, confirmations)
- **`tests/Feature/Livewire/Coach/DashboardTest.php`** — 12 tests covering:
  - Access control (coach allowed, athlete blocked)
  - Correct session grouping by status/tab
  - Own sessions only (other coach's sessions hidden)
  - Quick actions (publish, cancel, delete)
  - Empty state display

### Testing

All 12 new tests pass. Full suite (445 tests) passes.

Resolves #63