### PR TITLE
Add temp files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ scripts/*.key
 # Docker
 .docker/.env.docker
 docker-compose.override.yml
+
+# Local temp files
+temp*.md


### PR DESCRIPTION
Include local temporary markdown files in .gitignore to prevent them from being tracked by Git.