### PR TITLE
E2-S13 · Coach profile view + edit

### DIFF
--- a/app/Livewire/Coach/Profile.php
+++ b/app/Livewire/Coach/Profile.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Coach;
+
+use App\Enums\CoachProfileStatus;
+use App\Enums\SessionStatus;
+use App\Enums\UserRole;
+use App\Models\SportSession;
+use App\Models\User;
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class Profile extends Component
+{
+    public User $user;
+
+    public function mount(User $user): void
+    {
+        if ($user->role !== UserRole::Coach) {
+            throw new NotFoundHttpException;
+        }
+
+        $this->user = $user;
+    }
+
+    public function render(): View
+    {
+        $profile = $this->user->coachProfile;
+
+        $upcomingSessions = SportSession::where('coach_id', $this->user->id)
+            ->whereIn('status', [SessionStatus::Published, SessionStatus::Confirmed])
+            ->where('date', '>=', now()->toDateString())
+            ->orderBy('date')
+            ->orderBy('start_time')
+            ->limit(6)
+            ->get();
+
+        return view('livewire.coach.profile', [
+            'profile' => $profile,
+            'upcomingSessions' => $upcomingSessions,
+            'isVerified' => $profile?->status === CoachProfileStatus::Approved,
+        ])->title($this->user->name.' — '.__('coach.profile_title'));
+    }
+}

--- a/app/Livewire/Coach/ProfileEdit.php
+++ b/app/Livewire/Coach/ProfileEdit.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Coach;
+
+use App\Livewire\Forms\CoachProfileForm;
+use App\Models\CoachProfile as CoachProfileModel;
+use App\Models\User;
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+
+final class ProfileEdit extends Component
+{
+    public CoachProfileForm $form;
+
+    public bool $isVatSubject = false;
+
+    public function mount(): void
+    {
+        /** @var User $user */
+        $user = auth()->user();
+        $profile = $user->coachProfile;
+
+        if ($profile !== null) {
+            $this->form->setFromModel($profile);
+            $this->isVatSubject = $profile->is_vat_subject ?? false;
+        }
+    }
+
+    public function save(): void
+    {
+        $this->form->validate();
+
+        /** @var User $user */
+        $user = auth()->user();
+        $profile = $user->coachProfile;
+
+        if ($profile === null) {
+            $profile = new CoachProfileModel;
+            $profile->user_id = $user->id;
+        }
+
+        $profile->fill($this->form->toServiceArray());
+        $profile->save();
+
+        $this->dispatch('notify', type: 'success', message: __('coach.profile_updated'));
+    }
+
+    public function render(): View
+    {
+        return view('livewire.coach.profile-edit')
+            ->title(__('coach.profile_edit_title'));
+    }
+}

--- a/app/Livewire/Forms/CoachProfileForm.php
+++ b/app/Livewire/Forms/CoachProfileForm.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Forms;
+
+use App\Models\CoachProfile;
+use Livewire\Attributes\Validate;
+use Livewire\Form;
+
+final class CoachProfileForm extends Form
+{
+    /** @var array<int, string> */
+    #[Validate('required|array|min:1')]
+    public array $specialties = [];
+
+    #[Validate('required|string|max:2000')]
+    public string $bio = '';
+
+    #[Validate('required|string|in:beginner,intermediate,advanced,expert')]
+    public string $experienceLevel = '';
+
+    #[Validate('required|string|regex:/^[1-9]\d{3}$/')]
+    public string $postalCode = '';
+
+    #[Validate('nullable|string|max:50')]
+    public string $enterpriseNumber = '';
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toServiceArray(): array
+    {
+        return [
+            'specialties' => $this->specialties,
+            'bio' => $this->bio,
+            'experience_level' => $this->experienceLevel,
+            'postal_code' => $this->postalCode,
+            'enterprise_number' => $this->enterpriseNumber,
+        ];
+    }
+
+    public function setFromModel(CoachProfile $profile): void
+    {
+        $this->specialties = $profile->specialties ?? [];
+        $this->bio = $profile->bio ?? '';
+        $this->experienceLevel = $profile->experience_level ?? '';
+        $this->postalCode = $profile->postal_code ?? '';
+        $this->enterpriseNumber = $profile->enterprise_number ?? '';
+    }
+}

--- a/lang/en/coach.php
+++ b/lang/en/coach.php
@@ -86,4 +86,22 @@ return [
     'stat_avg_fill_rate' => 'Avg Fill Rate',
     'stat_total_revenue' => 'Total Revenue',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Coach Profile
+    |--------------------------------------------------------------------------
+    */
+
+    'profile_title' => 'Coach Profile',
+    'profile_edit_title' => 'Edit Coach Profile',
+    'profile_edit_heading' => 'Edit My Coach Profile',
+    'profile_updated' => 'Profile updated successfully.',
+    'verified_badge' => 'Verified',
+    'upcoming_sessions' => 'Upcoming Sessions',
+    'no_upcoming_public' => 'No upcoming sessions.',
+    'vat_subject_label' => 'VAT Subject',
+    'vat_subject_yes' => 'Yes — VAT registered',
+    'vat_subject_no' => 'No — Small business / Franchise regime',
+    'vat_subject_hint' => 'This field is managed by the platform administrator.',
+
 ];

--- a/lang/fr/coach.php
+++ b/lang/fr/coach.php
@@ -86,4 +86,22 @@ return [
     'stat_avg_fill_rate' => 'Taux de remplissage',
     'stat_total_revenue' => 'Revenu total',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Coach Profile
+    |--------------------------------------------------------------------------
+    */
+
+    'profile_title' => 'Profil Coach',
+    'profile_edit_title' => 'Modifier le profil Coach',
+    'profile_edit_heading' => 'Modifier mon profil Coach',
+    'profile_updated' => 'Profil mis \u00e0 jour avec succ\u00e8s.',
+    'verified_badge' => 'V\u00e9rifi\u00e9',
+    'upcoming_sessions' => 'S\u00e9ances \u00e0 venir',
+    'no_upcoming_public' => 'Aucune s\u00e9ance \u00e0 venir.',
+    'vat_subject_label' => 'Assujetti TVA',
+    'vat_subject_yes' => 'Oui \u2014 Assujetti \u00e0 la TVA',
+    'vat_subject_no' => 'Non \u2014 Petite entreprise / R\u00e9gime de franchise',
+    'vat_subject_hint' => 'Ce champ est g\u00e9r\u00e9 par l\u2019administrateur de la plateforme.',
+
 ];

--- a/lang/nl/coach.php
+++ b/lang/nl/coach.php
@@ -86,4 +86,22 @@ return [
     'stat_avg_fill_rate' => 'Gem. bezettingsgraad',
     'stat_total_revenue' => 'Totale omzet',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Coach Profile
+    |--------------------------------------------------------------------------
+    */
+
+    'profile_title' => 'Coachprofiel',
+    'profile_edit_title' => 'Coachprofiel bewerken',
+    'profile_edit_heading' => 'Mijn coachprofiel bewerken',
+    'profile_updated' => 'Profiel succesvol bijgewerkt.',
+    'verified_badge' => 'Geverifieerd',
+    'upcoming_sessions' => 'Aankomende sessies',
+    'no_upcoming_public' => 'Geen aankomende sessies.',
+    'vat_subject_label' => 'BTW-plichtig',
+    'vat_subject_yes' => 'Ja \u2014 BTW-geregistreerd',
+    'vat_subject_no' => 'Nee \u2014 Kleine onderneming / Vrijstellingsregeling',
+    'vat_subject_hint' => 'Dit veld wordt beheerd door de platformbeheerder.',
+
 ];

--- a/resources/views/livewire/coach/profile-edit.blade.php
+++ b/resources/views/livewire/coach/profile-edit.blade.php
@@ -1,0 +1,85 @@
+<div class="mx-auto max-w-2xl px-4 py-6 sm:px-6 lg:px-8">
+    <h1 class="mb-6 text-2xl font-bold text-gray-900 dark:text-gray-100">{{ __('coach.profile_edit_heading') }}</h1>
+
+    <form wire:submit="save" class="space-y-6">
+        {{-- Specialties --}}
+        <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('coach.specialties_label') }}</label>
+            <p class="mb-2 text-xs text-gray-500 dark:text-gray-400">{{ __('coach.specialties_hint') }}</p>
+            <div class="flex flex-wrap gap-2">
+                @php
+                    $allSpecialties = ['fitness', 'yoga', 'running', 'cycling', 'swimming', 'boxing', 'dance', 'pilates', 'crossfit', 'martial_arts', 'tennis', 'other'];
+                @endphp
+                @foreach ($allSpecialties as $specialty)
+                    <label class="inline-flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition
+                        {{ in_array($specialty, $form->specialties) ? 'border-indigo-600 bg-indigo-50 text-indigo-700 dark:border-indigo-400 dark:bg-indigo-900 dark:text-indigo-300' : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700' }}">
+                        <input type="checkbox" wire:model.live="form.specialties" value="{{ $specialty }}" class="sr-only" />
+                        {{ __('coach.specialty_' . $specialty) }}
+                    </label>
+                @endforeach
+            </div>
+            @error('form.specialties') <p class="mt-1 text-sm text-red-600">{{ $message }}</p> @enderror
+        </div>
+
+        {{-- Bio --}}
+        <div>
+            <label for="bio" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('coach.bio_label') }}</label>
+            <textarea id="bio" wire:model="form.bio" rows="4"
+                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 sm:text-sm"
+                placeholder="{{ __('coach.bio_placeholder') }}"></textarea>
+            @error('form.bio') <p class="mt-1 text-sm text-red-600">{{ $message }}</p> @enderror
+        </div>
+
+        {{-- Experience Level --}}
+        <div>
+            <label for="experience_level" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('coach.experience_level_label') }}</label>
+            <select id="experience_level" wire:model="form.experienceLevel"
+                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 sm:text-sm">
+                <option value="">{{ __('coach.experience_select') }}</option>
+                <option value="beginner">{{ __('coach.experience_beginner') }}</option>
+                <option value="intermediate">{{ __('coach.experience_intermediate') }}</option>
+                <option value="advanced">{{ __('coach.experience_advanced') }}</option>
+                <option value="expert">{{ __('coach.experience_expert') }}</option>
+            </select>
+            @error('form.experienceLevel') <p class="mt-1 text-sm text-red-600">{{ $message }}</p> @enderror
+        </div>
+
+        {{-- Postal Code --}}
+        <div>
+            <label for="postal_code" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('coach.postal_code_label') }}</label>
+            <input id="postal_code" type="text" wire:model="form.postalCode"
+                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 sm:text-sm" />
+            @error('form.postalCode') <p class="mt-1 text-sm text-red-600">{{ $message }}</p> @enderror
+        </div>
+
+        {{-- Enterprise Number --}}
+        <div>
+            <label for="enterprise_number" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('coach.enterprise_number_label') }}</label>
+            <p class="mb-1 text-xs text-gray-500 dark:text-gray-400">{{ __('coach.enterprise_number_hint') }}</p>
+            <input id="enterprise_number" type="text" wire:model="form.enterpriseNumber"
+                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 sm:text-sm" />
+            @error('form.enterpriseNumber') <p class="mt-1 text-sm text-red-600">{{ $message }}</p> @enderror
+        </div>
+
+        {{-- VAT Subject (read-only) --}}
+        <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('coach.vat_subject_label') }}</label>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                {{ $isVatSubject ? __('coach.vat_subject_yes') : __('coach.vat_subject_no') }}
+            </p>
+            <p class="mt-0.5 text-xs text-gray-400 dark:text-gray-500">{{ __('coach.vat_subject_hint') }}</p>
+        </div>
+
+        {{-- Submit --}}
+        <div class="flex items-center gap-4">
+            <button type="submit"
+                class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+                {{ __('common.save') }}
+            </button>
+            <a href="{{ route('coaches.show', auth()->user()) }}"
+                class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300" wire:navigate>
+                {{ __('common.cancel') }}
+            </a>
+        </div>
+    </form>
+</div>

--- a/resources/views/livewire/coach/profile.blade.php
+++ b/resources/views/livewire/coach/profile.blade.php
@@ -1,0 +1,69 @@
+<div class="mx-auto max-w-4xl px-4 py-6 sm:px-6 lg:px-8">
+    {{-- Coach header --}}
+    <div class="mb-8 rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-center">
+            <div class="flex h-20 w-20 items-center justify-center rounded-full bg-indigo-100 text-2xl font-bold text-indigo-600 dark:bg-indigo-900 dark:text-indigo-300">
+                {{ strtoupper(substr($user->name, 0, 1)) }}
+            </div>
+            <div class="flex-1">
+                <div class="flex items-center gap-2">
+                    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ $user->name }}</h1>
+                    @if ($isVerified)
+                        <span class="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900 dark:text-green-300">
+                            {{ __('coach.verified_badge') }}
+                        </span>
+                    @endif
+                </div>
+                @if ($profile?->bio)
+                    <p class="mt-2 text-gray-600 dark:text-gray-300">{{ $profile->bio }}</p>
+                @endif
+            </div>
+        </div>
+
+        @if ($profile)
+            <div class="mt-4 flex flex-wrap gap-4 border-t border-gray-200 pt-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                @if ($profile->specialties)
+                    <div>
+                        <span class="font-medium text-gray-700 dark:text-gray-300">{{ __('coach.specialties_label') }}:</span>
+                        @foreach ($profile->specialties as $specialty)
+                            <span class="ml-1 inline-flex items-center rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300">
+                                {{ __('coach.specialty_' . $specialty) }}
+                            </span>
+                        @endforeach
+                    </div>
+                @endif
+                @if ($profile->experience_level)
+                    <div>
+                        <span class="font-medium text-gray-700 dark:text-gray-300">{{ __('coach.experience_level_label') }}:</span>
+                        {{ __('coach.experience_' . $profile->experience_level) }}
+                    </div>
+                @endif
+                @if ($profile->postal_code)
+                    <div>
+                        <span class="font-medium text-gray-700 dark:text-gray-300">{{ __('coach.postal_code_label') }}:</span>
+                        {{ $profile->postal_code }}
+                    </div>
+                @endif
+            </div>
+        @endif
+    </div>
+
+    {{-- Upcoming sessions --}}
+    @if ($upcomingSessions->isNotEmpty())
+        <h2 class="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">{{ __('coach.upcoming_sessions') }}</h2>
+        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            @foreach ($upcomingSessions as $session)
+                <a href="{{ route('sessions.show', $session) }}" wire:navigate
+                    class="block rounded-lg border border-gray-200 bg-white p-4 shadow-sm transition hover:shadow-md dark:border-gray-700 dark:bg-gray-800">
+                    <h3 class="font-semibold text-gray-900 dark:text-gray-100">{{ $session->title }}</h3>
+                    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ $session->activity_type->label() }}</p>
+                    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ $session->date->translatedFormat('D j M Y') }}</p>
+                    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ substr($session->start_time, 0, 5) }} – {{ substr($session->end_time, 0, 5) }}</p>
+                    <p class="mt-2 font-semibold text-gray-900 dark:text-gray-100"><x-money :cents="$session->price_per_person" /></p>
+                </a>
+            @endforeach
+        </div>
+    @else
+        <p class="py-8 text-center text-gray-500 dark:text-gray-400">{{ __('coach.no_upcoming_public') }}</p>
+    @endif
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Livewire\Auth\ResetPassword;
 use App\Livewire\Auth\TwoFactorChallenge;
 use App\Livewire\Auth\VerifyEmail;
 use App\Livewire\Coach\Application as CoachApplication;
+use App\Livewire\Coach\Profile as CoachProfile;
 use App\Livewire\Profile\Edit as ProfileEdit;
 use App\Livewire\Session\Show as SessionShow;
 use Illuminate\Support\Facades\DB;
@@ -46,6 +47,9 @@ Route::get('/coach/apply', CoachApplication::class)
 Route::get('/sessions/{sportSession}', SessionShow::class)
     ->middleware('auth')
     ->name('sessions.show');
+
+Route::get('/coaches/{user}', CoachProfile::class)
+    ->name('coaches.show');
 
 Route::get('/health', function () {
     $checks = ['status' => 'ok'];

--- a/routes/web/coach.php
+++ b/routes/web/coach.php
@@ -3,10 +3,12 @@
 declare(strict_types=1);
 
 use App\Livewire\Coach\Dashboard as CoachDashboard;
+use App\Livewire\Coach\ProfileEdit as CoachProfileEdit;
 use App\Livewire\Session\Create as SessionCreate;
 use App\Livewire\Session\Edit as SessionEdit;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/dashboard', CoachDashboard::class)->name('dashboard');
+Route::get('/profile/edit', CoachProfileEdit::class)->name('profile.edit');
 Route::get('/sessions/create', SessionCreate::class)->name('sessions.create');
 Route::get('/sessions/{sportSession}/edit', SessionEdit::class)->name('sessions.edit');

--- a/tests/Feature/Livewire/Coach/ProfileEditTest.php
+++ b/tests/Feature/Livewire/Coach/ProfileEditTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Coach\ProfileEdit;
+use App\Models\CoachProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+describe('coach profile edit', function () {
+    it('renders for a coach', function () {
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->approved()->create(['user_id' => $coach->id]);
+
+        $this->actingAs($coach)
+            ->get(route('coach.profile.edit'))
+            ->assertOk();
+    });
+
+    it('does not render for an athlete', function () {
+        $athlete = User::factory()->athlete()->create();
+
+        $this->actingAs($athlete)
+            ->get(route('coach.profile.edit'))
+            ->assertForbidden();
+    });
+
+    it('prefills form from existing profile', function () {
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->approved()->create([
+            'user_id' => $coach->id,
+            'bio' => 'My coaching bio.',
+            'experience_level' => 'advanced',
+            'postal_code' => '1000',
+            'specialties' => ['yoga', 'fitness'],
+        ]);
+
+        Livewire::actingAs($coach)
+            ->test(ProfileEdit::class)
+            ->assertSet('form.bio', 'My coaching bio.')
+            ->assertSet('form.experienceLevel', 'advanced')
+            ->assertSet('form.postalCode', '1000')
+            ->assertSet('form.specialties', ['yoga', 'fitness']);
+    });
+
+    it('saves profile updates', function () {
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->approved()->create([
+            'user_id' => $coach->id,
+            'bio' => 'Old bio.',
+            'experience_level' => 'beginner',
+            'postal_code' => '1000',
+            'specialties' => ['yoga'],
+        ]);
+
+        Livewire::actingAs($coach)
+            ->test(ProfileEdit::class)
+            ->set('form.bio', 'Updated bio.')
+            ->set('form.experienceLevel', 'expert')
+            ->set('form.postalCode', '1050')
+            ->set('form.specialties', ['yoga', 'running'])
+            ->set('form.enterpriseNumber', '0123.456.789')
+            ->call('save')
+            ->assertDispatched('notify');
+
+        $coach->refresh();
+        $profile = $coach->coachProfile;
+        expect($profile->bio)->toBe('Updated bio.');
+        expect($profile->experience_level)->toBe('expert');
+        expect($profile->postal_code)->toBe('1050');
+        expect($profile->specialties)->toBe(['yoga', 'running']);
+        expect($profile->enterprise_number)->toBe('0123.456.789');
+    });
+
+    it('validates required fields', function () {
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->approved()->create(['user_id' => $coach->id]);
+
+        Livewire::actingAs($coach)
+            ->test(ProfileEdit::class)
+            ->set('form.bio', '')
+            ->set('form.experienceLevel', '')
+            ->set('form.postalCode', '')
+            ->set('form.specialties', [])
+            ->call('save')
+            ->assertHasErrors(['form.bio', 'form.experienceLevel', 'form.postalCode', 'form.specialties']);
+    });
+
+    it('does not allow editing is_vat_subject', function () {
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->approved()->vatSubject()->create(['user_id' => $coach->id]);
+
+        // isVatSubject is read-only — set from model, not editable
+        Livewire::actingAs($coach)
+            ->test(ProfileEdit::class)
+            ->assertSet('isVatSubject', true);
+    });
+
+    it('creates profile if none exists', function () {
+        $coach = User::factory()->coach()->create();
+
+        Livewire::actingAs($coach)
+            ->test(ProfileEdit::class)
+            ->set('form.bio', 'New bio.')
+            ->set('form.experienceLevel', 'intermediate')
+            ->set('form.postalCode', '1000')
+            ->set('form.specialties', ['fitness'])
+            ->call('save')
+            ->assertDispatched('notify');
+
+        $coach->refresh();
+        expect($coach->coachProfile)->not->toBeNull();
+        expect($coach->coachProfile->bio)->toBe('New bio.');
+    });
+});

--- a/tests/Feature/Livewire/Coach/ProfileTest.php
+++ b/tests/Feature/Livewire/Coach/ProfileTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Coach\Profile;
+use App\Models\CoachProfile;
+use App\Models\SportSession;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+describe('coach public profile', function () {
+    it('renders for a coach user', function () {
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->approved()->create(['user_id' => $coach->id]);
+
+        $this->get(route('coaches.show', $coach))
+            ->assertOk();
+    });
+
+    it('returns 404 for a non-coach user', function () {
+        $athlete = User::factory()->athlete()->create();
+
+        $this->get(route('coaches.show', $athlete))
+            ->assertNotFound();
+    });
+
+    it('displays coach name and bio', function () {
+        $coach = User::factory()->coach()->create(['name' => 'Coach Alice']);
+        CoachProfile::factory()->approved()->create([
+            'user_id' => $coach->id,
+            'bio' => 'Experienced fitness coach.',
+        ]);
+
+        Livewire::test(Profile::class, ['user' => $coach])
+            ->assertSee('Coach Alice')
+            ->assertSee('Experienced fitness coach.');
+    });
+
+    it('shows verified badge for approved coaches', function () {
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->approved()->create(['user_id' => $coach->id]);
+
+        Livewire::test(Profile::class, ['user' => $coach])
+            ->assertSee(__('coach.verified_badge'));
+    });
+
+    it('does not show verified badge for pending coaches', function () {
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->pending()->create(['user_id' => $coach->id]);
+
+        Livewire::test(Profile::class, ['user' => $coach])
+            ->assertDontSee(__('coach.verified_badge'));
+    });
+
+    it('shows coach specialties', function () {
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->approved()->create([
+            'user_id' => $coach->id,
+            'specialties' => ['yoga', 'fitness'],
+        ]);
+
+        Livewire::test(Profile::class, ['user' => $coach])
+            ->assertSee(__('coach.specialty_yoga'))
+            ->assertSee(__('coach.specialty_fitness'));
+    });
+
+    it('shows upcoming published sessions', function () {
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->approved()->create(['user_id' => $coach->id]);
+
+        SportSession::factory()->published()->create([
+            'coach_id' => $coach->id,
+            'title' => 'Morning Yoga',
+            'date' => now()->addDays(3),
+        ]);
+
+        Livewire::test(Profile::class, ['user' => $coach])
+            ->assertSee('Morning Yoga');
+    });
+
+    it('does not show draft sessions on public profile', function () {
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->approved()->create(['user_id' => $coach->id]);
+
+        SportSession::factory()->draft()->create([
+            'coach_id' => $coach->id,
+            'title' => 'Secret Draft',
+        ]);
+
+        Livewire::test(Profile::class, ['user' => $coach])
+            ->assertDontSee('Secret Draft');
+    });
+
+    it('shows empty state when no upcoming sessions', function () {
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->approved()->create(['user_id' => $coach->id]);
+
+        Livewire::test(Profile::class, ['user' => $coach])
+            ->assertSee(__('coach.no_upcoming_public'));
+    });
+});


### PR DESCRIPTION
## Summary

Implements the public coach profile page and the coach's own profile edit page.

### Changes

#### Public Profile (`GET /coaches/{user}` — `coaches.show`)
- **`app/Livewire/Coach/Profile.php`** — Public-facing Livewire component:
  - Shows coach name with initial avatar, bio, verified badge (for approved coaches)
  - Displays specialties as tags, experience level, postal code
  - Lists up to 6 upcoming published/confirmed sessions as linked cards
  - Returns 404 for non-coach users
- **`resources/views/livewire/coach/profile.blade.php`** — Responsive profile layout with session cards grid

#### Profile Edit (`GET /coach/profile/edit` — `coach.profile.edit`)
- **`app/Livewire/Coach/ProfileEdit.php`** — Authenticated edit component:
  - Prefills form from existing CoachProfile
  - Creates new profile if none exists
  - `is_vat_subject` displayed as read-only (admin-managed)
- **`app/Livewire/Forms/CoachProfileForm.php`** — Form Object with:
  - Validated fields: specialties (array, min 1), bio, experience_level, postal_code, enterprise_number
  - `toServiceArray()` and `setFromModel()` methods
- **`resources/views/livewire/coach/profile-edit.blade.php`** — Edit form with:
  - Interactive specialty chips with `wire:model.live`
  - Select dropdown for experience level
  - Postal code and enterprise number inputs
  - Read-only VAT subject display

#### Routes & i18n
- **`routes/web.php`** — `GET /coaches/{user}` (public, no auth required)
- **`routes/web/coach.php`** — `GET /coach/profile/edit` (coach-only, `coach.profile.edit`)
- **`lang/{en,fr,nl}/coach.php`** — 12 new profile keys per locale

### Tests (16 new)

**Profile view (9 tests):**
- Renders for coach, 404 for non-coach
- Displays name, bio, verified badge (approved vs pending)
- Shows specialties, upcoming published sessions
- Hides draft sessions, shows empty state

**Profile edit (7 tests):**
- Renders for coach, forbidden for athlete
- Prefills form from existing profile
- Saves updates successfully
- Validates required fields
- Read-only `is_vat_subject`
- Creates profile if none exists

### Testing

All 16 new tests pass. Full suite (468 tests) passes.

Resolves #65