### PR TITLE
feat: E3-S01 · Booking model + migration (#68)

### DIFF
--- a/app/Enums/BookingStatus.php
+++ b/app/Enums/BookingStatus.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum BookingStatus: string
+{
+    case PendingPayment = 'pending_payment';
+    case Confirmed = 'confirmed';
+    case Cancelled = 'cancelled';
+    case Refunded = 'refunded';
+
+    public function label(): string
+    {
+        return __('bookings.status_'.$this->value);
+    }
+}

--- a/app/Models/Booking.php
+++ b/app/Models/Booking.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\BookingStatus;
+use Database\Factories\BookingFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Booking extends Model
+{
+    /** @use HasFactory<BookingFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'sport_session_id',
+        'athlete_id',
+        'status',
+        'stripe_payment_intent_id',
+        'amount_paid',
+        'cancelled_at',
+        'refunded_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'status' => BookingStatus::class,
+            'amount_paid' => 'integer',
+            'cancelled_at' => 'datetime',
+            'refunded_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<SportSession, $this>
+     */
+    public function sportSession(): BelongsTo
+    {
+        return $this->belongsTo(SportSession::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function athlete(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'athlete_id');
+    }
+}

--- a/app/Models/SportSession.php
+++ b/app/Models/SportSession.php
@@ -11,6 +11,7 @@ use Database\Factories\SportSessionFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class SportSession extends Model
 {
@@ -73,5 +74,13 @@ class SportSession extends Model
     public function coverImage(): BelongsTo
     {
         return $this->belongsTo(ActivityImage::class, 'cover_image_id');
+    }
+
+    /**
+     * @return HasMany<Booking, $this>
+     */
+    public function bookings(): HasMany
+    {
+        return $this->hasMany(Booking::class, 'sport_session_id');
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,6 +9,7 @@ use App\Enums\UserRole;
 use Database\Factories\UserFactory;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -65,5 +66,13 @@ class User extends Authenticatable implements MustVerifyEmail
     public function coachProfile(): HasOne
     {
         return $this->hasOne(CoachProfile::class);
+    }
+
+    /**
+     * @return HasMany<Booking, $this>
+     */
+    public function bookings(): HasMany
+    {
+        return $this->hasMany(Booking::class, 'athlete_id');
     }
 }

--- a/database/factories/BookingFactory.php
+++ b/database/factories/BookingFactory.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\BookingStatus;
+use App\Models\Booking;
+use App\Models\SportSession;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Booking>
+ */
+class BookingFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'sport_session_id' => SportSession::factory(),
+            'athlete_id' => User::factory()->athlete(),
+            'status' => BookingStatus::PendingPayment->value,
+            'amount_paid' => $this->faker->numberBetween(500, 5000),
+        ];
+    }
+
+    public function pendingPayment(): static
+    {
+        return $this->state(['status' => BookingStatus::PendingPayment->value]);
+    }
+
+    public function confirmed(): static
+    {
+        return $this->state(['status' => BookingStatus::Confirmed->value]);
+    }
+
+    public function cancelled(): static
+    {
+        return $this->state([
+            'status' => BookingStatus::Cancelled->value,
+            'cancelled_at' => now(),
+        ]);
+    }
+
+    public function refunded(): static
+    {
+        return $this->state([
+            'status' => BookingStatus::Refunded->value,
+            'refunded_at' => now(),
+        ]);
+    }
+}

--- a/database/migrations/2026_04_12_153752_create_bookings_table.php
+++ b/database/migrations/2026_04_12_153752_create_bookings_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('bookings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('sport_session_id')->constrained('sport_sessions')->cascadeOnDelete();
+            $table->foreignId('athlete_id')->constrained('users')->cascadeOnDelete();
+            $table->string('status')->default('pending_payment');
+            $table->string('stripe_payment_intent_id')->nullable();
+            $table->unsignedInteger('amount_paid')->default(0);
+            $table->timestamp('cancelled_at')->nullable();
+            $table->timestamp('refunded_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['sport_session_id', 'athlete_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('bookings');
+    }
+};

--- a/lang/en/bookings.php
+++ b/lang/en/bookings.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'status_pending_payment' => 'Pending Payment',
+    'status_confirmed' => 'Confirmed',
+    'status_cancelled' => 'Cancelled',
+    'status_refunded' => 'Refunded',
+];

--- a/lang/fr/bookings.php
+++ b/lang/fr/bookings.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'status_pending_payment' => 'En attente de paiement',
+    'status_confirmed' => 'Confirmée',
+    'status_cancelled' => 'Annulée',
+    'status_refunded' => 'Remboursée',
+];

--- a/lang/nl/bookings.php
+++ b/lang/nl/bookings.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'status_pending_payment' => 'In afwachting van betaling',
+    'status_confirmed' => 'Bevestigd',
+    'status_cancelled' => 'Geannuleerd',
+    'status_refunded' => 'Terugbetaald',
+];

--- a/tests/Unit/Enums/BookingStatusTest.php
+++ b/tests/Unit/Enums/BookingStatusTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\BookingStatus;
+
+describe('BookingStatus', function () {
+
+    it('has the correct backed string values', function () {
+        expect(BookingStatus::PendingPayment->value)->toBe('pending_payment');
+        expect(BookingStatus::Confirmed->value)->toBe('confirmed');
+        expect(BookingStatus::Cancelled->value)->toBe('cancelled');
+        expect(BookingStatus::Refunded->value)->toBe('refunded');
+    });
+
+    it('can be created from a string value', function () {
+        expect(BookingStatus::from('pending_payment'))->toBe(BookingStatus::PendingPayment);
+        expect(BookingStatus::from('confirmed'))->toBe(BookingStatus::Confirmed);
+        expect(BookingStatus::from('cancelled'))->toBe(BookingStatus::Cancelled);
+        expect(BookingStatus::from('refunded'))->toBe(BookingStatus::Refunded);
+    });
+
+    it('lists all four cases', function () {
+        expect(BookingStatus::cases())->toHaveCount(4);
+    });
+
+    it('returns a localized label for each case', function () {
+        app()->setLocale('en');
+
+        foreach (BookingStatus::cases() as $case) {
+            expect($case->label())->toBeString()->not->toBeEmpty();
+        }
+    });
+
+});

--- a/tests/Unit/Models/BookingTest.php
+++ b/tests/Unit/Models/BookingTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\BookingStatus;
+use App\Models\Booking;
+use App\Models\SportSession;
+use App\Models\User;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+
+uses(RefreshDatabase::class);
+
+describe('Booking model', function () {
+
+    it('creates a booking with factory defaults', function () {
+        $booking = Booking::factory()->create();
+
+        expect($booking)->toBeInstanceOf(Booking::class);
+        expect($booking->status)->toBe(BookingStatus::PendingPayment);
+        expect($booking->amount_paid)->toBeInt();
+    });
+
+    it('casts status to BookingStatus enum', function () {
+        $booking = Booking::factory()->create(['status' => 'confirmed']);
+
+        expect($booking->status)->toBe(BookingStatus::Confirmed);
+    });
+
+    it('casts amount_paid to integer', function () {
+        $booking = Booking::factory()->create(['amount_paid' => 1250]);
+
+        expect($booking->amount_paid)->toBe(1250)->toBeInt();
+    });
+
+    it('casts cancelled_at to datetime', function () {
+        $booking = Booking::factory()->cancelled()->create();
+
+        expect($booking->cancelled_at)->toBeInstanceOf(Carbon::class);
+    });
+
+    it('casts refunded_at to datetime', function () {
+        $booking = Booking::factory()->refunded()->create();
+
+        expect($booking->refunded_at)->toBeInstanceOf(Carbon::class);
+    });
+
+    it('belongs to a sport session', function () {
+        $session = SportSession::factory()->create();
+        $booking = Booking::factory()->create(['sport_session_id' => $session->id]);
+
+        expect($booking->sportSession)->toBeInstanceOf(SportSession::class);
+        expect($booking->sportSession->id)->toBe($session->id);
+    });
+
+    it('belongs to an athlete (user)', function () {
+        $athlete = User::factory()->athlete()->create();
+        $booking = Booking::factory()->create(['athlete_id' => $athlete->id]);
+
+        expect($booking->athlete)->toBeInstanceOf(User::class);
+        expect($booking->athlete->id)->toBe($athlete->id);
+    });
+
+    it('has a unique constraint on sport_session_id and athlete_id', function () {
+        $session = SportSession::factory()->create();
+        $athlete = User::factory()->athlete()->create();
+
+        Booking::factory()->create([
+            'sport_session_id' => $session->id,
+            'athlete_id' => $athlete->id,
+        ]);
+
+        expect(fn () => Booking::factory()->create([
+            'sport_session_id' => $session->id,
+            'athlete_id' => $athlete->id,
+        ]))->toThrow(UniqueConstraintViolationException::class);
+    });
+
+});
+
+describe('SportSession bookings relationship', function () {
+
+    it('has many bookings', function () {
+        $session = SportSession::factory()->create();
+        Booking::factory()->count(3)->create(['sport_session_id' => $session->id]);
+
+        expect($session->bookings)->toHaveCount(3);
+        expect($session->bookings->first())->toBeInstanceOf(Booking::class);
+    });
+
+});
+
+describe('User bookings relationship', function () {
+
+    it('has many bookings as athlete', function () {
+        $athlete = User::factory()->athlete()->create();
+        Booking::factory()->count(2)->create(['athlete_id' => $athlete->id]);
+
+        expect($athlete->bookings)->toHaveCount(2);
+        expect($athlete->bookings->first())->toBeInstanceOf(Booking::class);
+    });
+
+});


### PR DESCRIPTION
## E3-S01 · Booking model + migration

Closes #68

### Changes

- **`app/Enums/BookingStatus.php`** — Backed string enum: `pending_payment`, `confirmed`, `cancelled`, `refunded`
- **`database/migrations/2026_04_12_153752_create_bookings_table.php`** — `bookings` table with FKs, `unique(sport_session_id, athlete_id)` constraint
- **`app/Models/Booking.php`** — Model with casts (status → enum, amount_paid → int, timestamps) and relationships (`belongsTo SportSession`, `belongsTo User`)
- **`database/factories/BookingFactory.php`** — Factory with state methods for all statuses
- **`app/Models/SportSession.php`** — Added `hasMany(Booking)` relationship
- **`app/Models/User.php`** — Added `hasMany(Booking, 'athlete_id')` relationship
- **`lang/{en,fr,nl}/bookings.php`** — Booking status translations (tri-lingual)
- **`tests/Unit/Enums/BookingStatusTest.php`** — Enum values, from(), cases count, localized labels
- **`tests/Unit/Models/BookingTest.php`** — Model creation, casts, relationships, unique constraint

### Test Results

All 14 new tests pass. Full suite: 492 passed.