### PR TITLE
Feat: Recurring session group editing — this only vs all future (#156)

### DIFF
--- a/app/Livewire/Session/Edit.php
+++ b/app/Livewire/Session/Edit.php
@@ -20,12 +20,17 @@ final class Edit extends Component
 
     public SportSession $sportSession;
 
+    public bool $isRecurring = false;
+
+    public string $editScope = 'this';
+
     public function mount(SportSession $sportSession): void
     {
         Gate::authorize('update', $sportSession);
 
         $this->sportSession = $sportSession;
         $this->form->setFromModel($sportSession);
+        $this->isRecurring = $sportSession->recurrence_group_id !== null;
     }
 
     public function save(SessionService $service): void
@@ -34,9 +39,16 @@ final class Edit extends Component
 
         $this->form->validate();
 
-        $service->update($this->sportSession, $this->form->toServiceArray());
+        if ($this->isRecurring && $this->editScope === 'all_future') {
+            $count = $service->updateGroup($this->sportSession, $this->form->toServiceArray());
 
-        $this->dispatch('notify', type: 'success', message: __('sessions.updated'));
+            $this->dispatch('notify', type: 'success', message: __('sessions.group_updated', ['count' => $count]));
+        } else {
+            $service->update($this->sportSession, $this->form->toServiceArray());
+
+            $this->dispatch('notify', type: 'success', message: __('sessions.updated'));
+        }
+
         $this->redirect(route('sessions.show', $this->sportSession), navigate: true);
     }
 

--- a/app/Services/SessionService.php
+++ b/app/Services/SessionService.php
@@ -112,6 +112,39 @@ final class SessionService
     }
 
     /**
+     * Update all future sessions in a recurrence group.
+     *
+     * Only updates sessions with date >= today that are in draft or published status.
+     *
+     * @param  array<string, mixed>  $data  Fields to update (date/time excluded — each session keeps its own schedule)
+     * @return int Number of sessions updated
+     */
+    public function updateGroup(SportSession $session, array $data): int
+    {
+        if ($session->recurrence_group_id === null) {
+            throw new InvalidArgumentException('Session does not belong to a recurrence group.');
+        }
+
+        $updatableFields = [
+            'activity_type' => $data['activity_type'],
+            'level' => $data['level'],
+            'title' => $data['title'],
+            'description' => $data['description'] ?? null,
+            'location' => $data['location'],
+            'postal_code' => $data['postal_code'],
+            'price_per_person' => $data['price_per_person'],
+            'min_participants' => $data['min_participants'],
+            'max_participants' => $data['max_participants'],
+            'cover_image_id' => $data['cover_image_id'] ?? null,
+        ];
+
+        return SportSession::where('recurrence_group_id', $session->recurrence_group_id)
+            ->where('date', '>=', now()->toDateString())
+            ->whereIn('status', [SessionStatus::Draft, SessionStatus::Published])
+            ->update($updatableFields);
+    }
+
+    /**
      * Delete a draft session (hard delete).
      */
     public function delete(SportSession $session): void

--- a/lang/en/sessions.php
+++ b/lang/en/sessions.php
@@ -101,5 +101,9 @@ return [
     'number_of_weeks' => 'Number of weeks',
     'recurring_hint' => 'Creates individual sessions for each week (max 12 weeks).',
     'recurring_created' => ':count recurring sessions created successfully.',
+    'recurring_edit_prompt' => 'This session is part of a recurring group. What would you like to edit?',
+    'edit_this_only' => 'This session only',
+    'edit_all_future' => 'All future sessions in this group',
+    'group_updated' => ':count sessions updated successfully.',
 
 ];

--- a/lang/fr/sessions.php
+++ b/lang/fr/sessions.php
@@ -100,6 +100,8 @@ return [
     'repeat_weekly' => 'Répéter chaque semaine',
     'number_of_weeks' => 'Nombre de semaines',
     'recurring_hint' => 'Crée des séances individuelles pour chaque semaine (max 12 semaines).',
-    'recurring_created' => ':count séances récurrentes créées avec succès.',
-
+    'recurring_created' => ':count séances récurrentes créées avec succès.',    'recurring_edit_prompt' => 'Cette session fait partie d\'un groupe récurrent. Que souhaitez-vous modifier ?',
+    'edit_this_only' => 'Cette session uniquement',
+    'edit_all_future' => 'Toutes les sessions futures de ce groupe',
+    'group_updated' => ':count sessions mises à jour avec succès.',
 ];

--- a/lang/nl/sessions.php
+++ b/lang/nl/sessions.php
@@ -100,6 +100,8 @@ return [
     'repeat_weekly' => 'Wekelijks herhalen',
     'number_of_weeks' => 'Aantal weken',
     'recurring_hint' => 'Maakt individuele sessies aan voor elke week (max 12 weken).',
-    'recurring_created' => ':count terugkerende sessies succesvol aangemaakt.',
-
+    'recurring_created' => ':count terugkerende sessies succesvol aangemaakt.',    'recurring_edit_prompt' => 'Deze sessie maakt deel uit van een terugkerende groep. Wat wilt u bewerken?',
+    'edit_this_only' => 'Alleen deze sessie',
+    'edit_all_future' => 'Alle toekomstige sessies in deze groep',
+    'group_updated' => ':count sessies bijgewerkt.',
 ];

--- a/resources/views/livewire/session/edit.blade.php
+++ b/resources/views/livewire/session/edit.blade.php
@@ -3,6 +3,27 @@
         {{ __('sessions.edit_heading') }}
     </h1>
 
+    {{-- Recurring session edit scope --}}
+    @if ($isRecurring)
+        <div class="mt-4 rounded-lg border border-indigo-200 bg-indigo-50 p-4 dark:border-indigo-800 dark:bg-indigo-900/30">
+            <p class="mb-3 text-sm font-medium text-indigo-800 dark:text-indigo-200">
+                {{ __('sessions.recurring_edit_prompt') }}
+            </p>
+            <div class="flex gap-4">
+                <label class="flex items-center gap-2">
+                    <input type="radio" wire:model="editScope" value="this"
+                        class="text-indigo-600 focus:ring-indigo-500">
+                    <span class="text-sm text-gray-700 dark:text-gray-300">{{ __('sessions.edit_this_only') }}</span>
+                </label>
+                <label class="flex items-center gap-2">
+                    <input type="radio" wire:model="editScope" value="all_future"
+                        class="text-indigo-600 focus:ring-indigo-500">
+                    <span class="text-sm text-gray-700 dark:text-gray-300">{{ __('sessions.edit_all_future') }}</span>
+                </label>
+            </div>
+        </div>
+    @endif
+
     <form wire:submit="save" class="mt-6 space-y-6">
         {{-- Activity type + level --}}
         <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">

--- a/tests/Feature/Livewire/Session/EditTest.php
+++ b/tests/Feature/Livewire/Session/EditTest.php
@@ -162,3 +162,134 @@ describe('session editing', function () {
             ->assertHasErrors(['form.title', 'form.location', 'form.postalCode']);
     });
 });
+
+describe('recurring session group editing', function () {
+    it('detects a recurring session and shows edit scope options', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->draft()->create([
+            'coach_id' => $coach->id,
+            'recurrence_group_id' => 'abc-123',
+        ]);
+
+        Livewire::actingAs($coach)
+            ->test(Edit::class, ['sportSession' => $session])
+            ->assertSet('isRecurring', true)
+            ->assertSet('editScope', 'this')
+            ->assertSee(__('sessions.recurring_edit_prompt'));
+    });
+
+    it('does not show edit scope for non-recurring sessions', function () {
+        $coach = User::factory()->coach()->create();
+        $session = SportSession::factory()->draft()->create([
+            'coach_id' => $coach->id,
+            'recurrence_group_id' => null,
+        ]);
+
+        Livewire::actingAs($coach)
+            ->test(Edit::class, ['sportSession' => $session])
+            ->assertSet('isRecurring', false)
+            ->assertDontSee(__('sessions.recurring_edit_prompt'));
+    });
+
+    it('updates only this session when edit scope is this', function () {
+        $coach = User::factory()->coach()->create();
+        $groupId = 'test-group-id';
+        $baseDate = now()->addDays(7);
+
+        $session1 = SportSession::factory()->draft()->create([
+            'coach_id' => $coach->id,
+            'recurrence_group_id' => $groupId,
+            'title' => 'Original',
+            'date' => $baseDate,
+        ]);
+        $session2 = SportSession::factory()->draft()->create([
+            'coach_id' => $coach->id,
+            'recurrence_group_id' => $groupId,
+            'title' => 'Original',
+            'date' => $baseDate->copy()->addWeek(),
+        ]);
+
+        Livewire::actingAs($coach)
+            ->test(Edit::class, ['sportSession' => $session1])
+            ->set('editScope', 'this')
+            ->set('form.title', 'Changed Title')
+            ->call('save')
+            ->assertDispatched('notify')
+            ->assertRedirect();
+
+        expect($session1->refresh()->title)->toBe('Changed Title');
+        expect($session2->refresh()->title)->toBe('Original');
+    });
+
+    it('updates all future sessions when edit scope is all_future', function () {
+        $coach = User::factory()->coach()->create();
+        $groupId = 'test-group-id';
+        $baseDate = now()->addDays(7);
+
+        $session1 = SportSession::factory()->draft()->create([
+            'coach_id' => $coach->id,
+            'recurrence_group_id' => $groupId,
+            'title' => 'Original',
+            'date' => $baseDate,
+        ]);
+        $session2 = SportSession::factory()->draft()->create([
+            'coach_id' => $coach->id,
+            'recurrence_group_id' => $groupId,
+            'title' => 'Original',
+            'date' => $baseDate->copy()->addWeek(),
+        ]);
+        $session3 = SportSession::factory()->published()->create([
+            'coach_id' => $coach->id,
+            'recurrence_group_id' => $groupId,
+            'title' => 'Original',
+            'date' => $baseDate->copy()->addWeeks(2),
+        ]);
+
+        Livewire::actingAs($coach)
+            ->test(Edit::class, ['sportSession' => $session1])
+            ->set('editScope', 'all_future')
+            ->set('form.title', 'Group Update')
+            ->call('save')
+            ->assertDispatched('notify')
+            ->assertRedirect();
+
+        expect($session1->refresh()->title)->toBe('Group Update');
+        expect($session2->refresh()->title)->toBe('Group Update');
+        expect($session3->refresh()->title)->toBe('Group Update');
+    });
+
+    it('does not update past or completed/cancelled sessions in group', function () {
+        $coach = User::factory()->coach()->create();
+        $groupId = 'test-group-id';
+
+        $futureSession = SportSession::factory()->draft()->create([
+            'coach_id' => $coach->id,
+            'recurrence_group_id' => $groupId,
+            'title' => 'Original',
+            'date' => now()->addDays(7),
+        ]);
+        $pastSession = SportSession::factory()->completed()->create([
+            'coach_id' => $coach->id,
+            'recurrence_group_id' => $groupId,
+            'title' => 'Original',
+            'date' => now()->subDays(7),
+        ]);
+        $cancelledSession = SportSession::factory()->cancelled()->create([
+            'coach_id' => $coach->id,
+            'recurrence_group_id' => $groupId,
+            'title' => 'Original',
+            'date' => now()->addDays(14),
+        ]);
+
+        Livewire::actingAs($coach)
+            ->test(Edit::class, ['sportSession' => $futureSession])
+            ->set('editScope', 'all_future')
+            ->set('form.title', 'Updated')
+            ->call('save')
+            ->assertDispatched('notify');
+
+        expect($futureSession->refresh()->title)->toBe('Updated');
+        expect($pastSession->refresh()->title)->toBe('Original');
+        expect($cancelledSession->refresh()->title)->toBe('Original');
+    });
+});


### PR DESCRIPTION
## Summary

Implements the missing E2-S09 acceptance criteria: when editing a session that belongs to a recurrence group, coaches can choose between "Edit this session only" and "Edit all future sessions in this group".

## Changes

### Service Layer
- **`app/Services/SessionService.php`**: Add `updateGroup()` method that bulk-updates all future sessions (date >= today, status = draft or published) in the same recurrence group. Date/time fields are excluded since each session keeps its own schedule.

### Livewire Component
- **`app/Livewire/Session/Edit.php`**: Add `isRecurring` and `editScope` properties. Detects recurring sessions on mount, delegates to `updateGroup()` when scope is `all_future`.

### UI
- **`resources/views/livewire/session/edit.blade.php`**: Shows a radio group for edit scope when the session belongs to a recurrence group.

### Localization
- `lang/en/sessions.php`, `lang/fr/sessions.php`, `lang/nl/sessions.php`: Add 4 new keys (`recurring_edit_prompt`, `edit_this_only`, `edit_all_future`, `group_updated`).

### Tests
- **`tests/Feature/Livewire/Session/EditTest.php`**: 5 new tests covering:
  - Recurring session detection and scope UI rendering
  - "This only" scope updates single session
  - "All future" scope updates all future draft/published sessions in group
  - Past/completed/cancelled sessions excluded from group update

All 474 tests pass.

Resolves #156