### PR TITLE
Fix map issue and improve session booking translations

### DIFF
--- a/app/Livewire/Session/Show.php
+++ b/app/Livewire/Session/Show.php
@@ -64,8 +64,8 @@ final class Show extends Component
         return collect([[
             'id' => $this->sportSession->id,
             'title' => $this->sportSession->title,
-            'latitude' => $this->sportSession->latitude,
-            'longitude' => $this->sportSession->longitude,
+            'latitude' => (float) $this->sportSession->latitude,
+            'longitude' => (float) $this->sportSession->longitude,
             'coach' => $this->sportSession->coach->name,
             'date' => $this->sportSession->date->translatedFormat('d/m/Y'),
             'time' => Carbon::parse($this->sportSession->start_time)->format('H:i'),

--- a/doc/stories/README.md
+++ b/doc/stories/README.md
@@ -10,6 +10,7 @@ This directory contains the detailed story breakdown for the Motivya project. Ea
 | [epic-2-coach.md](epic-2-coach.md) | Coach "Business-in-a-Box" | Epic 2 | Epic 1 |
 | [epic-3-athlete.md](epic-3-athlete.md) | Athlete Experience & Payments | Epic 3 | Epic 1, Epic 2 |
 | [epic-4-accountant.md](epic-4-accountant.md) | Accountant Portal + Invoicing | Epic 4 | Epic 3 |
+| [mvp-address-geolocation.md](mvp-address-geolocation.md) | MVP Address and Geolocation Precision | MVP Stabilization | Epic 2, Epic 3 |
 
 ## Conventions
 

--- a/doc/stories/mvp-address-geolocation.md
+++ b/doc/stories/mvp-address-geolocation.md
@@ -1,0 +1,224 @@
+# MVP Address and Geolocation Precision
+
+## Epic
+
+Title: Deliver Precise Validated Addresses for MVP Search, Sessions, and Directions
+
+Context: Motivya already has MapLibre/OpenFreeMap map rendering, Google directions links, `postal_code_coordinates`, `geocoding_cache`, `GeocodingService`, and distance-based session search. Local review shows session creation and editing still use split `location` and `postalCode` fields, `SessionService` still resolves coordinates through `PostalCodeCoordinateService`, and typed discovery searches only resolve postal codes or municipalities. Coach application/profile address data is also postal-code-only. OVH production has the required migrations (`sport_sessions`, `postal_code_coordinates`, `geocoding_cache`) and a configured Google Maps key, but `sport_sessions` stores only `location`, `postal_code`, `latitude`, and `longitude`; production currently has 9 sessions, 3 distinct session postal codes, 8 sessions with coordinates, 1 session missing coordinates, 35 postal-code reference rows, and 0 geocoding-cache rows. Existing coordinates therefore represent postal-code centers, not validated street addresses.
+
+Problem: The MVP cannot support user expectations for precise address entry, exact session pins, exact directions, or address-based search. The current implementation validates postal-code syntax instead of validating an address against the active maps/geocoding provider, and it does not persist a normalized address result or provider metadata.
+
+Solution: Add provider-backed address validation, store normalized address data and exact coordinates for every address-bearing workflow, replace split address inputs with one validated address field, update search and directions to use precise coordinates, and provide a production-safe backfill path for existing rows.
+
+Implementation Instructions:
+
+1. Implement the child stories below in order.
+2. Keep MapLibre/OpenFreeMap for map display. Do not replace the map component with Google Maps JavaScript.
+3. Use Laravel services for provider calls and normalization; keep Livewire components thin and use Form Objects.
+4. Use localized strings in `lang/fr`, `lang/en`, and `lang/nl` for all user-visible labels, placeholders, validation errors, and readiness messages.
+5. Do not call an external geocoder on every keystroke. Resolve only when the user selects a suggestion, submits a search, or triggers an explicit validation action with debounce and cache.
+
+Definition of Done:
+
+- Every child story below is completed in dependency order.
+- The requested behavior is implemented and follows the applicable project conventions.
+- Relevant automated tests are added or updated for the business logic and user-visible behavior.
+- Lint checks pass without warnings or errors.
+- Relevant test suites pass without warnings or errors.
+- No unrelated behavior, migrations, dependencies, or documentation are changed unless a child story explicitly requires them.
+
+## Story 1
+
+Title: Add Provider-Backed Address Validation Service
+
+Context: `app/Services/GeocodingService.php` currently resolves postal codes/municipalities locally and falls back to Google coordinates. It returns only latitude and longitude, and the cache table stores only query/provider/coordinates/found. The MVP requires a single address field that is validated against whichever geocoding provider is active. Both Google and the OpenFreeMap-compatible provider must work.
+
+Problem: There is no service contract that can validate a full street address, normalize the selected result, enforce Belgian address constraints, expose postal code/city/country components, or preserve provider metadata for storage and auditing.
+
+Solution: Introduce a reusable address validation layer that returns a normalized `ValidatedAddress` result for both Google and OpenFreeMap-compatible providers, with cached provider responses and deterministic validation failures.
+
+Implementation Instructions:
+
+1. Create `app/DataTransferObjects/ValidatedAddress.php` with fields: `formattedAddress`, `streetAddress`, `locality`, `postalCode`, `country`, `latitude`, `longitude`, `provider`, `providerPlaceId`, and `rawPayload`.
+2. Add `MAPS_GEOCODING_PROVIDER=google`, `OPENFREEMAP_GEOCODING_BASE_URL=`, and `OPENFREEMAP_GEOCODING_API_KEY=` to `.env.example`, and expose them through `config/maps.php`.
+3. Create `app/Services/AddressValidationService.php` that accepts a free-text address query and locale, chooses `config('maps.geocoding_provider')`, calls exactly one active provider, and returns `ValidatedAddress` only when the provider returns one Belgian street-level or venue-level result with coordinates.
+4. Implement a Google provider using the existing Google geocoding base URL and API key; it must reject non-BE results and results without coordinates or usable formatted address.
+5. Implement an OpenFreeMap-compatible provider using the configured base URL and optional API key; it must parse Nominatim-style JSON responses, reject non-BE results, and return the same `ValidatedAddress` shape.
+6. Extend or replace `geocoding_cache` storage so successful and failed address validations are cached by normalized query, locale, country, provider, and purpose `address_validation`; do not break existing city/postal-code search cache reads.
+7. Keep `PostalCodeCoordinateService` for postal-code reference lookups until later stories replace session write paths.
+8. Add structured logging for provider failures without logging API keys or full raw payloads.
+
+Definition of Done:
+
+- Address validation works with `MAPS_GEOCODING_PROVIDER=google` and `MAPS_GEOCODING_PROVIDER=openfreemap` using mocked HTTP responses.
+- Non-Belgian, ambiguous, coordinate-less, and not-found provider responses return validation failures instead of silently storing postal-code centers.
+- Cached successful and failed validations avoid duplicate HTTP calls.
+- Unit tests cover Google success/failure, OpenFreeMap-compatible success/failure, cache hits, provider selection, and secret-safe logging.
+- The requested behavior is implemented and follows the applicable project conventions.
+- Relevant automated tests are added or updated for the business logic and user-visible behavior.
+- Lint checks pass without warnings or errors.
+- Relevant test suites pass without warnings or errors.
+- No unrelated behavior, migrations, dependencies, or documentation are changed unless this story explicitly requires them.
+
+## Story 2
+
+Title: Store Normalized Address Data on Address-Bearing Models
+
+Context: `sport_sessions` has `location`, `postal_code`, `latitude`, and `longitude`; `coach_profiles` has `postal_code` and `country`. Production has no columns for formatted address, street address, locality, provider, provider place ID, geocoding timestamp, or provider payload. Admin exports currently include postal code but not exact address provenance.
+
+Problem: Even if the UI validates an address, the database cannot persist enough normalized address information to prove what was selected, show a complete address, backfill safely, or distinguish exact street coordinates from postal-code center coordinates.
+
+Solution: Add explicit normalized address columns to every address-bearing model while preserving legacy columns for compatibility during migration.
+
+Implementation Instructions:
+
+1. Create a migration for `sport_sessions` adding nullable columns: `formatted_address`, `street_address`, `locality`, `country` default `BE`, `geocoding_provider`, `geocoding_place_id`, `geocoded_at`, and `geocoding_payload` JSON.
+2. Create a migration for `coach_profiles` adding nullable columns: `formatted_address`, `street_address`, `locality`, `latitude`, `longitude`, `geocoding_provider`, `geocoding_place_id`, `geocoded_at`, and `geocoding_payload` JSON.
+3. Keep existing `location`, `postal_code`, and `country` columns for backward compatibility; do not drop or rename them in this story.
+4. Update `SportSession` and `CoachProfile` fillable/casts for the new fields, using `datetime` for `geocoded_at`, `array` for `geocoding_payload`, and decimal casts for coach profile coordinates.
+5. Update `database/factories/SportSessionFactory.php` and `database/factories/CoachProfileFactory.php` with states for validated precise addresses.
+6. Update `DatabaseExportService` coach and session exports to include formatted address, locality, latitude, longitude, geocoding provider, and geocoded-at timestamp.
+
+Definition of Done:
+
+- Fresh SQLite migrations and MySQL-compatible migrations create the new columns reversibly.
+- Existing code paths still work when new address columns are null.
+- Model tests cover fillable fields and casts for both models.
+- Export tests cover the new address and coordinate columns.
+- The requested behavior is implemented and follows the applicable project conventions.
+- Relevant automated tests are added or updated for the business logic and user-visible behavior.
+- Lint checks pass without warnings or errors.
+- Relevant test suites pass without warnings or errors.
+- No unrelated behavior, migrations, dependencies, or documentation are changed unless this story explicitly requires them.
+
+## Story 3
+
+Title: Replace Session Address Entry With One Validated Address Field
+
+Context: `SessionForm` currently exposes `location` and `postalCode`; `resources/views/livewire/session/create.blade.php` and `resources/views/livewire/session/edit.blade.php` render two separate fields. `SessionService` resolves session coordinates from the postal code through `PostalCodeCoordinateService`, including recurring sessions and group updates.
+
+Problem: Coaches can create or update a session with a venue name plus postal code that produces only postal-code center coordinates. The session detail map and directions can therefore point to the wrong place.
+
+Solution: Session create/edit must use a single address field, validate it through `AddressValidationService`, and persist the normalized address and exact coordinates from the selected provider result.
+
+Implementation Instructions:
+
+1. Update `SessionForm` to expose one user-facing `addressQuery` field plus hidden normalized address fields required by `ValidatedAddress`; remove user-facing postal-code validation from the form.
+2. Update `create.blade.php` and `edit.blade.php` to render one localized address input with an explicit validate/select action and a confirmation state showing the selected formatted address.
+3. In `Create` and `Edit` Livewire components, call `AddressValidationService` before saving; block save with localized validation errors when the address is missing, unvalidated, stale after editing, outside Belgium, or missing coordinates.
+4. Update `SessionService` create/update/createRecurring/updateGroup to accept normalized address data and set `location`, `postal_code`, `formatted_address`, `street_address`, `locality`, `country`, `latitude`, `longitude`, `geocoding_provider`, `geocoding_place_id`, `geocoded_at`, and `geocoding_payload` from `ValidatedAddress`.
+5. Remove `PostalCodeCoordinateService` from `SessionService` constructor after all session write paths use validated address data.
+6. Update `publish()` validation so a publishable session requires a validated formatted address and exact latitude/longitude, not only `location` and `postal_code`.
+7. Ensure recurring session creation resolves the address once and applies the same normalized address data to every generated session.
+8. Update session tests that currently set only `postal_code` so they use the validated-address factory state or provide exact coordinates and normalized address fields.
+
+Definition of Done:
+
+- A coach can create, edit, and bulk-update recurring sessions using one address field.
+- Saved sessions contain formatted address, postal code, locality, provider metadata, and exact coordinates from the selected provider result.
+- A session cannot be published when its address has not been validated or has no exact coordinates.
+- Existing detail pages remain readable for legacy rows with only `location` and `postal_code`.
+- Feature/Livewire tests cover create, edit, recurring create, recurring future update, invalid address, and stale-address validation.
+- The requested behavior is implemented and follows the applicable project conventions.
+- Relevant automated tests are added or updated for the business logic and user-visible behavior.
+- Lint checks pass without warnings or errors.
+- Relevant test suites pass without warnings or errors.
+- No unrelated behavior, migrations, dependencies, or documentation are changed unless this story explicitly requires them.
+
+## Story 4
+
+Title: Replace Coach Profile Address Entry With One Validated Address Field
+
+Context: Coach application step 2 and coach profile edit currently collect only `postal_code` and `country`. `coach_profiles` does not store coordinates, so coach geography cannot support precise address validation or future proximity features.
+
+Problem: Coach address data remains postal-code-only even after session addresses become precise, violating the MVP requirement that all address fields use one validated address field and store exact coordinates.
+
+Solution: Coach application and profile edit must use the same single validated address workflow and persist normalized address data and exact coordinates on `coach_profiles`.
+
+Implementation Instructions:
+
+1. Update `CoachApplicationForm` and `CoachProfileForm` to expose one user-facing `addressQuery` field plus hidden normalized address fields from `ValidatedAddress`; keep `postal_code` and `country` as persisted compatibility fields derived from the validated result.
+2. Update `Application` step 2 and `ProfileEdit` save handling to validate the address through `AddressValidationService` and reject missing, stale, non-Belgian, or coordinate-less results.
+3. Update `CoachApplicationService` to persist normalized address fields and coordinates when creating a pending profile.
+4. Update `profile-edit.blade.php` and `application.blade.php` to show a single localized address input and selected-address confirmation instead of separate postal code/country inputs.
+5. Update coach profile display and admin KYC review views, where applicable, to show the formatted address while preserving postal code visibility for legacy rows.
+6. Update tests in `tests/Feature/Livewire/Coach` and notification tests that currently set only `form.postal_code`.
+
+Definition of Done:
+
+- Coach application and coach profile edit use one validated address field.
+- Saved coach profiles contain formatted address, postal code, locality, country, provider metadata, and exact coordinates.
+- Invalid, stale, non-Belgian, and coordinate-less addresses block submission with localized errors.
+- Admin/coach views display formatted address for precise rows and keep legacy postal-code fallback readable.
+- Feature/Livewire tests cover application submit, profile edit, validation failures, and KYC/read-only display where applicable.
+- The requested behavior is implemented and follows the applicable project conventions.
+- Relevant automated tests are added or updated for the business logic and user-visible behavior.
+- Lint checks pass without warnings or errors.
+- Relevant test suites pass without warnings or errors.
+- No unrelated behavior, migrations, dependencies, or documentation are changed unless this story explicitly requires them.
+
+## Story 5
+
+Title: Use Precise Coordinates for Discovery Search, Maps, and Directions
+
+Context: `Session\Index` already supports browser geolocation, but typed `locationQuery` uses `PostalCodeCoordinateService::resolveByLocationQuery`, so typed searches are city/postal-code center based. `Show` directions use lat/lng when present, but existing lat/lng values may be postal-code centers. Map markers use the session coordinates as stored.
+
+Problem: Athletes cannot search by their current position plus precise session pins when session coordinates are postal-code centers, and typed address searches cannot use exact address coordinates. Directions can be technically coordinate-based while still leading to a postal-code center.
+
+Solution: Discovery must use exact coordinates from validated session addresses and must resolve typed location searches through the address validation/geocoding layer before applying radius filters. Directions must always prefer validated exact coordinates and clearly fall back only for legacy rows.
+
+Implementation Instructions:
+
+1. Update `Session\Index` to use `AddressValidationService` for non-empty `locationQuery` values that are not resolved by the local postal-code/municipality lookup, caching the result and using its exact coordinates as the search center.
+2. Keep browser geolocation as the highest-priority search center when `useGeolocation` is true.
+3. Keep backward-compatible support for `postalCode` URL aliases during migration.
+4. Update result cards, map popups, and session detail location display to use `formatted_address` when present and legacy `location` plus `postal_code` when not.
+5. Update the directions URL generation so validated rows use `latitude,longitude`; legacy rows without validated exact coordinates use encoded formatted/legacy address text only as a fallback.
+6. Add a small model helper on `SportSession`, such as `hasValidatedAddress()`, so views do not duplicate provider/coordinate checks.
+7. Update translations for location search labels/placeholders so users can search by current position, full address, city, or postal code.
+
+Definition of Done:
+
+- Athlete discovery can use browser position, full address query, city/municipality, or postal code as the search center.
+- Radius filtering and map markers remain consistent with the active search center.
+- Session detail maps and directions use exact validated coordinates when available.
+- Legacy rows remain viewable and searchable through existing postal-code/city behavior until backfilled.
+- Tests cover full-address typed search with mocked provider result, browser geolocation priority, legacy postal-code alias, map marker consistency, and directions URL behavior for validated and legacy rows.
+- The requested behavior is implemented and follows the applicable project conventions.
+- Relevant automated tests are added or updated for the business logic and user-visible behavior.
+- Lint checks pass without warnings or errors.
+- Relevant test suites pass without warnings or errors.
+- No unrelated behavior, migrations, dependencies, or documentation are changed unless this story explicitly requires them.
+
+## Story 6
+
+Title: Backfill and Monitor Production Address Precision
+
+Context: OVH production currently has the schema needed for postal-code coordinates and geocoding cache, a configured Google Maps key, 9 sessions, 8 session rows with coordinates, 1 session missing coordinates, and an empty geocoding cache. Existing coordinates were produced by postal-code lookup and cannot be assumed precise.
+
+Problem: Deploying precise address support will leave existing production rows in a mixed state unless operators can identify postal-code-center rows, validate exact addresses, and monitor readiness without creating demo data or exposing secrets.
+
+Solution: Add production-safe commands and readiness checks that report address precision coverage, backfill exact addresses only from validated provider responses, and keep legacy rows visible until an operator validates them.
+
+Implementation Instructions:
+
+1. Create `php artisan addresses:audit-precision` to report counts for sessions and coach profiles: total rows, validated exact addresses, legacy postal-code-only rows, rows missing coordinates, rows missing formatted address, and provider distribution.
+2. Create `php artisan addresses:backfill --model=sessions|coach_profiles --dry-run` that attempts provider validation only when enough legacy text exists to form a plausible Belgian address; dry-run must be the default behavior.
+3. Require `--apply` to write normalized address fields and exact coordinates; never overwrite rows that already have `formatted_address`, provider metadata, and coordinates unless `--force` is explicitly passed.
+4. Record audit events or structured logs for every applied row, including model type, model id, provider, and whether coordinates changed, without logging API keys.
+5. Update `app/Livewire/Admin/Readiness.php` and `app/Console/Commands/MvpHealthSnapshot.php` to report address precision coverage separately from postal-code reference data.
+6. Update `doc/Production-Readiness-Runbook.md` and `doc/MVP-Smoke-Test.md` with the new audit and backfill commands.
+7. Add tests for dry-run behavior, apply behavior, no-overwrite behavior, missing-data skips, and readiness/status output.
+
+Definition of Done:
+
+- Operators can see exact-address coverage for sessions and coach profiles without inspecting the database manually.
+- Backfill defaults to dry-run and writes only when `--apply` is passed.
+- Existing postal-code-center coordinates are not silently treated as validated exact addresses.
+- Readiness distinguishes postal-code reference availability from precise address validation coverage.
+- Production runbook and MVP smoke test explain the deployment/backfill order.
+- The requested behavior is implemented and follows the applicable project conventions.
+- Relevant automated tests are added or updated for the business logic and user-visible behavior.
+- Lint checks pass without warnings or errors.
+- Relevant test suites pass without warnings or errors.
+- No unrelated behavior, migrations, dependencies, or documentation are changed unless this story explicitly requires them.

--- a/lang/en/bookings.php
+++ b/lang/en/bookings.php
@@ -9,6 +9,7 @@ return [
     'session_status_label' => 'Session status',
     'booking_status_label' => 'Booking status',
     'book_action' => 'Book this session',
+    'opening_confirmation' => 'Opening…',
     'processing' => 'Redirecting to payment…',
     'ready_to_book' => 'Reserve your spot and continue to payment.',
     'already_booked' => 'You already have a booking for this session.',

--- a/lang/fr/bookings.php
+++ b/lang/fr/bookings.php
@@ -9,6 +9,7 @@ return [
     'session_status_label' => 'Statut de la séance',
     'booking_status_label' => 'Statut de la réservation',
     'book_action' => 'Réserver cette séance',
+    'opening_confirmation' => 'Ouverture…',
     'processing' => 'Redirection vers le paiement…',
     'ready_to_book' => 'Réservez votre place et poursuivez vers le paiement.',
     'already_booked' => 'Vous avez déjà une réservation pour cette séance.',

--- a/lang/nl/bookings.php
+++ b/lang/nl/bookings.php
@@ -9,6 +9,7 @@ return [
     'session_status_label' => 'Sessiestatus',
     'booking_status_label' => 'Boekingsstatus',
     'book_action' => 'Boek deze sessie',
+    'opening_confirmation' => 'Openen…',
     'processing' => 'Doorsturen naar betaling…',
     'ready_to_book' => 'Reserveer je plaats en ga verder naar de betaling.',
     'already_booked' => 'Je hebt al een boeking voor deze sessie.',

--- a/resources/js/session-map.js
+++ b/resources/js/session-map.js
@@ -2,49 +2,86 @@ import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 
 /**
+ * Return true when a value is a finite number (not NaN, not Infinity).
+ * Accepts both number primitives and numeric strings emitted by PHP's
+ * decimal:7 model cast so that either form passes validation.
+ *
+ * @param {*} v
+ * @returns {boolean}
+ */
+function isFiniteNumber(v) {
+    return (typeof v === 'number' || typeof v === 'string') && v !== '' && isFinite(Number(v));
+}
+
+/**
  * Alpine.js data factory for the session map component.
  *
  * Uses MapLibre GL JS (open-source, no API key required) with free
  * OpenFreeMap vector tiles. Marker clustering is handled by MapLibre's
  * built-in GeoJSON cluster support.
  *
+ * IMPORTANT: The MapLibre Map and Popup objects are stored in closure-local
+ * variables (_map, _popup) rather than on the Alpine reactive state object.
+ * MapLibre uses non-configurable, non-writable internal properties (such as
+ * colour arrays) that violate the ES2015 Proxy invariant when Alpine wraps them
+ * in a reactive proxy, producing "'rgb' is a read-only and non-configurable
+ * data property" errors that corrupt the Alpine/Livewire update cycle and
+ * prevent the booking confirmation modal from opening.
+ *
  * @param {string} containerId - The DOM element ID to render the map into
- * @param {Array} markers - Array of session marker objects from SessionQueryService::mapMarkers()
- * @param {Array} fallbackCenter - [lng, lat] to use when no markers are present (default: Brussels)
+ * @param {Array}  markers      - Array of session marker objects from SessionQueryService::mapMarkers()
+ * @param {Array}  fallbackCenter - [lng, lat] to use when no markers are present (default: Brussels)
  */
 export function sessionMap(containerId, markers, fallbackCenter = [4.3517, 50.8503]) {
-    return {
-        map: null,
-        popup: null,
+    // Closure-local variables — intentionally NOT on the Alpine reactive object
+    // so that MapLibre's internal state is never wrapped in a Proxy.
+    let _map = null;
+    let _popup = null;
 
+    // Validate fallbackCenter: both elements must be finite numbers.
+    const validFallback =
+        Array.isArray(fallbackCenter) &&
+        fallbackCenter.length >= 2 &&
+        isFiniteNumber(fallbackCenter[0]) &&
+        isFiniteNumber(fallbackCenter[1])
+            ? [Number(fallbackCenter[0]), Number(fallbackCenter[1])]
+            : [4.3517, 50.8503];
+
+    return {
         initMap() {
-            this.map = new maplibregl.Map({
+            _map = new maplibregl.Map({
                 container: containerId,
                 // OpenFreeMap liberty style — free, no API key, hosted by the OSM community
                 style: 'https://tiles.openfreemap.org/styles/liberty',
-                center: fallbackCenter,
+                center: validFallback,
                 zoom: 11,
             });
 
-            this.map.addControl(new maplibregl.NavigationControl(), 'top-right');
+            _map.addControl(new maplibregl.NavigationControl(), 'top-right');
 
-            this.popup = new maplibregl.Popup({ closeButton: true, closeOnClick: false });
+            _popup = new maplibregl.Popup({ closeButton: true, closeOnClick: false });
 
-            this.map.on('load', () => {
+            _map.on('load', () => {
                 this.addMarkers(markers);
             });
         },
 
-        addMarkers(markers) {
-            if (!this.map) return;
+        addMarkers(markerList) {
+            if (!_map) return;
+
+            // Reject markers where lat or lng is missing, null, or non-numeric.
+            // PHP's decimal:7 cast returns numeric strings; coerce to Number here.
+            const validMarkers = markerList.filter(
+                (s) => isFiniteNumber(s.latitude) && isFiniteNumber(s.longitude),
+            );
 
             const geojson = {
                 type: 'FeatureCollection',
-                features: markers.map((session) => ({
+                features: validMarkers.map((session) => ({
                     type: 'Feature',
                     geometry: {
                         type: 'Point',
-                        coordinates: [session.longitude, session.latitude],
+                        coordinates: [Number(session.longitude), Number(session.latitude)],
                     },
                     properties: {
                         id: session.id,
@@ -58,10 +95,10 @@ export function sessionMap(containerId, markers, fallbackCenter = [4.3517, 50.85
                 })),
             };
 
-            if (this.map.getSource('sessions')) {
-                this.map.getSource('sessions').setData(geojson);
+            if (_map.getSource('sessions')) {
+                _map.getSource('sessions').setData(geojson);
             } else {
-                this.map.addSource('sessions', {
+                _map.addSource('sessions', {
                     type: 'geojson',
                     data: geojson,
                     cluster: true,
@@ -70,7 +107,7 @@ export function sessionMap(containerId, markers, fallbackCenter = [4.3517, 50.85
                 });
 
                 // Cluster circles
-                this.map.addLayer({
+                _map.addLayer({
                     id: 'clusters',
                     type: 'circle',
                     source: 'sessions',
@@ -83,7 +120,7 @@ export function sessionMap(containerId, markers, fallbackCenter = [4.3517, 50.85
                 });
 
                 // Cluster count labels
-                this.map.addLayer({
+                _map.addLayer({
                     id: 'cluster-count',
                     type: 'symbol',
                     source: 'sessions',
@@ -97,7 +134,7 @@ export function sessionMap(containerId, markers, fallbackCenter = [4.3517, 50.85
                 });
 
                 // Individual session markers
-                this.map.addLayer({
+                _map.addLayer({
                     id: 'unclustered-point',
                     type: 'circle',
                     source: 'sessions',
@@ -111,22 +148,22 @@ export function sessionMap(containerId, markers, fallbackCenter = [4.3517, 50.85
                 });
 
                 // Click cluster → zoom in
-                this.map.on('click', 'clusters', (e) => {
-                    const features = this.map.queryRenderedFeatures(e.point, { layers: ['clusters'] });
+                _map.on('click', 'clusters', (e) => {
+                    const features = _map.queryRenderedFeatures(e.point, { layers: ['clusters'] });
                     const clusterId = features[0].properties.cluster_id;
-                    this.map.getSource('sessions').getClusterExpansionZoom(clusterId, (err, zoom) => {
+                    _map.getSource('sessions').getClusterExpansionZoom(clusterId, (err, zoom) => {
                         if (err) return;
-                        this.map.easeTo({ center: features[0].geometry.coordinates, zoom });
+                        _map.easeTo({ center: features[0].geometry.coordinates, zoom });
                     });
                 });
 
                 // Click individual marker → popup
-                this.map.on('click', 'unclustered-point', (e) => {
+                _map.on('click', 'unclustered-point', (e) => {
                     const props = e.features[0].properties;
                     const coords = e.features[0].geometry.coordinates.slice();
                     const priceFormatted = (props.price / 100).toFixed(2).replace('.', ',');
 
-                    this.popup
+                    _popup
                         .setLngLat(coords)
                         .setHTML(`
                             <div style="min-width:180px;padding:4px;">
@@ -139,27 +176,27 @@ export function sessionMap(containerId, markers, fallbackCenter = [4.3517, 50.85
                                     View session →
                                 </a>
                             </div>`)
-                        .addTo(this.map);
+                        .addTo(_map);
                 });
 
-                this.map.on('mouseenter', 'clusters', () => {
-                    this.map.getCanvas().style.cursor = 'pointer';
+                _map.on('mouseenter', 'clusters', () => {
+                    _map.getCanvas().style.cursor = 'pointer';
                 });
-                this.map.on('mouseleave', 'clusters', () => {
-                    this.map.getCanvas().style.cursor = '';
+                _map.on('mouseleave', 'clusters', () => {
+                    _map.getCanvas().style.cursor = '';
                 });
-                this.map.on('mouseenter', 'unclustered-point', () => {
-                    this.map.getCanvas().style.cursor = 'pointer';
+                _map.on('mouseenter', 'unclustered-point', () => {
+                    _map.getCanvas().style.cursor = 'pointer';
                 });
-                this.map.on('mouseleave', 'unclustered-point', () => {
-                    this.map.getCanvas().style.cursor = '';
+                _map.on('mouseleave', 'unclustered-point', () => {
+                    _map.getCanvas().style.cursor = '';
                 });
             }
 
-            if (markers.length > 0) {
-                const lngs = markers.map((s) => s.longitude);
-                const lats = markers.map((s) => s.latitude);
-                this.map.fitBounds(
+            if (validMarkers.length > 0) {
+                const lngs = validMarkers.map((s) => Number(s.longitude));
+                const lats = validMarkers.map((s) => Number(s.latitude));
+                _map.fitBounds(
                     [[Math.min(...lngs), Math.min(...lats)], [Math.max(...lngs), Math.max(...lats)]],
                     { padding: 40, maxZoom: 14 },
                 );

--- a/resources/views/livewire/booking/book.blade.php
+++ b/resources/views/livewire/booking/book.blade.php
@@ -55,7 +55,7 @@
                 wire:loading.attr="disabled"
                 class="inline-flex items-center justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-70">
                 <span wire:loading.remove wire:target="openConfirmModal">{{ __('bookings.book_action') }}</span>
-                <span wire:loading wire:target="openConfirmModal">{{ __('bookings.processing') }}</span>
+                <span wire:loading wire:target="openConfirmModal">{{ __('bookings.opening_confirmation') }}</span>
             </button>
         @endif
     </div>


### PR DESCRIPTION
**Story 1 — session-map.js**

- `_map` and `_popup` moved to closure-local variables — they are never stored on the Alpine reactive object, so Alpine's Proxy never wraps them and the `rgb` invariant violation is gone.
- Added `isFiniteNumber()` helper that accepts both JS `number` primitives and PHP `decimal:7` numeric strings.
- `addMarkers()` filters out any marker with missing or non-numeric coordinates before building GeoJSON.
- All coordinates passed to MapLibre are coerced with `Number()` so the `Expected value to be of type number` error cannot occur.
- `fitBounds()` only runs when `validMarkers.length > 0`.
- `fallbackCenter` is validated before use; falls back to Brussels if invalid.

**Story 2 — Show.php**

- `latitude` and `longitude` are now explicitly cast to `float` in `mapMarker()`, matching what `SessionQueryService::mapMarkers()` already did. This ensures `json_encode` produces JSON numbers, not strings, in the `x-data` attribute.

**Story 3 — book.blade.php + translations**

- First "Book this session" button now shows `bookings.opening_confirmation` ("Opening…" / "Ouverture…" / "Openen…") while `openConfirmModal` is loading.
- `bookings.processing` ("Redirecting to payment…") is preserved exclusively for the modal's "Confirm & Pay" button.
- Translation key added to bookings.php, bookings.php, and bookings.php.