### PR TITLE
Fix: Link coach name to profile on session detail page (#155)

### DIFF
--- a/resources/views/livewire/session/show.blade.php
+++ b/resources/views/livewire/session/show.blade.php
@@ -32,7 +32,7 @@
 
         <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
             {{ __('sessions.by_coach') }}
-            <a href="#" class="font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400">
+            <a href="{{ route('coaches.show', $sportSession->coach) }}" class="font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400" wire:navigate>
                 {{ $sportSession->coach->name }}
             </a>
         </p>

--- a/tests/Feature/Livewire/Session/ShowTest.php
+++ b/tests/Feature/Livewire/Session/ShowTest.php
@@ -110,6 +110,19 @@ describe('session detail page', function () {
             ->assertViewHas('spotsRemaining', 3);
     });
 
+    it('links coach name to coach profile page', function () {
+        $athlete = User::factory()->athlete()->create();
+        $coach = User::factory()->coach()->create(['name' => 'Coach Bob']);
+        $session = SportSession::factory()->published()->create([
+            'coach_id' => $coach->id,
+        ]);
+
+        Livewire::actingAs($athlete)
+            ->test(Show::class, ['sportSession' => $session])
+            ->assertSee('Coach Bob')
+            ->assertSeeHtml(route('coaches.show', $coach));
+    });
+
     it('requires authentication', function () {
         $session = SportSession::factory()->published()->create();
 


### PR DESCRIPTION
## Summary

The session detail page had a dead `href="#"` for the coach name link. Now links to the coach's public profile page via `route('coaches.show', $sportSession->coach)`.

## Changes

- **`resources/views/livewire/session/show.blade.php`**: Replace `href="#"` with `route('coaches.show', $sportSession->coach)` and add `wire:navigate`
- **`tests/Feature/Livewire/Session/ShowTest.php`**: Add test asserting the coach profile URL is rendered

Resolves #155