### PR TITLE
feat: E3-S05 · Stripe webhook controller + signature verification (#72)

### DIFF
--- a/app/Events/Stripe/AccountUpdated.php
+++ b/app/Events/Stripe/AccountUpdated.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Stripe;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Stripe\Event;
+
+final class AccountUpdated
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Event $stripeEvent,
+    ) {}
+}

--- a/app/Events/Stripe/ChargeRefunded.php
+++ b/app/Events/Stripe/ChargeRefunded.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Stripe;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Stripe\Event;
+
+final class ChargeRefunded
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Event $stripeEvent,
+    ) {}
+}

--- a/app/Events/Stripe/PaymentIntentFailed.php
+++ b/app/Events/Stripe/PaymentIntentFailed.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Stripe;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Stripe\Event;
+
+final class PaymentIntentFailed
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Event $stripeEvent,
+    ) {}
+}

--- a/app/Events/Stripe/PaymentIntentSucceeded.php
+++ b/app/Events/Stripe/PaymentIntentSucceeded.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Stripe;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Stripe\Event;
+
+final class PaymentIntentSucceeded
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Event $stripeEvent,
+    ) {}
+}

--- a/app/Http/Controllers/StripeWebhookController.php
+++ b/app/Http/Controllers/StripeWebhookController.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Events\Stripe\AccountUpdated;
+use App\Events\Stripe\ChargeRefunded;
+use App\Events\Stripe\PaymentIntentFailed;
+use App\Events\Stripe\PaymentIntentSucceeded;
+use App\Models\ProcessedWebhook;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Stripe\Event;
+use Stripe\Exception\SignatureVerificationException;
+use Stripe\Webhook;
+
+final class StripeWebhookController extends Controller
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $payload = $request->getContent();
+        $signature = $request->header('Stripe-Signature', '');
+        $secret = config('services.stripe.webhook.secret');
+
+        try {
+            $event = Webhook::constructEvent($payload, $signature, $secret);
+        } catch (SignatureVerificationException $e) {
+            Log::warning('Stripe webhook signature verification failed.', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return response()->json(['error' => 'Invalid signature'], 400);
+        } catch (\UnexpectedValueException $e) {
+            Log::warning('Stripe webhook payload invalid.', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return response()->json(['error' => 'Invalid payload'], 400);
+        }
+
+        // Idempotency check — skip duplicate events
+        if (ProcessedWebhook::where('stripe_event_id', $event->id)->exists()) {
+            return response()->json(['status' => 'already_processed']);
+        }
+
+        try {
+            // Record the event to prevent reprocessing
+            ProcessedWebhook::create([
+                'stripe_event_id' => $event->id,
+                'event_type' => $event->type,
+            ]);
+
+            // Dispatch internal Laravel event based on Stripe event type
+            $this->dispatchStripeEvent($event);
+
+            return response()->json(['status' => 'processed']);
+        } catch (\Throwable $e) {
+            Log::error('Stripe webhook processing error.', [
+                'event_id' => $event->id,
+                'event_type' => $event->type,
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            // Return 200 to prevent Stripe retries for non-transient errors
+            return response()->json(['status' => 'error']);
+        }
+    }
+
+    private function dispatchStripeEvent(Event $event): void
+    {
+        $eventMap = [
+            'payment_intent.succeeded' => PaymentIntentSucceeded::class,
+            'payment_intent.payment_failed' => PaymentIntentFailed::class,
+            'account.updated' => AccountUpdated::class,
+            'charge.refunded' => ChargeRefunded::class,
+        ];
+
+        $eventClass = $eventMap[$event->type] ?? null;
+
+        if ($eventClass !== null) {
+            event(new $eventClass($event));
+        } else {
+            Log::info('Unhandled Stripe webhook event type.', [
+                'event_type' => $event->type,
+                'event_id' => $event->id,
+            ]);
+        }
+    }
+}

--- a/app/Models/ProcessedWebhook.php
+++ b/app/Models/ProcessedWebhook.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ProcessedWebhook extends Model
+{
+    protected $fillable = [
+        'stripe_event_id',
+        'event_type',
+    ];
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -30,6 +30,9 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->web(append: [
             SetLocale::class,
         ]);
+        $middleware->validateCsrfTokens(except: [
+            'stripe/webhook',
+        ]);
         $middleware->alias([
             'role' => EnsureUserHasRole::class,
             '2fa' => EnsureTwoFactorEnabled::class,

--- a/database/migrations/2026_04_12_155112_create_processed_webhooks_table.php
+++ b/database/migrations/2026_04_12_155112_create_processed_webhooks_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('processed_webhooks', function (Blueprint $table) {
+            $table->id();
+            $table->string('stripe_event_id')->unique();
+            $table->string('event_type');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('processed_webhooks');
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\Auth\GoogleController;
+use App\Http\Controllers\StripeWebhookController;
 use App\Livewire\Auth\ForgotPassword;
 use App\Livewire\Auth\Login;
 use App\Livewire\Auth\Register;
@@ -94,3 +95,6 @@ Route::get('/locale/{locale}', function (string $locale) {
 
     return redirect()->back(fallback: '/');
 })->name('locale.switch');
+
+Route::post('/stripe/webhook', StripeWebhookController::class)
+    ->name('stripe.webhook');

--- a/tests/Feature/Webhooks/StripeWebhookTest.php
+++ b/tests/Feature/Webhooks/StripeWebhookTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Events\Stripe\AccountUpdated;
+use App\Events\Stripe\ChargeRefunded;
+use App\Events\Stripe\PaymentIntentFailed;
+use App\Events\Stripe\PaymentIntentSucceeded;
+use App\Models\ProcessedWebhook;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+
+uses(RefreshDatabase::class);
+
+function generateStripeSignature(string $payload, string $secret): string
+{
+    $timestamp = time();
+    $signedPayload = $timestamp.'.'.$payload;
+    $signature = hash_hmac('sha256', $signedPayload, $secret);
+
+    return 't='.$timestamp.',v1='.$signature;
+}
+
+function makeStripePayload(string $eventId, string $eventType, array $data = []): string
+{
+    return json_encode([
+        'id' => $eventId,
+        'type' => $eventType,
+        'object' => 'event',
+        'api_version' => '2024-06-20',
+        'created' => time(),
+        'data' => [
+            'object' => $data ?: ['id' => 'obj_test_123'],
+        ],
+        'livemode' => false,
+        'pending_webhooks' => 1,
+        'request' => ['id' => 'req_test_123', 'idempotency_key' => null],
+    ]);
+}
+
+describe('signature verification', function () {
+
+    it('rejects requests with invalid signature', function () {
+        config(['services.stripe.webhook.secret' => 'whsec_test_secret']);
+
+        $payload = makeStripePayload('evt_test_123', 'payment_intent.succeeded');
+
+        $response = $this->postJson('/stripe/webhook', [], [
+            'HTTP_STRIPE_SIGNATURE' => 'invalid_signature',
+            'CONTENT_TYPE' => 'application/json',
+        ]);
+
+        $response->assertStatus(400);
+        $response->assertJson(['error' => 'Invalid signature']);
+    });
+
+    it('accepts requests with valid signature', function () {
+        $secret = 'whsec_test_secret';
+        config(['services.stripe.webhook.secret' => $secret]);
+        Event::fake();
+
+        $payload = makeStripePayload('evt_test_valid', 'payment_intent.succeeded');
+        $signature = generateStripeSignature($payload, $secret);
+
+        $response = $this->call('POST', '/stripe/webhook', [], [], [], [
+            'HTTP_STRIPE_SIGNATURE' => $signature,
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertStatus(200);
+        $response->assertJson(['status' => 'processed']);
+    });
+
+});
+
+describe('idempotency', function () {
+
+    it('skips duplicate events', function () {
+        $secret = 'whsec_test_secret';
+        config(['services.stripe.webhook.secret' => $secret]);
+        Event::fake();
+
+        // Pre-record the event
+        ProcessedWebhook::create([
+            'stripe_event_id' => 'evt_duplicate_123',
+            'event_type' => 'payment_intent.succeeded',
+        ]);
+
+        $payload = makeStripePayload('evt_duplicate_123', 'payment_intent.succeeded');
+        $signature = generateStripeSignature($payload, $secret);
+
+        $response = $this->call('POST', '/stripe/webhook', [], [], [], [
+            'HTTP_STRIPE_SIGNATURE' => $signature,
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertStatus(200);
+        $response->assertJson(['status' => 'already_processed']);
+
+        // Should still be only one record
+        expect(ProcessedWebhook::where('stripe_event_id', 'evt_duplicate_123')->count())->toBe(1);
+    });
+
+    it('records processed events', function () {
+        $secret = 'whsec_test_secret';
+        config(['services.stripe.webhook.secret' => $secret]);
+        Event::fake();
+
+        $payload = makeStripePayload('evt_new_123', 'payment_intent.succeeded');
+        $signature = generateStripeSignature($payload, $secret);
+
+        $this->call('POST', '/stripe/webhook', [], [], [], [
+            'HTTP_STRIPE_SIGNATURE' => $signature,
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        expect(ProcessedWebhook::where('stripe_event_id', 'evt_new_123')->exists())->toBeTrue();
+    });
+
+});
+
+describe('event dispatching', function () {
+
+    it('dispatches PaymentIntentSucceeded for payment_intent.succeeded', function () {
+        $secret = 'whsec_test_secret';
+        config(['services.stripe.webhook.secret' => $secret]);
+        Event::fake();
+
+        $payload = makeStripePayload('evt_pi_success', 'payment_intent.succeeded');
+        $signature = generateStripeSignature($payload, $secret);
+
+        $this->call('POST', '/stripe/webhook', [], [], [], [
+            'HTTP_STRIPE_SIGNATURE' => $signature,
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        Event::assertDispatched(PaymentIntentSucceeded::class);
+    });
+
+    it('dispatches PaymentIntentFailed for payment_intent.payment_failed', function () {
+        $secret = 'whsec_test_secret';
+        config(['services.stripe.webhook.secret' => $secret]);
+        Event::fake();
+
+        $payload = makeStripePayload('evt_pi_failed', 'payment_intent.payment_failed');
+        $signature = generateStripeSignature($payload, $secret);
+
+        $this->call('POST', '/stripe/webhook', [], [], [], [
+            'HTTP_STRIPE_SIGNATURE' => $signature,
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        Event::assertDispatched(PaymentIntentFailed::class);
+    });
+
+    it('dispatches AccountUpdated for account.updated', function () {
+        $secret = 'whsec_test_secret';
+        config(['services.stripe.webhook.secret' => $secret]);
+        Event::fake();
+
+        $payload = makeStripePayload('evt_acct_updated', 'account.updated');
+        $signature = generateStripeSignature($payload, $secret);
+
+        $this->call('POST', '/stripe/webhook', [], [], [], [
+            'HTTP_STRIPE_SIGNATURE' => $signature,
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        Event::assertDispatched(AccountUpdated::class);
+    });
+
+    it('dispatches ChargeRefunded for charge.refunded', function () {
+        $secret = 'whsec_test_secret';
+        config(['services.stripe.webhook.secret' => $secret]);
+        Event::fake();
+
+        $payload = makeStripePayload('evt_charge_refunded', 'charge.refunded');
+        $signature = generateStripeSignature($payload, $secret);
+
+        $this->call('POST', '/stripe/webhook', [], [], [], [
+            'HTTP_STRIPE_SIGNATURE' => $signature,
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        Event::assertDispatched(ChargeRefunded::class);
+    });
+
+    it('does not dispatch for unhandled event types', function () {
+        $secret = 'whsec_test_secret';
+        config(['services.stripe.webhook.secret' => $secret]);
+        Event::fake();
+
+        $payload = makeStripePayload('evt_unknown', 'customer.created');
+        $signature = generateStripeSignature($payload, $secret);
+
+        $this->call('POST', '/stripe/webhook', [], [], [], [
+            'HTTP_STRIPE_SIGNATURE' => $signature,
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        Event::assertNotDispatched(PaymentIntentSucceeded::class);
+        Event::assertNotDispatched(PaymentIntentFailed::class);
+        Event::assertNotDispatched(AccountUpdated::class);
+        Event::assertNotDispatched(ChargeRefunded::class);
+    });
+
+});


### PR DESCRIPTION
## E3-S05 · Stripe webhook controller + signature verification

Closes #72

### Changes

- **`app/Http/Controllers/StripeWebhookController.php`** — Invokable controller that:
  - Verifies Stripe webhook signatures using `STRIPE_WEBHOOK_SECRET`
  - Checks idempotency via `processed_webhooks` table
  - Skips duplicate events (returns 200 with `already_processed`)
  - Returns HTTP 200 even on processing errors (logs the error, prevents Stripe retries)
  - Returns HTTP 400 only for invalid signatures
  - Dispatches internal Laravel events based on Stripe event type

- **`database/migrations/2026_04_12_155112_create_processed_webhooks_table.php`** — `processed_webhooks` table with unique `stripe_event_id` for idempotency

- **`app/Models/ProcessedWebhook.php`** — Eloquent model for webhook tracking

- **`app/Events/Stripe/`** — Four event classes dispatched by webhook handler:
  - `PaymentIntentSucceeded` (payment_intent.succeeded)
  - `PaymentIntentFailed` (payment_intent.payment_failed)
  - `AccountUpdated` (account.updated)
  - `ChargeRefunded` (charge.refunded)

- **`routes/web.php`** — Added `POST /stripe/webhook` route
- **`bootstrap/app.php`** — CSRF exclusion for `stripe/webhook`

- **`tests/Feature/Webhooks/StripeWebhookTest.php`** — 9 tests covering:
  - Invalid signature rejection
  - Valid signature processing
  - Duplicate event skipping
  - Event recording
  - Correct event dispatch for each Stripe event type
  - No dispatch for unhandled event types

### Test Results

9 new tests pass. Full suite: 520 passed.