### PR TITLE
feat: load session-map via global bundle for wire:navigate compatibility

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,1 +1,2 @@
 import './bootstrap';
+import './session-map';

--- a/resources/views/components/session-map.blade.php
+++ b/resources/views/components/session-map.blade.php
@@ -19,8 +19,3 @@
     wire:ignore>
 </div>
 
-@once
-    @push('scripts')
-        @vite('resources/js/session-map.js')
-    @endpush
-@endonce

--- a/tests/Feature/Livewire/Session/MapTest.php
+++ b/tests/Feature/Livewire/Session/MapTest.php
@@ -92,4 +92,21 @@ describe('session map', function () {
             ->assertSee(__('sessions.map_no_markers'));
     });
 
+    it('does not push a page-local session-map.js Vite entry in the component', function () {
+        // The session map initializer is loaded via the global app bundle (app.js → session-map.js).
+        // The <x-session-map> component must NOT inject its own @vite('resources/js/session-map.js')
+        // so that wire:navigate SPA visits — which reuse the already-loaded app bundle — have
+        // window.sessionMap available without a full-page reload.
+        $blade = file_get_contents(resource_path('views/components/session-map.blade.php'));
+
+        expect($blade)->not->toContain("@vite('resources/js/session-map.js')");
+    });
+
+    it('registers window.sessionMap from the global app bundle entry', function () {
+        // app.js must import session-map.js so the initializer is bundled globally.
+        $appJs = file_get_contents(resource_path('js/app.js'));
+
+        expect($appJs)->toContain("import './session-map'");
+    });
+
 });


### PR DESCRIPTION
## Summary

Fixes the session discovery map not rendering when `/sessions` is reached through `wire:navigate` (SPA navigation).

**Root cause:** `window.sessionMap` was only registered when `resources/js/session-map.js` was loaded via a component-local `@push('scripts')` stacked entry. On a full page render this works fine, but on a `wire:navigate` visit the document body is swapped without re-executing stacked scripts, so `window.sessionMap` is undefined when `x-data="sessionMap(...)"` is evaluated by Alpine.

## Changes

| File | Change |
|------|--------|
| `resources/js/app.js` | Import `./session-map` so the initializer is bundled in the global app bundle |
| `resources/views/components/session-map.blade.php` | Remove `@once @push('scripts') @vite(...)` block — the component keeps its existing markup and `x-data="sessionMap(...)"` contract unchanged |
| `tests/Feature/Livewire/Session/MapTest.php` | Add two contract-locking tests: component must not inject its own Vite entry; `app.js` must import `session-map.js` |

## Definition of Done

- [x] `session-map.js` loaded via global bundle — no component-local Vite entry
- [x] `<x-session-map>` API and MapLibre behavior unchanged
- [x] New tests lock the asset-loading contract (7 tests pass)
- [x] All existing Livewire session tests pass (33 total, 56 assertions)
- [x] Lint clean (516 files checked, 0 issues)

## Story reference

`doc/stories/mvp-session-discovery-map-wire-navigate.md`