### PR TITLE
Refactor mapping provider architecture to enforce a coherent Google-or-free system

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,7 @@ See [doc/Glossary.md](../doc/Glossary.md) for the canonical domain vocabulary, [
 - **Storage**: S3-compatible (OVH/Laravel Cloud) in prod; local filesystem in dev/test
 - **Cache**: Valkey-compatible in prod; file driver in dev/test
 - **i18n**: French fr-BE (default), English en-GB, Dutch nl-BE
+- **Maps**: Google Maps Platform when `GOOGLE_MAPS_API_KEY` is configured; otherwise the configured free map stack. The map provider is a hard config-derived selection, never a per-feature mix.
 
 ## Build & Test
 
@@ -56,6 +57,9 @@ php artisan serve
 - Use Laravel's localization (`lang/` directory) for all user-facing strings — never hardcode text
 - Environment-based config: never commit `.env`; use `config()` helper, not `env()` outside config files
 - Prefer `php artisan make:*` generators for scaffolding new classes
+- Do not implement degraded functionality or silent fallback for required external services. If the configured provider is present but fails, fail the operation, log/report the provider error, and expose an actionable readiness/admin status.
+- Map, geocoding, address validation, directions, and provider health checks must be routed through shared services/configuration. Do not inline provider URLs, API-key checks, or ad hoc fallback logic in Blade, Livewire components, or JavaScript entry points.
+- Map provider selection rule: if `GOOGLE_MAPS_API_KEY` is configured, all map capabilities use Google Maps Platform; if it is absent, all map capabilities use the configured free-service alternative. Never use Google for one capability and free services for another in the same runtime configuration.
 
 ## Testing
 

--- a/.github/instructions/maps-provider.instructions.md
+++ b/.github/instructions/maps-provider.instructions.md
@@ -1,0 +1,31 @@
+---
+description: "Use when working on maps, geocoding, address validation, directions links, map provider configuration, map JavaScript, provider health checks, or admin readiness checks for mapping APIs. Enforces Google-or-free-provider selection, no mixed providers, and no silent fallback."
+applyTo: "config/maps.php,app/Services/*Map*,app/Services/*Geocod*,app/Services/*Address*,app/Livewire/**/Readiness*.php,app/Livewire/Session/**,resources/js/*map*.js,resources/views/**/session*.blade.php,resources/views/components/*map*.blade.php,tests/**/*Map*,tests/**/*Geocod*,tests/**/*Address*,doc/**/*map*,doc/**/*geolocation*"
+---
+# Mapping Provider Rules - Motivya
+
+Motivya uses one coherent mapping provider stack per runtime configuration.
+
+## Provider Selection
+
+- Google Maps Platform is selected when `GOOGLE_MAPS_API_KEY` is configured and valid enough to be used.
+- The free-service alternative is selected only when `GOOGLE_MAPS_API_KEY` is absent.
+- Provider selection is a hard configuration-derived decision. Do not add per-feature switches such as one provider for tiles and another for geocoding in the same runtime.
+- Do not silently fall back from Google to the free provider, or from the free provider to Google, after an API error. The selected provider must fail visibly and be reported through logs/readiness checks.
+
+## Capability Coverage
+
+The selected provider stack must own all mapping capabilities:
+
+- Map display/rendering.
+- Address validation and geocoding.
+- Discovery search coordinate resolution.
+- Directions URL generation.
+- Admin readiness and health probes.
+
+## Implementation Shape
+
+- Centralize provider selection and capability calls in services under `app/Services/`; Livewire components and Blade views should consume provider-neutral DTOs or view models.
+- Do not hardcode provider URLs, tile style URLs, JavaScript loader URLs, API keys, or fallback behavior in Blade or feature-specific JavaScript.
+- Health checks must verify every required capability for the selected provider and report actionable failures.
+- Tests must cover Google-selected behavior, free-provider-selected behavior, and configured-provider failure behavior.

--- a/.github/instructions/php.instructions.md
+++ b/.github/instructions/php.instructions.md
@@ -24,7 +24,8 @@ No exceptions — migrations, seeders, config files, tests, service providers, a
 - Use `config()` helper for configuration — never `env()` outside `config/` files
 - Use `Storage::disk()` — never raw filesystem functions
 - Use Laravel built-in features over vendor-specific or low-level PHP equivalents
-- Never implement fallback logic or workarounds without explicit approval
+- Never implement fallback logic or workarounds without explicit approval. Approved alternatives must be explicit, deterministic configuration choices, not silent runtime fallback after an error.
+- Never implement degraded functionality for required external integrations. If the selected provider is configured and fails, log/report the failure and surface an actionable error or readiness status instead of silently switching providers, omitting validation, or returning partial results.
 - Never ignore warnings or errors, even pre-existing ones
 - **Never write code that "degrades gracefully" for missing migrations** — all required migrations are assumed to have been run. There is no valid scenario where application code executes against a schema missing its own columns. If a column is needed, the migration must exist; if the migration doesn't exist yet, the code that depends on it belongs in the same story or a later one. Do not use `getAttribute()` with null-coalescing, `Schema::hasColumn()`, or try/catch around column access as a substitute for running migrations.
 

--- a/.github/instructions/story-writing.instructions.md
+++ b/.github/instructions/story-writing.instructions.md
@@ -1,0 +1,47 @@
+---
+description: "Use when writing implementation stories, GitHub issue-ready stories, epics, milestones, task breakdowns, or change specifications for this project."
+---
+# Story Writing Guidelines
+
+- Write stories as Markdown documents that are ready to copy or convert into GitHub issues.
+- Write each story for exactly one change. If the requested change contains multiple independent changes, split it into multiple stories.
+- Keep stories brief but exhaustive: include all context and constraints needed for an implementer to complete the work without asking follow-up questions.
+- Make every story unambiguous. Do not include choices, open questions, optional approaches, or alternative implementations.
+- Align every story with the project's active rules, milestone constraints, architecture, file-specific instructions, and testing conventions that apply to the requested change.
+- Verify whether the requested behavior or related implementation already exists before writing implementation instructions.
+- When user asks to create epic/stories in GitHub, proceed in sequence to avoid race conditions. Github doesn't support "epic"/"stories" as first-class entities, so you must create the epic issue first, then create child stories that link to the epic. Do not create any child story until the epic issue is created and its URL is available to include in the child stories.
+- Stories must be self-contained and not rely on implicit references, conversations, or decisions. If the story requires information from those sources, include it in the story itself.
+- Stories must be actionable and not require further analysis or interpretation. They must not contain questions or open choices. Clarify with the user before writing the story if the request is ambiguous or contains multiple options.
+- Stories must not contain comments or statement related to the story writing process itself. They must be focused on the implementation task and not include meta-level discussion.
+
+## Required Story Structure
+
+Every story must include these sections:
+
+- `Title`: name the single change in imperative or outcome-focused language.
+- `Context`: explain the relevant project state, user-facing workflow, milestone, architectural boundary, and existing code pattern.
+- `Problem`: describe the exact gap, defect, or missing behavior the story addresses.
+- `Solution`: state the required end state in direct terms.
+- `Implementation Instructions`: provide precise, ordered instructions that follow the established project patterns and name the expected files, components, routes, tests, or services when known.
+- `Definition of Done`: list all acceptance criteria, including required validation.
+
+## Definition of Done Requirements
+
+Every story's `Definition of Done` must include:
+
+- The requested behavior is implemented and follows the applicable project conventions.
+- Relevant automated tests are added or updated for the business logic and user-visible behavior.
+- Lint checks pass without warnings or errors.
+- Relevant test suites pass without warnings or errors.
+- No unrelated behavior, migrations, dependencies, or documentation are changed unless the story explicitly requires them.
+- Code is linted
+- All tests are passing
+- No warnings or errors in lint or tests
+
+## Epics And Milestones
+
+- Create an epic instead of a story when the change is too large to implement safely as one autonomous story.
+- An epic must include context, the larger problem description, the high-level solution, cross-cutting constraints, and child stories.
+- Create a milestone when multiple epics are required, when stories span different domains, or when the work has meaningful dependencies between domains.
+- A milestone must include high-level context, scope boundaries, epics, child stories, dependency order, and completion criteria.
+- Child stories under an epic or milestone must still follow the required story structure and describe exactly one change each.

--- a/doc/Decisions.md
+++ b/doc/Decisions.md
@@ -140,3 +140,12 @@ This file tracks all key technical and business decisions for the Motivya projec
 - **Registration**: Role files are loaded in `bootstrap/app.php` via the `then:` callback with group-level middleware, prefix, and name prefix. Individual routes inside role files must **not** re-declare group middleware.
 - **What stays in `web.php`**: Public pages (home, privacy, health), guest-only auth (login, register, OAuth, password reset), shared authenticated routes used by all roles (profile, email verify, locale switch, logout), and cross-role routes gated by ability (e.g., coach application form accessible to athletes).
 - **Alternatives rejected**: (A) Flat hyphenated files (`web-admin.php`) — unconventional PHP naming, directory gets crowded. (B) Everything in one `web.php` with inline middleware groups — error-prone, caused the missing `2fa` bug (#133). (C) Original E1-S24 proposal (`admin.php`, `coach.php`) — ambiguous channel, inconsistent athlete handling.
+
+## ADR-016: Mapping Provider Selection — Google-or-Free, Never Mixed
+
+- **Status**: DECIDED
+- **Date**: 2026-05
+- **Decision**: Use one mapping provider stack per runtime configuration. If `GOOGLE_MAPS_API_KEY` is configured, all mapping capabilities use Google Maps Platform. If it is absent, all mapping capabilities use the configured free-service alternative. Mapping capabilities include map display, address validation, geocoding, discovery search coordinate resolution, directions, and provider health checks.
+- **Rationale**: Mixing Google geocoding/directions with OpenFreeMap/MapLibre display creates inconsistent behavior, unclear cost expectations, incomplete health checks, and hidden failure modes. A hard config-derived provider choice makes production behavior predictable and testable.
+- **Constraints**: Do not silently fall back from the selected provider to another provider after an API error. Do not provide degraded map behavior when a required selected-provider capability fails. Fail the operation, log/report the provider error, and expose actionable admin readiness status.
+- **Implementation note**: Provider URLs, API-key checks, map render configuration, geocoding/address validation, directions generation, and health probes must be centralized in services/configuration. Blade, Livewire components, and JavaScript entry points should consume provider-neutral view data instead of embedding provider-specific URLs or fallback logic.

--- a/doc/MVP-Smoke-Test.md
+++ b/doc/MVP-Smoke-Test.md
@@ -72,7 +72,7 @@ After seeding, verify address precision metrics with the audit command:
 php artisan addresses:audit-precision
 ```
 
-Expected output: at least some sessions show **Validated (exact)** count > 0. If all sessions are **Legacy (postal-code only)** and a geocoding provider is configured, run the backfill:
+Expected output: at least some sessions show **Validated (exact)** count > 0. If all sessions are **Legacy (postal-code only)** and the selected mapping provider is healthy, run the backfill:
 
 ```bash
 # Dry-run first (default — no writes)
@@ -85,7 +85,7 @@ php artisan addresses:backfill --model=coach_profiles --apply
 ```
 
 - [ ] `php artisan addresses:audit-precision` runs without errors
-- [ ] At least some sessions show **Validated (exact)** > 0 (or provider is not configured — yellow is acceptable locally without `GOOGLE_MAPS_API_KEY`)
+- [ ] At least some sessions show **Validated (exact)** > 0, or the selected provider readiness status clearly explains why local address validation is unavailable
 
 ### UAT / production bootstrap note
 
@@ -111,7 +111,7 @@ Epic 6 intentionally avoids Playwright for the current milestone. The MVP smoke 
 - It also asserts session detail renders the map container and a coordinate-based directions link.
 - `mvp:health-snapshot` remains the deployment-friendly check for missing public storage links, postal-code data, scheduler health, and payment anomalies.
 
-Full browser execution can be added later if the project needs pixel-level MapLibre validation, but it is not required for the partner-demo readiness gate.
+Full browser execution can be added later if the project needs pixel-level validation for the selected map provider, but it is not required for the partner-demo readiness gate.
 
 ---
 

--- a/doc/MVP-Stabilization-Milestone.md
+++ b/doc/MVP-Stabilization-Milestone.md
@@ -25,7 +25,7 @@ Observed production state:
 Core diagnosis:
 
 - Booking and payment are too fragile around Stripe failures, missing payment intent IDs, and webhook reconciliation.
-- Maps are implemented with MapLibre/OpenFreeMap, but no production session has coordinates, so no markers are produced and the map never renders.
+- Maps currently have mixed provider behavior and missing production coordinates, so markers can be absent and provider health is not fully observable.
 - Uploaded activity images are stored but not publicly served because the Laravel public storage link is missing in production.
 - The scheduler is not configured in production, so readiness correctly reports missing scheduled-command heartbeats, although the French wording is confusing.
 - Admin and accountant pages for audits and operations exist, but several are hidden from navigation or dashboard cards.
@@ -34,7 +34,7 @@ Core diagnosis:
 Implementation decisions for this milestone:
 
 - Booking holds remain in `PendingPayment` when Stripe Checkout creation fails, and athletes recover through retry/cancel actions until the hold expires.
-- Map display stays on MapLibre GL JS with OpenFreeMap tiles. Google is used for geocoding and directions through an environment-managed API key.
+- Map provider selection follows ADR-016: Google Maps Platform owns every mapping capability when `GOOGLE_MAPS_API_KEY` is configured; otherwise the configured free-service stack owns every mapping capability. No runtime provider mixing, silent fallback, or degraded map functionality is allowed.
 - Postal-code coordinates are loaded from a curated built-in Belgian/Brussels MVP dataset through a production-safe command.
 - OVH scheduler setup uses a systemd service and timer, not cron.
 - Production storage uses an explicit release-time symlink from `public/storage` to shared public storage.
@@ -211,7 +211,7 @@ The MVP is partner-demo ready when:
 
 **Implementation details:**
 
-- Keep MapLibre GL JS and OpenFreeMap as the default MVP map stack. It is already implemented in `resources/js/session-map.js` and does not require a Google Maps key for map display.
+- Replace the mixed map behavior with the ADR-016 provider model. Google-selected environments render maps through Google Maps Platform; environments without a Google key render through the configured free-service map stack.
 - Update the discovery view so a map container can render with Brussels as a fallback center even when there are no markers, alongside a localized message explaining that no mapped sessions match the current filters.
 - Avoid hiding all location context when filters return no markers.
 - Replace `<x-session-map>` with a reusable map component that accepts a unique DOM ID, marker collection, fallback center, height, and single-marker detail mode.
@@ -287,31 +287,31 @@ The MVP is partner-demo ready when:
 - Feature test: detail page without coordinates contains an address-based directions URL.
 - Render assertions for all three languages.
 
-## Story 2.4: Configure Google Geocoding With MapLibre/OpenFreeMap Maps
+## Story 2.4: Configure Coherent Google-or-Free Mapping
 
 **Role:** Operator, Developer
 
-**Context:** Map display is currently free and API-keyless through MapLibre/OpenFreeMap. That remains the required MVP map-rendering stack. Address/city geocoding and directions must use Google APIs through an environment-managed key so Brussels searches and directions are reliable during partner demos.
+**Context:** Map display, address/city geocoding, and directions are currently split across free map tiles and Google APIs. ADR-016 replaces that mixed approach with a hard provider choice: Google everywhere when `GOOGLE_MAPS_API_KEY` is configured, otherwise the configured free-service stack everywhere.
 
 **Implementation details:**
 
-- Keep MapLibre GL JS and OpenFreeMap for map rendering. Do not replace the map UI with Google Maps JavaScript in this milestone.
-- Add a `config/maps.php` file with these settings: MapLibre tile style URL, Google directions base URL, Google geocoding base URL, timeout, cache TTL, and `GOOGLE_MAPS_API_KEY`.
-- Implement `GeocodingService` with two ordered resolvers: first the local curated postal-code table, then Google Geocoding API.
+- Add a `config/maps.php` file with provider-neutral settings plus Google-provider and free-provider subsections.
+- Implement a single provider resolver: Google is selected when `GOOGLE_MAPS_API_KEY` is configured; the free-service provider is selected only when it is absent.
+- Implement geocoding/address validation, map display config, and directions generation through provider-specific services behind shared contracts.
 - Cache Google geocoding responses in a dedicated `geocoding_cache` table keyed by normalized query, locale, country, and provider.
-- Never call a free public geocoding service on every keystroke; resolve on search submission or debounced final input only.
-- Add readiness checks for the Google API key shape, geocoding cache table availability, and last successful geocoding probe.
+- Never call an external geocoding service on every keystroke; resolve on search submission, selected suggestion, or debounced final input only.
+- Add readiness checks for the selected provider's map display, geocoding/address validation, directions config, cache/table availability, and last successful provider probe.
 
 **Acceptance criteria:**
 
-- The app resolves Belgian city/postal-code searches through the local curated table first and Google Geocoding second.
-- Map display remains functional without a Google key.
-- Missing/invalid Google API key produces an actionable readiness warning and disables Google fallback geocoding while preserving local postal-code search.
+- The app resolves Belgian city/postal-code/address searches through the selected provider strategy.
+- Map display, directions, and geocoding use Google when a Google key is configured, and use the free-service stack only when the Google key is absent.
+- Missing or invalid selected-provider configuration produces an actionable readiness error.
 - Geocoding responses are cached and rate-limited.
 
 **Test expectations:**
 
-- Unit tests for provider selection and fallback behavior.
+- Unit tests for provider selection and no-fallback failure behavior.
 - Unit tests for cached geocoding results.
 - Feature test for city/postal-code search with mocked external provider.
 

--- a/doc/Production-Readiness-Runbook.md
+++ b/doc/Production-Readiness-Runbook.md
@@ -255,9 +255,9 @@ Limit the number of rows processed per run (default: 100) to avoid long-running 
 php artisan addresses:backfill --model=sessions --apply --limit=50
 ```
 
-Exit codes: `0` = success, `1` = no provider configured or invalid options.
+Exit codes: `0` = success, `1` = selected provider misconfigured, unavailable, or invalid options.
 
-**Requires a geocoding provider**: `MAPS_GEOCODING_PROVIDER` must be set (default: `google`) and `GOOGLE_MAPS_API_KEY` must be present when using the Google provider.
+**Requires the active mapping provider**: provider selection follows ADR-016. If `GOOGLE_MAPS_API_KEY` is configured, Google Maps Platform must be healthy for geocoding/address validation, map display, and directions. If it is absent, the configured free-service provider must be healthy for the same capabilities. Do not treat one provider failing as permission to switch to another provider at runtime.
 
 The readiness page `address_precision` check turns **green** when all sessions and coach profiles have a validated formatted address with coordinates and provider. It turns **yellow** when some rows are still legacy postal-code-only, and **red** when NO rows at all are validated (and rows exist).
 

--- a/doc/stories/README.md
+++ b/doc/stories/README.md
@@ -11,6 +11,7 @@ This directory contains the detailed story breakdown for the Motivya project. Ea
 | [epic-3-athlete.md](epic-3-athlete.md) | Athlete Experience & Payments | Epic 3 | Epic 1, Epic 2 |
 | [epic-4-accountant.md](epic-4-accountant.md) | Accountant Portal + Invoicing | Epic 4 | Epic 3 |
 | [mvp-address-geolocation.md](mvp-address-geolocation.md) | MVP Address and Geolocation Precision | MVP Stabilization | Epic 2, Epic 3 |
+| [mvp-mapping-provider-coherence.md](mvp-mapping-provider-coherence.md) | MVP Mapping Provider Coherence | MVP Stabilization | MVP Address and Geolocation Precision |
 
 ## Conventions
 
@@ -46,3 +47,4 @@ This directory contains the detailed story breakdown for the Motivya project. Ea
 | Epic 2: Coach Business-in-a-Box | — | Coach profile, sessions, recurring, dashboard |
 | Epic 3: Athlete Experience & Payments | — | Discovery, booking, Stripe, refunds, athlete dashboard |
 | Epic 4: Accountant Portal + Invoicing | — | PEPPOL, VAT engine, credit notes, exports |
+| MVP Mapping Provider Coherence | — | Google-or-free map provider architecture, readiness, and discovery map fixes |

--- a/doc/stories/mvp-address-geolocation.md
+++ b/doc/stories/mvp-address-geolocation.md
@@ -4,7 +4,7 @@
 
 Title: Deliver Precise Validated Addresses for MVP Search, Sessions, and Directions
 
-Context: Motivya already has MapLibre/OpenFreeMap map rendering, Google directions links, `postal_code_coordinates`, `geocoding_cache`, `GeocodingService`, and distance-based session search. Local review shows session creation and editing still use split `location` and `postalCode` fields, `SessionService` still resolves coordinates through `PostalCodeCoordinateService`, and typed discovery searches only resolve postal codes or municipalities. Coach application/profile address data is also postal-code-only. OVH production has the required migrations (`sport_sessions`, `postal_code_coordinates`, `geocoding_cache`) and a configured Google Maps key, but `sport_sessions` stores only `location`, `postal_code`, `latitude`, and `longitude`; production currently has 9 sessions, 3 distinct session postal codes, 8 sessions with coordinates, 1 session missing coordinates, 35 postal-code reference rows, and 0 geocoding-cache rows. Existing coordinates therefore represent postal-code centers, not validated street addresses.
+Context: Motivya already has map rendering, directions links, `postal_code_coordinates`, `geocoding_cache`, `GeocodingService`, and distance-based session search. Local review shows session creation and editing still use split `location` and `postalCode` fields, `SessionService` still resolves coordinates through `PostalCodeCoordinateService`, and typed discovery searches only resolve postal codes or municipalities. Coach application/profile address data is also postal-code-only. OVH production has the required migrations (`sport_sessions`, `postal_code_coordinates`, `geocoding_cache`) and a configured Google Maps key, but `sport_sessions` stores only `location`, `postal_code`, `latitude`, and `longitude`; production currently has 9 sessions, 3 distinct session postal codes, 8 sessions with coordinates, 1 session missing coordinates, 35 postal-code reference rows, and 0 geocoding-cache rows. Existing coordinates therefore represent postal-code centers, not validated street addresses.
 
 Problem: The MVP cannot support user expectations for precise address entry, exact session pins, exact directions, or address-based search. The current implementation validates postal-code syntax instead of validating an address against the active maps/geocoding provider, and it does not persist a normalized address result or provider metadata.
 
@@ -13,7 +13,7 @@ Solution: Add provider-backed address validation, store normalized address data 
 Implementation Instructions:
 
 1. Implement the child stories below in order.
-2. Keep MapLibre/OpenFreeMap for map display. Do not replace the map component with Google Maps JavaScript.
+2. Follow ADR-016: when `GOOGLE_MAPS_API_KEY` is configured, the Google Maps Platform stack must own map display, address validation/geocoding, discovery coordinate resolution, directions, and health checks. When the key is absent, the configured free-service stack must own all of those capabilities. Do not mix providers in the same runtime.
 3. Use Laravel services for provider calls and normalization; keep Livewire components thin and use Form Objects.
 4. Use localized strings in `lang/fr`, `lang/en`, and `lang/nl` for all user-visible labels, placeholders, validation errors, and readiness messages.
 5. Do not call an external geocoder on every keystroke. Resolve only when the user selects a suggestion, submits a search, or triggers an explicit validation action with debounce and cache.
@@ -31,29 +31,29 @@ Definition of Done:
 
 Title: Add Provider-Backed Address Validation Service
 
-Context: `app/Services/GeocodingService.php` currently resolves postal codes/municipalities locally and falls back to Google coordinates. It returns only latitude and longitude, and the cache table stores only query/provider/coordinates/found. The MVP requires a single address field that is validated against whichever geocoding provider is active. Both Google and the OpenFreeMap-compatible provider must work.
+Context: `app/Services/GeocodingService.php` currently resolves postal codes/municipalities locally and falls back to Google coordinates. It returns only latitude and longitude, and the cache table stores only query/provider/coordinates/found. The MVP requires a single address field that is validated through the active mapping provider selected by ADR-016. Google and the free-service alternative must both work as complete provider stacks, but only one may be active at runtime.
 
 Problem: There is no service contract that can validate a full street address, normalize the selected result, enforce Belgian address constraints, expose postal code/city/country components, or preserve provider metadata for storage and auditing.
 
-Solution: Introduce a reusable address validation layer that returns a normalized `ValidatedAddress` result for both Google and OpenFreeMap-compatible providers, with cached provider responses and deterministic validation failures.
+Solution: Introduce a reusable address validation layer that returns a normalized `ValidatedAddress` result through the active mapping provider, with cached provider responses and deterministic validation failures.
 
 Implementation Instructions:
 
 1. Create `app/DataTransferObjects/ValidatedAddress.php` with fields: `formattedAddress`, `streetAddress`, `locality`, `postalCode`, `country`, `latitude`, `longitude`, `provider`, `providerPlaceId`, and `rawPayload`.
-2. Add `MAPS_GEOCODING_PROVIDER=google`, `OPENFREEMAP_GEOCODING_BASE_URL=`, and `OPENFREEMAP_GEOCODING_API_KEY=` to `.env.example`, and expose them through `config/maps.php`.
-3. Create `app/Services/AddressValidationService.php` that accepts a free-text address query and locale, chooses `config('maps.geocoding_provider')`, calls exactly one active provider, and returns `ValidatedAddress` only when the provider returns one Belgian street-level or venue-level result with coordinates.
+2. Expose mapping provider settings through `config/maps.php`. `GOOGLE_MAPS_API_KEY` controls provider selection; free-provider endpoint/key settings are used only when the Google key is absent.
+3. Create `app/Services/AddressValidationService.php` that accepts a free-text address query and locale, delegates to the selected mapping provider, calls exactly one active provider, and returns `ValidatedAddress` only when the provider returns one Belgian street-level or venue-level result with coordinates.
 4. Implement a Google provider using the existing Google geocoding base URL and API key; it must reject non-BE results and results without coordinates or usable formatted address.
-5. Implement an OpenFreeMap-compatible provider using the configured base URL and optional API key; it must parse Nominatim-style JSON responses, reject non-BE results, and return the same `ValidatedAddress` shape.
+5. Implement a free-provider address validation adapter using the configured free-service geocoding endpoint and optional API key; it must parse the configured response format, reject non-BE results, and return the same `ValidatedAddress` shape. This provider is used only when Google is absent.
 6. Extend or replace `geocoding_cache` storage so successful and failed address validations are cached by normalized query, locale, country, provider, and purpose `address_validation`; do not break existing city/postal-code search cache reads.
 7. Keep `PostalCodeCoordinateService` for postal-code reference lookups until later stories replace session write paths.
 8. Add structured logging for provider failures without logging API keys or full raw payloads.
 
 Definition of Done:
 
-- Address validation works with `MAPS_GEOCODING_PROVIDER=google` and `MAPS_GEOCODING_PROVIDER=openfreemap` using mocked HTTP responses.
+- Address validation works with Google-selected and free-provider-selected configurations using mocked HTTP responses.
 - Non-Belgian, ambiguous, coordinate-less, and not-found provider responses return validation failures instead of silently storing postal-code centers.
 - Cached successful and failed validations avoid duplicate HTTP calls.
-- Unit tests cover Google success/failure, OpenFreeMap-compatible success/failure, cache hits, provider selection, and secret-safe logging.
+- Unit tests cover Google success/failure, free-provider success/failure, cache hits, provider selection, no cross-provider fallback, and secret-safe logging.
 - The requested behavior is implemented and follows the applicable project conventions.
 - Relevant automated tests are added or updated for the business logic and user-visible behavior.
 - Lint checks pass without warnings or errors.

--- a/doc/stories/mvp-mapping-provider-coherence.md
+++ b/doc/stories/mvp-mapping-provider-coherence.md
@@ -1,0 +1,405 @@
+# MVP Mapping Provider Coherence
+
+## Epic
+
+Title: Make Mapping a Coherent Google-or-Free Provider System
+
+Context: Motivya currently has map-provider decisions split across `config/maps.php`, `app/Services/AddressValidationService.php`, `app/Services/GeocodingService.php`, `resources/views/components/session-map.blade.php`, `resources/js/session-map.js`, `resources/views/livewire/session/show.blade.php`, `app/Livewire/Admin/Readiness.php`, and `app/Console/Commands/MvpHealthSnapshot.php`. The verified current state is mixed: `GOOGLE_MAPS_API_KEY` is used for Google geocoding and Google directions, `MAPS_GEOCODING_PROVIDER` independently selects address validation, `resources/js/session-map.js` hardcodes OpenFreeMap tiles, and readiness only checks Google key shape plus geocoding cache existence. The `/sessions` map can fail to render when reached from the home page Browse Sessions link, and marker clusters can remain stale after filters change.
+
+Problem: The app does not enforce the project rule that one selected mapping provider stack must own every mapping capability in a runtime configuration. Google Maps Platform must own map display, address validation, geocoding, discovery coordinate resolution, directions, and provider health checks when `GOOGLE_MAPS_API_KEY` is configured. The free-service stack must own those same capabilities only when `GOOGLE_MAPS_API_KEY` is absent. The current implementation allows mixed providers, silent fallback, hidden degradation, and incomplete operational health reporting.
+
+Solution: Replace the current split map implementation with a provider-neutral mapping subsystem. Provider selection is computed once from configuration: `GOOGLE_MAPS_API_KEY` present selects Google; absent selects the free-service stack. All map rendering, address validation, geocoding, discovery coordinate resolution, directions URL generation, and readiness probes use the selected provider through shared services. Provider failures fail visibly and are reported through logs and readiness checks. Session discovery map rendering, navigation, and marker synchronization are fixed through the same provider-neutral map surface.
+
+Cross-Cutting Constraints:
+
+1. `GOOGLE_MAPS_API_KEY` is the only provider-selection switch. `MAPS_GEOCODING_PROVIDER` must be removed from `.env.example`, `config/maps.php`, tests, and documentation.
+2. The Google provider stack must use Google Maps Platform for every mapping capability.
+3. The free provider stack must use MapLibre with the configured OpenFreeMap style URL for map display, the configured Nominatim-compatible endpoint for address validation and geocoding, and the configured OpenStreetMap directions URL for directions.
+4. The selected provider must not fall back to another provider after an API failure.
+5. Required selected-provider capability failures must block the operation and show an actionable error state. They must not silently omit maps, skip validation, use postal-code centers as exact addresses, or return partial provider results.
+6. Blade, Livewire components, and JavaScript entry points must consume provider-neutral DTOs. Provider URLs, API keys, probes, and request logic belong in config and services.
+7. All user-visible provider, map, validation, readiness, and navigation text must be localized in `lang/fr`, `lang/en`, and `lang/nl`.
+8. Each child story must keep unrelated behavior, migrations, dependencies, and documentation unchanged unless explicitly listed in that story.
+
+Child Stories:
+
+1. Replace map provider selection with one resolver.
+2. Implement complete Google mapping services.
+3. Implement complete free mapping services.
+4. Refactor address validation and discovery geocoding to the selected provider.
+5. Render session maps through provider-neutral components.
+6. Generate directions through the selected provider.
+7. Add selected-provider health checks to readiness tools.
+8. Fix session discovery navigation and map initialization.
+9. Keep session map markers and clusters synchronized with filters.
+10. Update mapping configuration, tests, and operator documentation.
+
+Completion Criteria:
+
+- Google-configured environments use Google Maps Platform for every mapping capability.
+- Environments without `GOOGLE_MAPS_API_KEY` use the complete configured free-service stack for every mapping capability.
+- `MAPS_GEOCODING_PROVIDER` is no longer read, documented, or used by tests.
+- Selected-provider API failures are visible to users or operators where appropriate and are reported through logs/readiness checks.
+- Session discovery maps render consistently from every navigation entry point.
+- Map markers and clusters match the active filtered session scope.
+- Relevant automated tests and lint checks pass without warnings or errors.
+
+---
+
+## Story 1: Replace Map Provider Selection With One Resolver
+
+Title: Replace map provider selection with one resolver
+
+Context: `config/maps.php` currently contains `google_api_key`, Google endpoint URLs, OpenFreeMap/Nominatim endpoint settings, and `geocoding_provider`. `AddressValidationService` reads `config('maps.geocoding_provider')`, while `resources/js/session-map.js` always uses OpenFreeMap tiles. This permits geocoding, display, and directions to choose different providers in the same runtime.
+
+Problem: The application has no single source of truth for the active mapping provider. `MAPS_GEOCODING_PROVIDER` creates a per-feature provider switch and violates the project rule that provider selection must be derived from whether `GOOGLE_MAPS_API_KEY` is configured.
+
+Solution: Add one map provider resolver that selects `google` when `GOOGLE_MAPS_API_KEY` is configured and `free` when it is absent. Remove `MAPS_GEOCODING_PROVIDER` from configuration and make every mapping capability consume the resolver.
+
+Implementation Instructions:
+
+1. Create `app/Enums/MapProvider.php` with string-backed cases `Google = 'google'` and `Free = 'free'`.
+2. Create `app/Services/Maps/MapProviderResolver.php` with a public method returning `MapProvider::Google` when `config('maps.google.api_key')` is a non-empty string and `MapProvider::Free` otherwise.
+3. Restructure `config/maps.php` into provider-neutral settings plus `google` and `free` subsections. Read `GOOGLE_MAPS_API_KEY` only inside the `google` subsection.
+4. Remove `geocoding_provider` from `config/maps.php` and remove `MAPS_GEOCODING_PROVIDER` from `.env.example`.
+5. Add a configuration validation method on `MapProviderResolver` that returns a provider-neutral result object containing provider, capability name, status, and message for each required capability.
+6. Update service container bindings so all map-related services receive `MapProviderResolver` instead of reading provider env values directly.
+7. Add unit tests in `tests/Unit/Services/Maps/MapProviderResolverTest.php` proving Google is selected when the key is present, free is selected when the key is absent, and `MAPS_GEOCODING_PROVIDER` has no effect.
+
+Definition of Done:
+
+- `MAPS_GEOCODING_PROVIDER` is removed from `.env.example`, `config/maps.php`, and provider-selection tests.
+- One resolver determines the active map provider for every map capability.
+- Provider selection depends only on `GOOGLE_MAPS_API_KEY` presence.
+- Invalid selected-provider configuration is represented as failed capability checks, not as a different selected provider.
+- The requested behavior is implemented and follows the applicable project conventions.
+- Relevant automated tests are added or updated for the business logic and user-visible behavior.
+- Lint checks pass without warnings or errors.
+- Relevant test suites pass without warnings or errors.
+- No unrelated behavior, migrations, dependencies, or documentation are changed unless this story explicitly requires them.
+- Code is linted.
+- All tests are passing.
+- No warnings or errors in lint or tests.
+
+## Story 2: Implement Complete Google Mapping Services
+
+Title: Implement complete Google mapping services
+
+Context: Current Google logic is embedded in `AddressValidationService`, `GeocodingService`, and the session detail Blade directions block. Google-enabled environments still render maps through hardcoded OpenFreeMap tiles in `resources/js/session-map.js`.
+
+Problem: A runtime with `GOOGLE_MAPS_API_KEY` configured still uses the free renderer for map display and inlined Google URL logic for directions. This is mixed-provider behavior and keeps provider code scattered across services, Blade, and JavaScript.
+
+Solution: Add a complete Google provider implementation behind shared map contracts. The Google provider owns map render configuration, address validation, geocoding, discovery coordinate resolution, directions URL generation, and health probes when selected.
+
+Implementation Instructions:
+
+1. Create provider contracts under `app/Contracts/Maps/` for map render configuration, address validation, geocoding, directions URL generation, and health probing.
+2. Create Google implementations under `app/Services/Maps/Google/` for those contracts.
+3. Move Google geocoding request and response parsing out of `AddressValidationService` and `GeocodingService` into `GoogleAddressValidationProvider` and `GoogleGeocodingProvider`.
+4. Add Google map render configuration that emits the Google Maps JavaScript API URL, required libraries, API key, fallback center, marker data, cluster setting, locale, and map container options through a provider-neutral DTO.
+5. Add Google directions URL generation that produces `https://www.google.com/maps/dir/?api=1&destination={lat},{lng}` for validated coordinates and an encoded destination text URL only for legacy rows without coordinates.
+6. Create `app/Exceptions/Maps/MapProviderException.php` and make Google HTTP errors, invalid responses, quota errors, and missing required response fields throw that exception with provider and capability context. Do not call any free-provider class from Google provider code.
+7. Add unit tests covering Google address validation success, outside-Belgium rejection, no-result rejection, HTTP failure, geocoding cache keys, directions URL generation, map render DTO output, and no free-provider call when Google fails.
+
+Definition of Done:
+
+- With `GOOGLE_MAPS_API_KEY` configured, session maps are configured for Google Maps JavaScript and no OpenFreeMap tile URL is emitted.
+- Google address validation, geocoding, directions, and health probes live under the Google provider implementation.
+- Google provider failures do not call the free provider.
+- Tests cover Google success and failure behavior for every required mapping capability.
+- The requested behavior is implemented and follows the applicable project conventions.
+- Relevant automated tests are added or updated for the business logic and user-visible behavior.
+- Lint checks pass without warnings or errors.
+- Relevant test suites pass without warnings or errors.
+- No unrelated behavior, migrations, dependencies, or documentation are changed unless this story explicitly requires them.
+- Code is linted.
+- All tests are passing.
+- No warnings or errors in lint or tests.
+
+## Story 3: Implement Complete Free Mapping Services
+
+Title: Implement complete free mapping services
+
+Context: The existing free-service behavior is partial. `resources/js/session-map.js` uses MapLibre/OpenFreeMap for display, `AddressValidationService` can call a Nominatim-compatible endpoint, and session directions still use Google Maps URLs.
+
+Problem: Environments without `GOOGLE_MAPS_API_KEY` do not have a complete free-provider stack because directions and some geocoding behavior remain tied to Google or independent fallback logic.
+
+Solution: Add a complete free provider implementation behind the same map contracts. The free provider owns map display, address validation, geocoding, discovery coordinate resolution, directions URL generation, and health probes when Google is absent.
+
+Implementation Instructions:
+
+1. Create free provider implementations under `app/Services/Maps/Free/` for the map contracts created in Story 2.
+2. Configure the free provider in `config/maps.php` with `style_url`, `geocoding_base_url`, `geocoding_api_key`, `directions_base_url`, `timeout`, `cache_ttl`, `attribution`, and probe address settings.
+3. Use MapLibre with the configured OpenFreeMap style URL only inside the free map render implementation.
+4. Use the configured Nominatim-compatible endpoint only inside the free address validation and geocoding implementations.
+5. Generate free-provider directions URLs through the configured OpenStreetMap directions/search base URL. Do not generate Google directions URLs when `GOOGLE_MAPS_API_KEY` is absent.
+6. Reject free-provider address validation responses that are outside Belgium, missing coordinates, missing a display name, or missing street/venue-level evidence required by the existing `ValidatedAddress` contract.
+7. Make free-provider HTTP errors, invalid responses, missing endpoint configuration, and missing required response fields throw `MapProviderException` with provider and capability context. Do not call any Google provider class from free provider code.
+8. Add unit tests covering free address validation success, outside-Belgium rejection, no-result rejection, HTTP failure, geocoding cache keys, directions URL generation, map render DTO output, and no Google-provider call when the free provider fails.
+
+Definition of Done:
+
+- Without `GOOGLE_MAPS_API_KEY`, no Google map, geocoding, address validation, or directions endpoint is emitted or called.
+- The free provider supports every required mapping capability.
+- Free-provider failures do not call Google and do not return partial map behavior.
+- Tests cover free-provider success and failure behavior for every required mapping capability.
+- The requested behavior is implemented and follows the applicable project conventions.
+- Relevant automated tests are added or updated for the business logic and user-visible behavior.
+- Lint checks pass without warnings or errors.
+- Relevant test suites pass without warnings or errors.
+- No unrelated behavior, migrations, dependencies, or documentation are changed unless this story explicitly requires them.
+- Code is linted.
+- All tests are passing.
+- No warnings or errors in lint or tests.
+
+## Story 4: Refactor Address Validation and Discovery Geocoding to the Selected Provider
+
+Title: Refactor address validation and discovery geocoding to the selected provider
+
+Context: `AddressValidationService` currently chooses between Google and OpenFreeMap through `config('maps.geocoding_provider')`. `GeocodingService` first checks local postal-code data and then calls Google when a key exists. `App\Livewire\Session\Index` calls `AddressValidationService` and then silently falls back to `PostalCodeCoordinateService` when validation returns null.
+
+Problem: Address validation and discovery coordinate resolution are inconsistent and can silently degrade from provider validation to postal-code or municipality centers after provider failure.
+
+Solution: Make `AddressValidationService`, `GeocodingService`, and session discovery use the selected provider contracts. Local postal-code or municipality centers remain available only as explicit approximate discovery centers, never as fallback after a selected-provider API failure and never as validated addresses.
+
+Implementation Instructions:
+
+1. Update `AddressValidationService` to delegate to the selected provider's address validation contract and remove all provider-specific HTTP code from the service.
+2. Update `GeocodingService` to delegate to the selected provider's geocoding contract and remove direct Google HTTP code from the service.
+3. Add a provider-neutral `ResolvedLocation` DTO with `latitude`, `longitude`, `source`, `precision`, `query`, and `provider` fields. Valid `precision` values are `exact`, `approximate`, and `browser`.
+4. Update `PostalCodeCoordinateService` usage so postal-code and municipality matches return `ResolvedLocation` with `precision = approximate` and `provider = null`.
+5. Update `App\Livewire\Session\Index` so provider failures are not passed to `PostalCodeCoordinateService`. Only user input classified as postal code or municipality before provider calls may use local approximate coordinates.
+6. Update the session create/edit address workflows so saving requires `ValidatedAddress` from the selected provider and never accepts `ResolvedLocation` with approximate precision.
+7. Cache provider lookup results by provider, purpose, normalized query, locale, country, and precision. Cache keys must not collide between Google and free provider results.
+8. Add tests covering exact address validation, approximate postal-code discovery, provider failure without local fallback, invalid user input, and cache separation by provider and purpose.
+
+Definition of Done:
+
+- Address validation calls only the selected provider stack.
+- Discovery geocoding calls only the selected provider stack for exact address queries.
+- Postal-code and municipality centers are labelled approximate and are never persisted as validated exact addresses.
+- Selected-provider failures do not fall back to local postal-code centers.
+- The requested behavior is implemented and follows the applicable project conventions.
+- Relevant automated tests are added or updated for the business logic and user-visible behavior.
+- Lint checks pass without warnings or errors.
+- Relevant test suites pass without warnings or errors.
+- No unrelated behavior, migrations, dependencies, or documentation are changed unless this story explicitly requires them.
+- Code is linted.
+- All tests are passing.
+- No warnings or errors in lint or tests.
+
+## Story 5: Render Session Maps Through Provider-Neutral Components
+
+Title: Render session maps through provider-neutral components
+
+Context: `resources/views/components/session-map.blade.php` directly calls `sessionMap(...)` and pushes `resources/js/session-map.js`. The JavaScript imports MapLibre and hardcodes the OpenFreeMap style URL. This cannot render Google maps when Google is selected.
+
+Problem: Map rendering is coupled to one free renderer and cannot switch coherently with the selected provider.
+
+Solution: Replace the current hardcoded map component with provider-neutral Blade data and provider-specific JavaScript modules selected from server-generated render configuration.
+
+Implementation Instructions:
+
+1. Create a provider-neutral `MapRenderConfig` DTO containing provider, container ID, center, zoom, markers, clustering flag, locale, script URLs, style URLs, attribution, and failure message key.
+2. Add a `MapRenderConfigService` that returns `MapRenderConfig` from the selected provider's map render contract.
+3. Update `resources/views/components/session-map.blade.php` to accept a `MapRenderConfig` object and render provider-neutral JSON script data in an `application/json` script tag keyed by map container ID.
+4. Split `resources/js/session-map.js` into provider-neutral bootstrapping plus `resources/js/maps/google-session-map.js` and `resources/js/maps/free-session-map.js`.
+5. Ensure the Google module loads Google Maps JavaScript only for `provider = google` and the free module loads MapLibre only for `provider = free`.
+6. Remove the hardcoded OpenFreeMap style URL from JavaScript. The free style URL must come from `config/maps.php` through `MapRenderConfig`.
+7. Make map initialization idempotent for Livewire navigation by destroying the existing map instance for the same container before creating a new one.
+8. Add feature tests asserting the rendered component emits Google config when Google is selected and free config when Google is absent.
+9. Add browser tests proving both provider modules render markers and clusters from the provided marker dataset.
+
+Definition of Done:
+
+- Session map Blade and bootstrapping JavaScript contain no hardcoded provider endpoint URLs.
+- Google-selected environments emit only Google map render configuration.
+- Free-selected environments emit only free map render configuration.
+- Map initialization works after Livewire navigation and repeated component mounts.
+- The requested behavior is implemented and follows the applicable project conventions.
+- Relevant automated tests are added or updated for the business logic and user-visible behavior.
+- Lint checks pass without warnings or errors.
+- Relevant test suites pass without warnings or errors.
+- No unrelated behavior, migrations, dependencies, or documentation are changed unless this story explicitly requires them.
+- Code is linted.
+- All tests are passing.
+- No warnings or errors in lint or tests.
+
+## Story 6: Generate Directions Through the Selected Provider
+
+Title: Generate directions through the selected provider
+
+Context: `resources/views/livewire/session/show.blade.php` builds directions URLs inline using `config('maps.google_directions_base_url')`. This calls Google directions even when the free provider should be active.
+
+Problem: Directions are provider-specific and currently bypass the mapping provider selection rule.
+
+Solution: Move directions URL generation into a provider-neutral service that delegates to the selected provider.
+
+Implementation Instructions:
+
+1. Create `app/Services/Maps/DirectionsUrlService.php` that accepts a `SportSession` and returns a provider-neutral DTO containing URL, provider, destination label, and precision.
+2. Implement Google directions generation in the Google provider using Google Maps directions URLs.
+3. Implement free directions generation in the free provider using the configured OpenStreetMap directions/search base URL.
+4. Update `resources/views/livewire/session/show.blade.php` to consume `DirectionsUrlService` output and remove inline directions URL construction.
+5. Use validated exact coordinates when `SportSession::hasValidatedAddress()` is true.
+6. Use encoded address text for legacy rows without validated exact coordinates and mark the DTO precision as `legacy_text`.
+7. Add localized UI text for exact-coordinate directions and legacy-address directions where the distinction is shown to users.
+8. Add tests for Google exact coordinates, Google legacy text, free exact coordinates, free legacy text, and absence of cross-provider URLs.
+
+Definition of Done:
+
+- Direction links are generated only by `DirectionsUrlService` and selected-provider implementations.
+- Google-selected environments emit Google directions URLs.
+- Free-selected environments emit free-provider directions URLs and no Google URL.
+- Session detail Blade contains no provider-specific directions URL construction.
+- The requested behavior is implemented and follows the applicable project conventions.
+- Relevant automated tests are added or updated for the business logic and user-visible behavior.
+- Lint checks pass without warnings or errors.
+- Relevant test suites pass without warnings or errors.
+- No unrelated behavior, migrations, dependencies, or documentation are changed unless this story explicitly requires them.
+- Code is linted.
+- All tests are passing.
+- No warnings or errors in lint or tests.
+
+## Story 7: Add Selected-Provider Health Checks to Readiness Tools
+
+Title: Add selected-provider health checks to readiness tools
+
+Context: `app/Livewire/Admin/Readiness.php` currently has `checkGoogleMapsKey()` and `checkGeocodingCache()`. `app/Console/Commands/MvpHealthSnapshot.php` reports address precision but does not probe selected map-provider capabilities. Neither tool verifies map display config, address validation/geocoding probe health, directions config, or provider-specific failures.
+
+Problem: Operators cannot verify that every required capability of the selected map provider is healthy before users hit broken mapping flows.
+
+Solution: Add provider-capability readiness checks for the selected provider to the admin readiness page and health snapshot command.
+
+Implementation Instructions:
+
+1. Create `app/Services/Maps/MapProviderHealthService.php` that returns checks for selected provider, map display, address validation, geocoding, directions, cache, and recent provider failures.
+2. For Google-selected environments, check Google API key presence and expected shape, Google Maps JavaScript render config, Google geocoding/address validation probe against a configured Belgian probe address, directions config, cache/table access, and recent provider failure records.
+3. For free-selected environments, check free style URL config, Nominatim-compatible geocoding endpoint probe against the same Belgian probe address, free directions config, attribution config, cache/table access, and recent provider failure records.
+4. Add provider failure logging persistence through a `map_provider_failures` table with provider, capability, message, occurred_at, and context columns. Store no API keys and no full provider payloads.
+5. Replace `checkGoogleMapsKey()` and `checkGeocodingCache()` in `Readiness` with selected-provider capability checks from `MapProviderHealthService`.
+6. Add the same capability checks to `MvpHealthSnapshot` and make red selected-provider failures produce exit code `1`.
+7. Add localized readiness labels and remediation messages in `lang/fr/admin.php`, `lang/en/admin.php`, and `lang/nl/admin.php`.
+8. Add tests for Google healthy, Google key missing selecting free, Google probe failure, free healthy, free endpoint missing, free probe failure, and health snapshot exit codes.
+
+Definition of Done:
+
+- Admin readiness shows the active map provider and separate statuses for map display, address validation, geocoding, directions, cache, and recent failures.
+- `mvp:health-snapshot` includes the same selected-provider capability statuses.
+- Failing selected-provider capabilities are red and actionable.
+- No readiness check suggests switching provider after a selected-provider failure.
+- The requested behavior is implemented and follows the applicable project conventions.
+- Relevant automated tests are added or updated for the business logic and user-visible behavior.
+- Lint checks pass without warnings or errors.
+- Relevant test suites pass without warnings or errors.
+- No unrelated behavior, migrations, dependencies, or documentation are changed unless this story explicitly requires them.
+- Code is linted.
+- All tests are passing.
+- No warnings or errors in lint or tests.
+
+## Story 8: Fix Session Discovery Navigation and Map Initialization
+
+Title: Fix session discovery navigation and map initialization
+
+Context: The home page Browse Sessions link in `resources/views/welcome.blade.php`, the top navigation links in `resources/views/components/nav/main.blade.php`, the mobile menu links in `resources/views/components/nav/mobile-menu.blade.php`, and the athlete contextual menu link in `resources/views/components/nav/user-menu.blade.php` all route to `sessions.index` in different navigation contexts. The map component currently relies on `@push('scripts')` inside `resources/views/components/session-map.blade.php`, which can behave differently across first load and Livewire `wire:navigate` transitions.
+
+Problem: The session map can be missing when the user reaches `/sessions` from the home page Browse Sessions link, and navigation exposes redundant session discovery links.
+
+Solution: Make every discovery entry point use one navigation pattern and make map assets initialize reliably for first page load and Livewire navigation.
+
+Implementation Instructions:
+
+1. Update `resources/views/welcome.blade.php`, `resources/views/components/nav/main.blade.php`, `resources/views/components/nav/mobile-menu.blade.php`, and `resources/views/components/nav/user-menu.blade.php` so every public/athlete discovery link points to `route('sessions.index')` with `wire:navigate`.
+2. Remove the standalone top-bar Sessions link for authenticated athletes when the athlete contextual menu already contains `common.nav.athlete_sessions`.
+3. Keep the coach top-bar session link pointing to `route('coach.sessions.create')` and label it with the coach create-session translation, not the athlete discovery translation.
+4. Move provider-neutral map bootstrapping imports into `resources/js/app.js` so they are available before the session map component initializes on both normal page loads and Livewire navigation.
+5. Add a browser event listener for Livewire navigation completion that initializes visible uninitialized map containers exactly once.
+6. Add tests proving the home Browse Sessions link, desktop navigation, mobile navigation, and athlete contextual menu all reach `/sessions` and render a provider-specific map container.
+7. Add a regression test proving the authenticated athlete top bar does not duplicate the contextual session discovery link.
+
+Definition of Done:
+
+- `/sessions` renders the map when reached from home Browse Sessions, desktop navigation, mobile navigation, and athlete contextual navigation.
+- Athlete navigation has one contextual discovery link and no redundant standalone top-bar Sessions link.
+- Coach navigation still exposes create-session behavior separately from athlete discovery.
+- Map bootstrapping works on first load and after Livewire navigation.
+- The requested behavior is implemented and follows the applicable project conventions.
+- Relevant automated tests are added or updated for the business logic and user-visible behavior.
+- Lint checks pass without warnings or errors.
+- Relevant test suites pass without warnings or errors.
+- No unrelated behavior, migrations, dependencies, or documentation are changed unless this story explicitly requires them.
+- Code is linted.
+- All tests are passing.
+- No warnings or errors in lint or tests.
+
+## Story 9: Keep Session Map Markers and Clusters Synchronized With Filters
+
+Title: Keep session map markers and clusters synchronized with filters
+
+Context: `App\Livewire\Session\Index` builds list results and map markers in the same render method, and `SessionQueryService::mapMarkers()` applies the current filters. The frontend map code initializes markers once on map load and only calls `setData()` when `addMarkers()` is called. The reported production behavior is that cluster counts can remain stale after date filters change.
+
+Problem: Filter updates can refresh the visible session list without reliably replacing the frontend map source data, leaving stale cluster counts and markers.
+
+Solution: Make marker data a first-class Livewire output that updates the provider-neutral map component after every filter, pagination, and location-state change.
+
+Implementation Instructions:
+
+1. Add a `SessionQueryService::filteredDiscoverableQuery()` method used by both paginated list results and marker collection generation.
+2. Ensure markers include all sessions matching the active filters and location/radius scope, independent of the current pagination page.
+3. Keep activity, level, date, time, status, publication, location center, and radius filters identical between list scope and marker scope.
+4. Add a stable marker payload checksum in `App\Livewire\Session\Index` and pass it to the map component.
+5. Update provider-neutral map bootstrapping so marker checksum changes trigger a provider-specific `replaceMarkers()` call that clears stale popups, replaces source data, and refreshes clusters.
+6. Clear map markers when filters produce no matching sessions.
+7. Add Livewire tests proving marker payloads change for date filters, activity filters, time filters, location/radius filters, and reset filters.
+8. Add browser coverage proving cluster counts update after marker payload replacement.
+
+Definition of Done:
+
+- Map markers and clusters always reflect the active filters.
+- Date filters reduce marker counts when fewer sessions match.
+- Resetting filters restores the unfiltered marker set.
+- No stale markers or popups remain after marker data changes.
+- The requested behavior is implemented and follows the applicable project conventions.
+- Relevant automated tests are added or updated for the business logic and user-visible behavior.
+- Lint checks pass without warnings or errors.
+- Relevant test suites pass without warnings or errors.
+- No unrelated behavior, migrations, dependencies, or documentation are changed unless this story explicitly requires them.
+- Code is linted.
+- All tests are passing.
+- No warnings or errors in lint or tests.
+
+## Story 10: Update Mapping Configuration, Tests, and Operator Documentation
+
+Title: Update mapping configuration, tests, and operator documentation
+
+Context: `.env.example`, `doc/stories/mvp-address-geolocation.md`, `doc/MVP-Stabilization-Milestone.md`, `doc/MVP-Smoke-Test.md`, `doc/Production-Readiness-Runbook.md`, and map-related tests still describe or exercise pieces of the old mixed-provider system.
+
+Problem: Maintained documentation and tests can reintroduce mixed providers or silent fallback if they continue to mention independent geocoding provider switches, Google fallback geocoding, or MapLibre/OpenFreeMap display in Google-selected environments.
+
+Solution: Update documentation, environment examples, and tests so they describe and enforce the hard Google-or-free provider system.
+
+Implementation Instructions:
+
+1. Update `.env.example` to remove `MAPS_GEOCODING_PROVIDER` and document the required `GOOGLE_MAPS_API_KEY`, Google provider settings, and free provider settings.
+2. Update `doc/stories/mvp-address-geolocation.md` so address precision work delegates provider selection to the resolver introduced in this epic and does not describe an independent geocoding provider switch.
+3. Update `doc/MVP-Stabilization-Milestone.md` so it no longer instructs implementers to keep MapLibre/OpenFreeMap display while using Google geocoding or directions.
+4. Update `doc/MVP-Smoke-Test.md` with smoke steps for Google-selected and free-selected mapping readiness.
+5. Update `doc/Production-Readiness-Runbook.md` with operator steps for verifying selected provider, map display, address validation/geocoding, directions, and recent provider failures.
+6. Update existing map/address tests that refer to `MAPS_GEOCODING_PROVIDER` so they use `GOOGLE_MAPS_API_KEY` presence or absence to select the provider.
+7. Add a documentation note that historical stored values in `geocoding_provider` are address provenance metadata only and do not control runtime provider selection.
+8. Run markdown diagnostics, targeted map/address tests, and lint checks.
+
+Definition of Done:
+
+- Maintained docs no longer prescribe or test mixed map providers in one runtime.
+- `.env.example` documents `GOOGLE_MAPS_API_KEY` as the provider-selection input and does not include `MAPS_GEOCODING_PROVIDER`.
+- Operator docs explain selected-provider readiness for Google-selected and free-selected environments.
+- Tests no longer use `MAPS_GEOCODING_PROVIDER` as a provider switch.
+- The requested behavior is implemented and follows the applicable project conventions.
+- Relevant automated tests are added or updated for the business logic and user-visible behavior.
+- Lint checks pass without warnings or errors.
+- Relevant test suites pass without warnings or errors.
+- No unrelated behavior, migrations, dependencies, or documentation are changed unless this story explicitly requires them.
+- Code is linted.
+- All tests are passing.
+- No warnings or errors in lint or tests.


### PR DESCRIPTION
- Updated documentation across multiple files to reflect the new provider selection logic based on the presence of GOOGLE_MAPS_API_KEY.
- Removed MAPS_GEOCODING_PROVIDER from configuration and tests, consolidating provider selection into a single resolver.
- Implemented complete Google and free mapping services, ensuring all mapping capabilities are handled by the selected provider.
- Refactored address validation and geocoding services to utilize the selected provider, eliminating fallback to postal-code centers.
- Enhanced readiness checks to verify the health of the selected provider's capabilities.
- Fixed session discovery navigation and map initialization to ensure consistent rendering across all entry points.
- Updated tests to cover new provider logic and ensure no mixed-provider behavior occurs.