### PR TITLE
fix: add User-Agent header to all Nominatim HTTP requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,8 @@ MAPS_TILE_STYLE_URL=https://tiles.openfreemap.org/styles/liberty
 OPENFREEMAP_GEOCODING_BASE_URL=
 # Optional API key for hosted Nominatim services (sent as X-Api-Key header)
 OPENFREEMAP_GEOCODING_API_KEY=
+# User-Agent header sent on every Nominatim request (required by OSM policy)
+NOMINATIM_USER_AGENT=Motivya/1.0 (+https://motivya.be)
 # OSM directions base URL
 MAPS_FREE_DIRECTIONS_BASE_URL=
 

--- a/app/Services/Maps/Free/FreeAddressValidationProvider.php
+++ b/app/Services/Maps/Free/FreeAddressValidationProvider.php
@@ -29,7 +29,8 @@ final class FreeAddressValidationProvider implements AddressValidationProviderCo
             $apiKey = config('maps.free.geocoding_api_key');
 
             $request = Http::timeout((int) config('maps.geocoding_timeout', 5))
-                ->acceptJson();
+                ->acceptJson()
+                ->withHeaders(['User-Agent' => (string) config('maps.free.nominatim_user_agent', 'Motivya/1.0 (+https://motivya.be)')]);
 
             if (is_string($apiKey) && $apiKey !== '') {
                 $request = $request->withHeaders(['X-Api-Key' => $apiKey]);

--- a/app/Services/Maps/Free/FreeGeocodingProvider.php
+++ b/app/Services/Maps/Free/FreeGeocodingProvider.php
@@ -28,7 +28,8 @@ final class FreeGeocodingProvider implements GeocodingProviderContract
             $apiKey = config('maps.free.geocoding_api_key');
 
             $request = Http::timeout((int) config('maps.geocoding_timeout', 5))
-                ->acceptJson();
+                ->acceptJson()
+                ->withHeaders(['User-Agent' => (string) config('maps.free.nominatim_user_agent', 'Motivya/1.0 (+https://motivya.be)')]);
 
             if (is_string($apiKey) && $apiKey !== '') {
                 $request = $request->withHeaders(['X-Api-Key' => $apiKey]);

--- a/app/Services/Maps/Free/FreeHealthProbeProvider.php
+++ b/app/Services/Maps/Free/FreeHealthProbeProvider.php
@@ -56,7 +56,9 @@ final class FreeHealthProbeProvider implements HealthProbeProviderContract
         // 3. Geocoding endpoint reachable
         try {
             $apiKey = config('maps.free.geocoding_api_key');
-            $request = Http::timeout((int) config('maps.geocoding_timeout', 5))->acceptJson();
+            $request = Http::timeout((int) config('maps.geocoding_timeout', 5))
+                ->acceptJson()
+                ->withHeaders(['User-Agent' => (string) config('maps.free.nominatim_user_agent', 'Motivya/1.0 (+https://motivya.be)')]);
 
             if (is_string($apiKey) && $apiKey !== '') {
                 $request = $request->withHeaders(['X-Api-Key' => $apiKey]);

--- a/config/maps.php
+++ b/config/maps.php
@@ -45,6 +45,7 @@ return [
         'tile_style_url' => env('MAPS_TILE_STYLE_URL', 'https://tiles.openfreemap.org/styles/liberty'),
         'geocoding_base_url' => env('OPENFREEMAP_GEOCODING_BASE_URL', 'https://nominatim.openstreetmap.org/search'),
         'geocoding_api_key' => env('OPENFREEMAP_GEOCODING_API_KEY'),
+        'nominatim_user_agent' => env('NOMINATIM_USER_AGENT', 'Motivya/1.0 (+https://motivya.be)'),
         'directions_base_url' => env('MAPS_FREE_DIRECTIONS_BASE_URL', 'https://www.openstreetmap.org/directions'),
         'attribution' => '© OpenStreetMap contributors',
     ],

--- a/tests/Unit/Services/AddressValidationServiceTest.php
+++ b/tests/Unit/Services/AddressValidationServiceTest.php
@@ -332,6 +332,30 @@ describe('AddressValidationService — OpenFreeMap provider', function (): void 
         Http::assertSent(fn ($request): bool => ! $request->hasHeader('X-Api-Key'));
     });
 
+    it('sends the default User-Agent header to Nominatim', function (): void {
+        Http::fake([
+            'https://nominatim.openstreetmap.org/*' => Http::response(nominatimBelgianSuccessResponse(), 200),
+        ]);
+
+        $service = app(AddressValidationService::class);
+        $service->validate('Grand-Place 1, Bruxelles');
+
+        Http::assertSent(fn ($request): bool => $request->hasHeader('User-Agent', 'Motivya/1.0 (+https://motivya.be)'));
+    });
+
+    it('sends the configured User-Agent header when NOMINATIM_USER_AGENT is overridden', function (): void {
+        Config::set('maps.free.nominatim_user_agent', 'MyApp/2.0 (+https://myapp.example.com)');
+
+        Http::fake([
+            'https://nominatim.openstreetmap.org/*' => Http::response(nominatimBelgianSuccessResponse(), 200),
+        ]);
+
+        $service = app(AddressValidationService::class);
+        $service->validate('Grand-Place 1, Bruxelles');
+
+        Http::assertSent(fn ($request): bool => $request->hasHeader('User-Agent', 'MyApp/2.0 (+https://myapp.example.com)'));
+    });
+
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/Unit/Services/Maps/AddressValidationProviderTest.php
+++ b/tests/Unit/Services/Maps/AddressValidationProviderTest.php
@@ -223,6 +223,30 @@ describe('FreeAddressValidationProvider', function (): void {
         });
     });
 
+    it('sends the default User-Agent header to Nominatim', function (): void {
+        Http::fake([
+            'nominatim.openstreetmap.org/*' => Http::response([]),
+        ]);
+
+        $provider = new FreeAddressValidationProvider;
+        $provider->validate('Test', 'fr', 'BE');
+
+        Http::assertSent(fn ($request): bool => $request->hasHeader('User-Agent', 'Motivya/1.0 (+https://motivya.be)'));
+    });
+
+    it('sends the configured User-Agent header when nominatim_user_agent is overridden', function (): void {
+        Config::set('maps.free.nominatim_user_agent', 'TestApp/3.0 (+https://test.example.com)');
+
+        Http::fake([
+            'nominatim.openstreetmap.org/*' => Http::response([]),
+        ]);
+
+        $provider = new FreeAddressValidationProvider;
+        $provider->validate('Test', 'fr', 'BE');
+
+        Http::assertSent(fn ($request): bool => $request->hasHeader('User-Agent', 'TestApp/3.0 (+https://test.example.com)'));
+    });
+
     it('returns null on HTTP error and logs a warning', function (): void {
         Http::fake([
             'nominatim.openstreetmap.org/*' => Http::response([], 503),


### PR DESCRIPTION
Closes #364

## Context

The OSM [Nominatim usage policy](https://operations.osmfoundation.org/policies/nominatim/) requires every request to identify the caller via a `User-Agent` header. PR #365 applied this fix to `AddressValidationService::validateOpenFreeMap()`, but that method was removed by PR #379 which introduced three dedicated free-provider classes. None of those classes sent the header.

This PR re-implements the same requirement against the new architecture.

## Changes

| File | Change |
|------|--------|
| `config/maps.php` | Added `free.nominatim_user_agent` key read from `NOMINATIM_USER_AGENT` (default `Motivya/1.0 (+https://motivya.be)`) |
| `.env.example` | Documented `NOMINATIM_USER_AGENT` next to the other free-stack options |
| `FreeAddressValidationProvider` | Sends `User-Agent` header on every Nominatim request |
| `FreeGeocodingProvider` | Sends `User-Agent` header on every Nominatim request |
| `FreeHealthProbeProvider` | Sends `User-Agent` header on every Nominatim probe request |
| `AddressValidationProviderTest` | Two new tests: default UA sent; overridden UA sent |
| `AddressValidationServiceTest` | Two new tests: default UA sent; overridden UA sent |

## Testing

39 tests pass, 92 assertions — all green.

## Supersedes

PR #365 (closed — targets code that no longer exists after PR #379).