### PR TITLE
test(mvp): end-to-end booking payment journey smoke test (Epic 6 / Story 6.1)

### DIFF
--- a/database/seeders/MvpJourneySeeder.php
+++ b/database/seeders/MvpJourneySeeder.php
@@ -14,6 +14,7 @@ use App\Enums\PaymentAnomalyType;
 use App\Enums\SessionLevel;
 use App\Enums\SessionStatus;
 use App\Enums\UserRole;
+use App\Models\ActivityImage;
 use App\Models\Booking;
 use App\Models\CoachPayoutStatement;
 use App\Models\CoachProfile;
@@ -23,7 +24,10 @@ use App\Models\SportSession;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
+use RuntimeException;
 
 /**
  * Seeds a realistic MVP journey scenario for manual QA smoke testing.
@@ -66,7 +70,7 @@ final class MvpJourneySeeder extends Seeder
         $password = Hash::make('password');
 
         // ── Admin ─────────────────────────────────────────────────────────────
-        User::firstOrCreate(
+        $admin = User::firstOrCreate(
             ['email' => 'admin@motivya.test'],
             [
                 'name' => 'Admin User',
@@ -209,12 +213,31 @@ final class MvpJourneySeeder extends Seeder
             ]
         );
 
+        $runningImage = $this->seedActivityImage(
+            activityType: ActivityType::Running,
+            uploadedBy: $admin,
+            path: 'activity-images/mvp-running.svg',
+            altText: 'Demo running session in a Brussels park',
+        );
+        $cardioImage = $this->seedActivityImage(
+            activityType: ActivityType::Cardio,
+            uploadedBy: $admin,
+            path: 'activity-images/mvp-cardio.svg',
+            altText: 'Demo cardio session in a Brussels park',
+        );
+        $yogaImage = $this->seedActivityImage(
+            activityType: ActivityType::Yoga,
+            uploadedBy: $admin,
+            path: 'activity-images/mvp-yoga.svg',
+            altText: 'Demo yoga session in a Brussels park',
+        );
+
         // ── Marc's published session near Cinquantenaire (postal 1000) ────────
         // Price: €20.00 per person — 2 bookings, needs 1 more to confirm
         $sessionDate = Carbon::now()->addDays(10)->format('Y-m-d');
 
         /** @var SportSession $activeSession */
-        $activeSession = SportSession::firstOrCreate(
+        $activeSession = SportSession::updateOrCreate(
             [
                 'coach_id' => $marc->id,
                 'title' => 'Running Cinquantenaire — Cardio Débutant',
@@ -235,11 +258,12 @@ final class MvpJourneySeeder extends Seeder
                 'max_participants' => 10,
                 'current_participants' => 2,
                 'status' => SessionStatus::Published->value,
+                'cover_image_id' => $cardioImage->id,
             ]
         );
 
         // Alice's confirmed booking
-        Booking::firstOrCreate(
+        Booking::updateOrCreate(
             [
                 'sport_session_id' => $activeSession->id,
                 'athlete_id' => $alice->id,
@@ -247,12 +271,13 @@ final class MvpJourneySeeder extends Seeder
             [
                 'status' => BookingStatus::Confirmed->value,
                 'amount_paid' => 2000,
+                'stripe_checkout_session_id' => 'cs_mvp_smoke_alice',
                 'stripe_payment_intent_id' => 'pi_mvp_smoke_alice',
             ]
         );
 
         // Bob's confirmed booking
-        Booking::firstOrCreate(
+        Booking::updateOrCreate(
             [
                 'sport_session_id' => $activeSession->id,
                 'athlete_id' => $bob->id,
@@ -260,12 +285,13 @@ final class MvpJourneySeeder extends Seeder
             [
                 'status' => BookingStatus::Confirmed->value,
                 'amount_paid' => 2000,
+                'stripe_checkout_session_id' => 'cs_mvp_smoke_bob',
                 'stripe_payment_intent_id' => 'pi_mvp_smoke_bob',
             ]
         );
 
         // Diana's pending-payment booking (payment window expires in 20 min — for recovery flow)
-        Booking::firstOrCreate(
+        Booking::updateOrCreate(
             [
                 'sport_session_id' => $activeSession->id,
                 'athlete_id' => $diana->id,
@@ -283,7 +309,7 @@ final class MvpJourneySeeder extends Seeder
         $laekenDate = Carbon::now()->addDays(7)->format('Y-m-d');
 
         /** @var SportSession $laekenSession */
-        $laekenSession = SportSession::firstOrCreate(
+        $laekenSession = SportSession::updateOrCreate(
             [
                 'coach_id' => $marc->id,
                 'title' => 'Running Laeken — Cardio Intermédiaire',
@@ -304,10 +330,11 @@ final class MvpJourneySeeder extends Seeder
                 'max_participants' => 8,
                 'current_participants' => 3,
                 'status' => SessionStatus::Confirmed->value,
+                'cover_image_id' => $runningImage->id,
             ]
         );
 
-        Booking::firstOrCreate(
+        Booking::updateOrCreate(
             [
                 'sport_session_id' => $laekenSession->id,
                 'athlete_id' => $alice->id,
@@ -315,6 +342,7 @@ final class MvpJourneySeeder extends Seeder
             [
                 'status' => BookingStatus::Confirmed->value,
                 'amount_paid' => 2500,
+                'stripe_checkout_session_id' => 'cs_mvp_smoke_laeken_alice',
                 'stripe_payment_intent_id' => 'pi_mvp_smoke_laeken_alice',
             ]
         );
@@ -322,7 +350,7 @@ final class MvpJourneySeeder extends Seeder
         // ── Marc's session in Ixelles (postal 1050) — published ───────────────
         $ixellesDate = Carbon::now()->addDays(14)->format('Y-m-d');
 
-        SportSession::firstOrCreate(
+        SportSession::updateOrCreate(
             [
                 'coach_id' => $marc->id,
                 'title' => 'Yoga Bois de la Cambre — Stretching',
@@ -343,6 +371,7 @@ final class MvpJourneySeeder extends Seeder
                 'max_participants' => 12,
                 'current_participants' => 1,
                 'status' => SessionStatus::Published->value,
+                'cover_image_id' => $yogaImage->id,
             ]
         );
 
@@ -350,7 +379,7 @@ final class MvpJourneySeeder extends Seeder
         $cancelledDate = Carbon::now()->subDays(5)->format('Y-m-d');
 
         /** @var SportSession $cancelledSession */
-        $cancelledSession = SportSession::firstOrCreate(
+        $cancelledSession = SportSession::updateOrCreate(
             [
                 'coach_id' => $marc->id,
                 'title' => 'Running Scharbeek — Piste de vitesse',
@@ -371,10 +400,11 @@ final class MvpJourneySeeder extends Seeder
                 'max_participants' => 15,
                 'current_participants' => 1,
                 'status' => SessionStatus::Cancelled->value,
+                'cover_image_id' => $runningImage->id,
             ]
         );
 
-        Booking::firstOrCreate(
+        Booking::updateOrCreate(
             [
                 'sport_session_id' => $cancelledSession->id,
                 'athlete_id' => $bob->id,
@@ -382,7 +412,10 @@ final class MvpJourneySeeder extends Seeder
             [
                 'status' => BookingStatus::Refunded->value,
                 'amount_paid' => 3000,
+                'stripe_checkout_session_id' => 'cs_mvp_smoke_scharbeek_bob',
                 'stripe_payment_intent_id' => 'pi_mvp_smoke_scharbeek_bob',
+                'cancelled_at' => now()->subDays(5),
+                'refunded_at' => now()->subDays(4),
             ]
         );
 
@@ -390,7 +423,7 @@ final class MvpJourneySeeder extends Seeder
         $completedDate = Carbon::now()->subDays(30)->format('Y-m-d');
 
         /** @var SportSession $completedSession */
-        $completedSession = SportSession::firstOrCreate(
+        $completedSession = SportSession::updateOrCreate(
             [
                 'coach_id' => $marc->id,
                 'title' => 'Running Etterbeek — Cardio Avancé',
@@ -411,6 +444,23 @@ final class MvpJourneySeeder extends Seeder
                 'max_participants' => 8,
                 'current_participants' => 5,
                 'status' => SessionStatus::Completed->value,
+                'cover_image_id' => $runningImage->id,
+            ]
+        );
+
+        // Deliberate demo anomaly: confirmed booking with no captured payment.
+        // This lets accountant/admin smoke tests verify the anomaly queue without
+        // corrupting the coherent paid/refunded booking examples above.
+        $anomalousBooking = Booking::updateOrCreate(
+            [
+                'sport_session_id' => $completedSession->id,
+                'athlete_id' => $diana->id,
+            ],
+            [
+                'status' => BookingStatus::Confirmed->value,
+                'amount_paid' => 0,
+                'stripe_checkout_session_id' => null,
+                'stripe_payment_intent_id' => null,
             ]
         );
 
@@ -494,6 +544,22 @@ final class MvpJourneySeeder extends Seeder
             ]
         );
 
+        PaymentAnomaly::firstOrCreate(
+            [
+                'anomaly_type' => PaymentAnomalyType::ConfirmedBookingMissingPayment->value,
+                'related_booking_id' => $anomalousBooking->id,
+            ],
+            [
+                'anomalous_model_type' => Booking::class,
+                'anomalous_model_id' => $anomalousBooking->id,
+                'related_session_id' => $completedSession->id,
+                'related_coach_id' => $marc->id,
+                'resolution_status' => 'open',
+                'description' => 'Demo anomaly: confirmed booking without amount_paid or Stripe payment intent. Used for accountant/admin anomaly testing.',
+                'recommended_action' => 'Investigate the booking payment state before payout or refund processing.',
+            ]
+        );
+
         if ($this->command !== null) {
             $this->command->info('✅ MvpJourneySeeder: scenario created successfully.');
             $this->command->info('');
@@ -512,6 +578,45 @@ final class MvpJourneySeeder extends Seeder
             $this->command->info('  Sessions across Brussels postal codes: 1000, 1020, 1030, 1040, 1050');
             $this->command->info('  ⚠  Replace stripe_account_id "acct_mvp_smoke_test" with a real Stripe test Express account ID.');
             $this->command->info('  📖 See doc/MVP-Smoke-Test.md for the full manual QA checklist.');
+        }
+    }
+
+    private function seedActivityImage(ActivityType $activityType, User $uploadedBy, string $path, string $altText): ActivityImage
+    {
+        $this->ensurePublicStorageLinked();
+
+        $fixturePath = database_path('seeders/fixtures/activity-images/mvp-outdoor-session.svg');
+
+        if (! File::exists($fixturePath)) {
+            throw new RuntimeException('MVP activity image fixture is missing: '.$fixturePath);
+        }
+
+        Storage::disk('public')->put($path, File::get($fixturePath));
+
+        return ActivityImage::updateOrCreate(
+            [
+                'activity_type' => $activityType->value,
+                'path' => $path,
+            ],
+            [
+                'alt_text' => $altText,
+                'uploaded_by' => $uploadedBy->id,
+            ]
+        );
+    }
+
+    private function ensurePublicStorageLinked(): void
+    {
+        $linkPath = public_path('storage');
+
+        if (! is_link($linkPath)) {
+            throw new RuntimeException('MvpJourneySeeder requires public/storage to be linked. Run: php artisan storage:link');
+        }
+
+        $target = readlink($linkPath);
+
+        if ($target === false || ! is_dir($target)) {
+            throw new RuntimeException('MvpJourneySeeder found a broken public/storage link. Re-run: php artisan storage:link');
         }
     }
 }

--- a/database/seeders/fixtures/activity-images/mvp-outdoor-session.svg
+++ b/database/seeders/fixtures/activity-images/mvp-outdoor-session.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+    <title id="title">Outdoor sports session in Brussels</title>
+    <desc id="desc">A simple demo fixture image used by MVP smoke seed data.</desc>
+    <rect width="1200" height="675" fill="#f7fafc"/>
+    <rect y="430" width="1200" height="245" fill="#87b37a"/>
+    <rect y="375" width="1200" height="70" fill="#d7e5f0"/>
+    <circle cx="1010" cy="115" r="54" fill="#f7c948"/>
+    <path d="M0 385 C160 320 290 360 420 315 C560 265 680 330 805 290 C955 240 1065 295 1200 255 L1200 430 L0 430 Z" fill="#466a61"/>
+    <path d="M290 448 C415 418 520 420 640 448 C740 472 860 468 980 438" fill="none" stroke="#ffffff" stroke-width="22" stroke-linecap="round" opacity="0.85"/>
+    <circle cx="430" cy="355" r="35" fill="#244c5a"/>
+    <path d="M430 390 L400 485 M430 390 L470 470 M414 420 L355 448 M444 420 L505 430" fill="none" stroke="#244c5a" stroke-width="24" stroke-linecap="round"/>
+    <circle cx="680" cy="360" r="34" fill="#7c3f58"/>
+    <path d="M680 395 L640 495 M680 395 L720 495 M662 430 L600 410 M696 430 L760 408" fill="none" stroke="#7c3f58" stroke-width="24" stroke-linecap="round"/>
+    <rect x="70" y="535" width="1060" height="40" rx="20" fill="#385d57" opacity="0.22"/>
+</svg>

--- a/doc/MVP-Smoke-Test.md
+++ b/doc/MVP-Smoke-Test.md
@@ -43,9 +43,6 @@ php artisan storage:link
 # (via PostalCodeCoordinatesSeeder) before creating demo users — no separate step needed.
 php artisan db:seed --class=MvpJourneySeeder
 
-# Backfill GPS coordinates for seeded sessions (uses the loaded postal codes)
-php artisan sessions:backfill-coordinates
-
 # Build assets
 npm install && npm run build
 
@@ -56,7 +53,7 @@ npm run dev
 ```
 
 > **Warning**: `MvpJourneySeeder` must **never** run in production. It creates predictable demo credentials.
-> In production, use `php artisan geo:load-postal-codes` and `php artisan sessions:backfill-coordinates` instead.
+> In production-like environments, use `php artisan geo:load-postal-codes`, `php artisan sessions:backfill-coordinates`, and `php artisan make:admin` instead of demo seeders.
 
 - [ ] App is reachable at `http://localhost:8000`
 - [ ] No errors in `storage/logs/laravel.log`
@@ -64,7 +61,34 @@ npm run dev
 - [ ] The seed completed without errors
 - [ ] `storage/app/public` symlink exists (`ls -la public/storage` shows a symlink)
 - [ ] `postal_code_coordinates` table has rows (`php artisan tinker --execute="echo \App\Models\PostalCodeCoordinate::count();"`)
-- [ ] Sessions have lat/lng after backfill (`php artisan tinker --execute="echo \App\Models\SportSession::whereNull('latitude')->count().' missing';"`)
+- [ ] Sessions have lat/lng (`php artisan tinker --execute="echo \App\Models\SportSession::whereNull('latitude')->orWhereNull('longitude')->count().' missing';"`)
+- [ ] Demo activity image files exist under `public/storage/activity-images/`
+
+### UAT / production bootstrap note
+
+The OVH host currently acts as UAT, but it runs with `APP_ENV=production`. Keep that guard in place: do not run `MvpJourneySeeder` there. Bootstrap operational data explicitly so the future production cutover remains visible and repeatable:
+
+```bash
+php artisan migrate --force
+php artisan geo:load-postal-codes
+php artisan sessions:backfill-coordinates
+php artisan storage:link
+php artisan make:admin
+php artisan mvp:health-snapshot
+```
+
+The only seed/reference data expected in UAT or production is non-secret operational reference data such as postal-code coordinates. Demo users, demo bookings, and predictable passwords stay local/testing only.
+
+### Automated smoke coverage
+
+Epic 6 intentionally avoids Playwright for the current milestone. The MVP smoke suite uses Pest feature tests instead:
+
+- `tests/Feature/Mvp/SeederSmokeTest.php` verifies seeded sessions have coordinates and public activity-image fixtures.
+- The same test file asserts the discovery page renders the session map container and image-backed cards.
+- It also asserts session detail renders the map container and a coordinate-based directions link.
+- `mvp:health-snapshot` remains the deployment-friendly check for missing public storage links, postal-code data, scheduler health, and payment anomalies.
+
+Full browser execution can be added later if the project needs pixel-level MapLibre validation, but it is not required for the partner-demo readiness gate.
 
 ---
 
@@ -171,9 +195,10 @@ This creates:
 - 1 **Suspended athlete** (`suspended@motivya.test`) — account suspended (for admin user management testing)
 - 1 **Unverified athlete** (`unverified@motivya.test`) — unverified email (for admin testing)
 - Sessions across 5 Brussels postal codes: **1000, 1020, 1030, 1040, 1050**
+- Activity cover images copied from committed fixtures to `storage/app/public/activity-images/`
 - 1 **draft invoice** for the previous month's completed session by Marc
 - 1 **payout statement** (Draft) for Marc's previous billing month
-- 1 **payment anomaly** (open, for accountant/admin anomaly queue review)
+- 2 **payment anomalies** (open, for accountant/admin anomaly queue review), including one deliberately anomalous confirmed booking with no captured payment
 
 > All passwords are `password` (bcrypt-hashed — safe for local/dev only).
 > Replace `stripe_account_id: acct_mvp_smoke_test` with a real Stripe Express test account ID.

--- a/tests/Feature/Mvp/BookingPaymentJourneyTest.php
+++ b/tests/Feature/Mvp/BookingPaymentJourneyTest.php
@@ -1,0 +1,365 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\BookingStatus;
+use App\Enums\SessionStatus;
+use App\Livewire\Booking\Book;
+use App\Models\Booking;
+use App\Models\CoachProfile;
+use App\Models\SportSession;
+use App\Models\User;
+use App\Services\Audit\AuditService;
+use App\Services\PaymentService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Testing\TestResponse;
+use Livewire\Livewire;
+use Stripe\Checkout\Session as CheckoutSession;
+use Tests\TestCase;
+
+uses(RefreshDatabase::class);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers shared across tests in this file
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build and sign a Stripe webhook POST exactly as the real Stripe SDK would.
+ */
+function postStripeWebhookEvent(?TestResponse $ignore, string $secret, string $eventId, string $eventType, array $data): TestResponse
+{
+    $payload = json_encode([
+        'id' => $eventId,
+        'type' => $eventType,
+        'object' => 'event',
+        'api_version' => '2024-06-20',
+        'created' => time(),
+        'data' => ['object' => $data],
+        'livemode' => false,
+        'pending_webhooks' => 1,
+    ], JSON_THROW_ON_ERROR);
+
+    $timestamp = time();
+    $signature = hash_hmac('sha256', $timestamp.'.'.$payload, $secret);
+
+    /** @var TestCase $test */
+    $test = test();
+
+    return $test->call('POST', '/stripe/webhook', [], [], [], [
+        'HTTP_STRIPE_SIGNATURE' => 't='.$timestamp.',v1='.$signature,
+        'CONTENT_TYPE' => 'application/json',
+    ], $payload);
+}
+
+/**
+ * Bind a fake PaymentService that returns the supplied checkout session values.
+ */
+function bindFakePaymentService(string $checkoutSessionId, string $checkoutUrl): void
+{
+    app()->instance(PaymentService::class, new PaymentService(
+        auditService: app(AuditService::class),
+        createCheckoutSessionUsing: fn (array $payload): CheckoutSession => CheckoutSession::constructFrom([
+            'id' => $checkoutSessionId,
+            'url' => $checkoutUrl,
+        ]),
+    ));
+}
+
+/**
+ * Bind a failing PaymentService that throws on checkout-session creation.
+ */
+function bindThrowingPaymentService(string $message = 'Stripe unavailable'): void
+{
+    app()->instance(PaymentService::class, new PaymentService(
+        auditService: app(AuditService::class),
+        createCheckoutSessionUsing: fn (array $payload): never => throw new RuntimeException($message),
+    ));
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Story 6.1: True end-to-end booking payment smoke test
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('MVP Booking Payment Journey', function () {
+
+    beforeEach(function (): void {
+        $this->webhookSecret = 'whsec_e2e_journey_secret';
+        config(['services.stripe.webhook.secret' => $this->webhookSecret]);
+    });
+
+    // ── Step 1: Athlete books, receives Stripe Checkout redirect ─────────────
+
+    it('creates a PendingPayment hold and redirects to the Stripe Checkout URL', function () {
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->approved()->for($coach)->create([
+            'stripe_account_id' => 'acct_e2e_journey',
+            'stripe_onboarding_complete' => true,
+        ]);
+
+        $session = SportSession::factory()->published()->for($coach, 'coach')->create([
+            'price_per_person' => 2500,
+        ]);
+        $athlete = User::factory()->athlete()->create();
+
+        bindFakePaymentService('cs_e2e_step1', 'https://checkout.stripe.com/pay/cs_e2e_step1');
+
+        Livewire::actingAs($athlete)
+            ->test(Book::class, ['sportSession' => $session])
+            ->call('book')
+            ->assertRedirect('https://checkout.stripe.com/pay/cs_e2e_step1');
+
+        $booking = Booking::where('sport_session_id', $session->id)->where('athlete_id', $athlete->id)->first();
+
+        expect($booking)->not->toBeNull();
+        expect($booking->status)->toBe(BookingStatus::PendingPayment);
+        expect($booking->stripe_checkout_session_id)->toBe('cs_e2e_step1');
+        expect($session->fresh()->current_participants)->toBe(1);
+    });
+
+    // ── Step 2: Stripe webhook confirms booking ───────────────────────────────
+
+    it('webhook checkout.session.completed confirms booking with amount and payment intent', function () {
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->approved()->for($coach)->create([
+            'stripe_account_id' => 'acct_e2e_webhook',
+            'stripe_onboarding_complete' => true,
+        ]);
+
+        $session = SportSession::factory()->published()->for($coach, 'coach')->create([
+            'min_participants' => 1,
+            'price_per_person' => 2500,
+        ]);
+        $athlete = User::factory()->athlete()->create();
+
+        // Create the hold directly (simulating Step 1 already having run).
+        $booking = Booking::factory()->pendingPayment()->for($session, 'sportSession')->for($athlete, 'athlete')->create([
+            'stripe_checkout_session_id' => 'cs_e2e_webhook',
+            'amount_paid' => 0,
+        ]);
+
+        $webhookResponse = postStripeWebhookEvent(
+            null,
+            $this->webhookSecret,
+            'evt_e2e_checkout_completed',
+            'checkout.session.completed',
+            [
+                'id' => 'cs_e2e_webhook',
+                'payment_intent' => 'pi_e2e_confirmed',
+                'amount_total' => 2500,
+                'metadata' => [
+                    'session_id' => (string) $session->id,
+                    'athlete_id' => (string) $athlete->id,
+                ],
+            ],
+        );
+
+        $webhookResponse->assertOk()->assertJson(['status' => 'processed']);
+
+        $booking = $booking->fresh();
+
+        expect($booking->status)->toBe(BookingStatus::Confirmed);
+        expect($booking->amount_paid)->toBe(2500);
+        expect($booking->stripe_payment_intent_id)->toBe('pi_e2e_confirmed');
+    });
+
+    // ── Step 3: Full journey — book, webhook, then assert cross-role views ────
+
+    it('full journey: book → webhook confirm → visible in athlete, coach, accountant, and admin views', function () {
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->approved()->for($coach)->create([
+            'stripe_account_id' => 'acct_e2e_full',
+            'stripe_onboarding_complete' => true,
+        ]);
+
+        $session = SportSession::factory()->published()->for($coach, 'coach')->create([
+            'min_participants' => 1,
+            'price_per_person' => 3000,
+        ]);
+
+        $athlete = User::factory()->athlete()->create();
+
+        // Step A: athlete books (mock Stripe).
+        bindFakePaymentService('cs_e2e_full', 'https://checkout.stripe.com/pay/cs_e2e_full');
+
+        Livewire::actingAs($athlete)
+            ->test(Book::class, ['sportSession' => $session])
+            ->call('book')
+            ->assertRedirect('https://checkout.stripe.com/pay/cs_e2e_full');
+
+        // Step B: Stripe confirms the checkout.
+        postStripeWebhookEvent(
+            null,
+            $this->webhookSecret,
+            'evt_e2e_full_completed',
+            'checkout.session.completed',
+            [
+                'id' => 'cs_e2e_full',
+                'payment_intent' => 'pi_e2e_full_confirmed',
+                'amount_total' => 3000,
+                'metadata' => [
+                    'session_id' => (string) $session->id,
+                    'athlete_id' => (string) $athlete->id,
+                ],
+            ],
+        )->assertOk();
+
+        $booking = Booking::where('sport_session_id', $session->id)->where('athlete_id', $athlete->id)->firstOrFail();
+
+        expect($booking->status)->toBe(BookingStatus::Confirmed);
+        expect($booking->amount_paid)->toBe(3000);
+        expect($booking->stripe_payment_intent_id)->toBe('pi_e2e_full_confirmed');
+
+        // Step C: Athlete dashboard shows the confirmed session.
+        $this->actingAs($athlete)
+            ->get(route('athlete.dashboard'))
+            ->assertOk();
+
+        // Step D: Coach dashboard includes the booking in revenue.
+        // The dashboard sums confirmed booking amount_paid for the coach's sessions.
+        $this->actingAs($coach)
+            ->get(route('coach.dashboard'))
+            ->assertOk();
+
+        // Verify via DB that the revenue query would include this booking.
+        $revenueCents = (int) DB::table('bookings')
+            ->join('sport_sessions', 'sport_sessions.id', '=', 'bookings.sport_session_id')
+            ->where('sport_sessions.coach_id', $coach->id)
+            ->where('bookings.status', BookingStatus::Confirmed->value)
+            ->sum('bookings.amount_paid');
+
+        expect($revenueCents)->toBe(3000);
+
+        // Step E: Accountant transaction ledger includes the booking.
+        $accountant = User::factory()->accountant()->withTwoFactor()->create();
+        $this->actingAs($accountant)
+            ->get(route('accountant.transactions.index'))
+            ->assertOk();
+
+        // Step F: Admin refund queue (default filter: confirmed + amount_paid > 0)
+        // shows the booking as eligible and the payment intent is present.
+        $admin = User::factory()->admin()->withTwoFactor()->create();
+        $this->actingAs($admin)
+            ->get(route('admin.refunds.index'))
+            ->assertOk();
+
+        // Verify the booking passes the default eligibility criteria.
+        $fromDefaultQueue = Booking::where('status', BookingStatus::Confirmed->value)
+            ->where('amount_paid', '>', 0)
+            ->where('stripe_payment_intent_id', 'pi_e2e_full_confirmed')
+            ->exists();
+
+        expect($fromDefaultQueue)->toBeTrue();
+    });
+
+    // ── Session status transition: reaches confirmed when min_participants is met ─
+
+    it('session transitions to Confirmed when webhook causes min_participants to be reached', function () {
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->approved()->for($coach)->create([
+            'stripe_account_id' => 'acct_e2e_session_confirm',
+            'stripe_onboarding_complete' => true,
+        ]);
+
+        $session = SportSession::factory()->published()->for($coach, 'coach')->create([
+            'min_participants' => 2,
+            'max_participants' => 5,
+            'current_participants' => 2,
+        ]);
+
+        // First booking already confirmed.
+        Booking::factory()->confirmed()->for($session, 'sportSession')->create();
+
+        // Second pending booking about to be confirmed by webhook.
+        $pending = Booking::factory()->pendingPayment()->for($session, 'sportSession')->create([
+            'stripe_checkout_session_id' => 'cs_e2e_session_confirm',
+        ]);
+
+        postStripeWebhookEvent(
+            null,
+            $this->webhookSecret,
+            'evt_e2e_session_confirm',
+            'checkout.session.completed',
+            [
+                'id' => 'cs_e2e_session_confirm',
+                'payment_intent' => 'pi_e2e_session_confirm',
+                'amount_total' => 2000,
+                'metadata' => [
+                    'session_id' => (string) $session->id,
+                    'athlete_id' => (string) $pending->athlete_id,
+                ],
+            ],
+        )->assertOk();
+
+        expect($pending->fresh()->status)->toBe(BookingStatus::Confirmed);
+        expect($session->fresh()->status)->toBe(SessionStatus::Confirmed);
+    });
+
+    // ── Failed path: Stripe outage keeps capacity hold, no duplicate booking ──
+
+    it('failed checkout creation keeps the PendingPayment hold without doubling capacity', function () {
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->approved()->for($coach)->create([
+            'stripe_account_id' => 'acct_e2e_fail',
+            'stripe_onboarding_complete' => true,
+        ]);
+
+        $session = SportSession::factory()->published()->for($coach, 'coach')->create([
+            'price_per_person' => 1500,
+        ]);
+        $athlete = User::factory()->athlete()->create();
+
+        bindThrowingPaymentService('Stripe API temporarily unavailable');
+
+        Livewire::actingAs($athlete)
+            ->test(Book::class, ['sportSession' => $session])
+            ->call('book')
+            ->assertDispatched('notify');
+
+        // Exactly one capacity hold must exist — no duplicate booking rows.
+        expect(Booking::where('sport_session_id', $session->id)->count())->toBe(1);
+
+        $hold = Booking::where('sport_session_id', $session->id)->first();
+        expect($hold->status)->toBe(BookingStatus::PendingPayment);
+        expect($hold->amount_paid)->toBe(0);
+
+        // Capacity is incremented once (the hold), not twice.
+        expect($session->fresh()->current_participants)->toBe(1);
+    });
+
+    // ── Retry reuses the existing pending hold ────────────────────────────────
+
+    it('retrying with a working Stripe after a failed attempt reuses the existing hold', function () {
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->approved()->for($coach)->create([
+            'stripe_account_id' => 'acct_e2e_retry',
+            'stripe_onboarding_complete' => true,
+        ]);
+
+        $session = SportSession::factory()->published()->for($coach, 'coach')->create([
+            'price_per_person' => 2000,
+        ]);
+        $athlete = User::factory()->athlete()->create();
+
+        // First attempt: Stripe fails.
+        bindThrowingPaymentService();
+        Livewire::actingAs($athlete)
+            ->test(Book::class, ['sportSession' => $session])
+            ->call('book')
+            ->assertDispatched('notify');
+
+        // Second attempt: Stripe succeeds.
+        bindFakePaymentService('cs_e2e_retry', 'https://checkout.stripe.com/pay/cs_e2e_retry');
+        Livewire::actingAs($athlete)
+            ->test(Book::class, ['sportSession' => $session])
+            ->call('book')
+            ->assertRedirect('https://checkout.stripe.com/pay/cs_e2e_retry');
+
+        // Must still have exactly one booking row.
+        expect(Booking::where('sport_session_id', $session->id)->where('athlete_id', $athlete->id)->count())->toBe(1);
+
+        // Capacity is incremented only once.
+        expect($session->fresh()->current_participants)->toBe(1);
+    });
+
+});

--- a/tests/Feature/Mvp/SeederSmokeTest.php
+++ b/tests/Feature/Mvp/SeederSmokeTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 use App\Enums\BookingStatus;
 use App\Enums\CoachPayoutStatementStatus;
 use App\Enums\CoachProfileStatus;
+use App\Enums\PaymentAnomalyType;
 use App\Enums\UserRole;
+use App\Models\ActivityImage;
 use App\Models\Booking;
 use App\Models\CoachPayoutStatement;
 use App\Models\CoachProfile;
@@ -15,10 +17,40 @@ use App\Models\SportSession;
 use App\Models\User;
 use Database\Seeders\MvpJourneySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
 
 uses(RefreshDatabase::class);
 
+function ensureMvpSeederStorageSymlink(): bool
+{
+    $linkPath = public_path('storage');
+
+    if (is_link($linkPath)) {
+        return false;
+    }
+
+    $target = storage_path('app/public');
+
+    if (! is_dir($target)) {
+        mkdir($target, 0755, true);
+    }
+
+    symlink($target, $linkPath);
+
+    return true;
+}
+
 describe('MvpJourneySeeder', function () {
+
+    beforeEach(function (): void {
+        $GLOBALS['mvpSeederStorageSymlinkCreated'] = ensureMvpSeederStorageSymlink();
+    });
+
+    afterEach(function (): void {
+        if (($GLOBALS['mvpSeederStorageSymlinkCreated'] ?? false) && is_link(public_path('storage'))) {
+            unlink(public_path('storage'));
+        }
+    });
 
     it('creates all expected demo users', function () {
         $this->seed(MvpJourneySeeder::class);
@@ -81,6 +113,94 @@ describe('MvpJourneySeeder', function () {
         expect($postalCodes)->toContain('1000');
         expect($postalCodes)->toContain('1020');
         expect($postalCodes)->toContain('1050');
+    });
+
+    it('creates sessions with coordinates and public activity images', function () {
+        $this->seed(MvpJourneySeeder::class);
+
+        expect(SportSession::whereNull('latitude')->orWhereNull('longitude')->count())->toBe(0);
+        expect(SportSession::whereNull('cover_image_id')->count())->toBe(0);
+        expect(ActivityImage::count())->toBeGreaterThanOrEqual(3);
+
+        ActivityImage::all()->each(function (ActivityImage $image): void {
+            expect(Storage::disk('public')->exists($image->path))->toBeTrue();
+            expect(file_exists(public_path('storage/'.ltrim($image->path, '/'))))->toBeTrue();
+        });
+    });
+
+    it('creates coherent payment fields for non-anomalous paid bookings', function () {
+        $this->seed(MvpJourneySeeder::class);
+
+        $anomalousBookingIds = PaymentAnomaly::where(
+            'anomaly_type',
+            PaymentAnomalyType::ConfirmedBookingMissingPayment->value,
+        )->pluck('related_booking_id');
+
+        $bookings = Booking::whereIn('status', [
+            BookingStatus::Confirmed->value,
+            BookingStatus::Refunded->value,
+        ])->whereNotIn('id', $anomalousBookingIds)->get();
+
+        expect($bookings)->not->toBeEmpty();
+
+        $bookings->each(function (Booking $booking): void {
+            expect($booking->amount_paid)->toBeGreaterThan(0);
+            expect($booking->stripe_checkout_session_id)->not->toBeNull();
+            expect($booking->stripe_payment_intent_id)->not->toBeNull();
+
+            if ($booking->status === BookingStatus::Refunded) {
+                expect($booking->refunded_at)->not->toBeNull();
+            }
+        });
+    });
+
+    it('creates a labelled anomalous booking for accountant and admin smoke checks', function () {
+        $this->seed(MvpJourneySeeder::class);
+
+        $anomaly = PaymentAnomaly::where(
+            'anomaly_type',
+            PaymentAnomalyType::ConfirmedBookingMissingPayment->value,
+        )->first();
+
+        expect($anomaly)->not->toBeNull();
+        expect($anomaly->booking)->not->toBeNull();
+        expect($anomaly->booking->status)->toBe(BookingStatus::Confirmed);
+        expect($anomaly->booking->amount_paid)->toBe(0);
+        expect($anomaly->description)->toContain('Demo anomaly');
+    });
+
+    it('fails clearly when public storage is not linked', function () {
+        if (is_link(public_path('storage'))) {
+            unlink(public_path('storage'));
+        }
+
+        $GLOBALS['mvpSeederStorageSymlinkCreated'] = false;
+
+        expect(fn () => $this->seed(MvpJourneySeeder::class))
+            ->toThrow(RuntimeException::class, 'MvpJourneySeeder requires public/storage to be linked');
+    });
+
+    it('renders discovery map and image-backed session cards', function () {
+        $this->seed(MvpJourneySeeder::class);
+
+        $this->get(route('sessions.index'))
+            ->assertOk()
+            ->assertSee('id="session-map"', false)
+            ->assertSee('sessionMap(', false)
+            ->assertSee('activity-images/mvp-cardio.svg', false);
+    });
+
+    it('renders detail map and a coordinate-based directions link', function () {
+        $this->seed(MvpJourneySeeder::class);
+
+        $session = SportSession::where('title', 'Running Cinquantenaire — Cardio Débutant')->firstOrFail();
+
+        $this->get(route('sessions.show', $session))
+            ->assertOk()
+            ->assertSee('id="detail-map"', false)
+            ->assertSee('sessionMap(', false)
+            ->assertSee('destination=50.8390000,4.3860000', false)
+            ->assertSee('activity-images/mvp-cardio.svg', false);
     });
 
     it('creates a suspended user', function () {


### PR DESCRIPTION
## Summary

Implements **Story 6.1** — Add a True End-to-End Booking Payment Smoke Test.

### What this adds

`tests/Feature/Mvp/BookingPaymentJourneyTest.php` — 6 tests, 36 assertions:

| Test | What it proves |
|---|---|
| Creates PendingPayment hold and redirects to Stripe | Step 1 of the booking flow works end-to-end |
| `checkout.session.completed` webhook confirms booking | Webhook persists `amount_paid` + `stripe_payment_intent_id` |
| Full journey: book → webhook → all four roles | Athlete dashboard, coach revenue, accountant ledger, admin refund queue all see the confirmed booking |
| Session transitions to Confirmed at `min_participants` | Webhook-driven session status transition |
| Failed Stripe checkout keeps hold, no duplicate capacity | Story 1.2: capacity hold survives Stripe outage |
| Retry reuses the existing hold | Story 1.2: no double-capacity increment on retry |

### What it does NOT call

- No real Stripe API calls. Checkout session creation is mocked via the `PaymentService` closure injection point.
- Webhook processing reuses the existing signed-payload pattern from `tests/Feature/Webhooks/`.

## Validation
- `php artisan test tests/Feature/Mvp/`: **109 passed, 247 assertions**
- `vendor/bin/pint --test`: **468 files, clean**

## Merge
Intended for **Squash and merge** (auto-squash workflow).