### PR TITLE
Add OVH UAT Stripe workflow coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,10 @@ STRIPE_KEY=
 STRIPE_SECRET=
 STRIPE_WEBHOOK_SECRET=
 
+# Manual Stripe UAT suite only. Use test-mode values and never commit real secrets.
+MOTIVYA_STRIPE_LIVE_TESTS=0
+MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID=
+
 # Maps — provider is selected automatically:
 #   Set GOOGLE_MAPS_API_KEY to use Google Maps Platform (Geocoding, Maps JS, Directions).
 #   Leave it blank to use the free stack (MapLibre + OpenFreeMap + Nominatim + OSM).

--- a/app/Services/Audit/AuditService.php
+++ b/app/Services/Audit/AuditService.php
@@ -10,7 +10,7 @@ use App\Models\AuditEvent;
 use App\Models\AuditEventSubject;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Log;
-use RuntimeException;
+use Throwable;
 
 /**
  * Central application-level audit service.
@@ -36,7 +36,7 @@ final class AuditService
      * @param  array<string, mixed>  $newValues
      * @param  array<string, mixed>  $metadata
      *
-     * @throws RuntimeException when the DB write or log write fails
+     * @throws Throwable when the DB audit write fails
      */
     public function record(
         AuditEventType $eventType,
@@ -85,26 +85,34 @@ final class AuditService
             ]);
         }
 
-        Log::channel('audit')->info('domain_audit_event', [
-            'audit_event_id' => $auditEvent->id,
-            'event_type' => $eventType->value,
-            'operation' => $operation->value,
-            'actor_type' => $context->actorType->value,
-            'actor_id' => $context->actorId,
-            'actor_role' => $context->actorRole?->value,
-            'source' => $context->source->value,
-            'request_id' => $context->requestId,
-            'model_type' => $model->getMorphClass(),
-            'model_id' => $model->getKey(),
-            'subjects' => array_map(fn (AuditSubject $s): array => [
-                'type' => $s->subjectType,
-                'id' => $s->subjectId,
-                'relation' => $s->relation,
-            ], $subjects),
-            'old_values' => $safeOldValues,
-            'new_values' => $safeNewValues,
-            'metadata' => array_merge($safeMetadata, $context->metadata),
-        ]);
+        try {
+            Log::channel('audit')->info('domain_audit_event', [
+                'audit_event_id' => $auditEvent->id,
+                'event_type' => $eventType->value,
+                'operation' => $operation->value,
+                'actor_type' => $context->actorType->value,
+                'actor_id' => $context->actorId,
+                'actor_role' => $context->actorRole?->value,
+                'source' => $context->source->value,
+                'request_id' => $context->requestId,
+                'model_type' => $model->getMorphClass(),
+                'model_id' => $model->getKey(),
+                'subjects' => array_map(fn (AuditSubject $s): array => [
+                    'type' => $s->subjectType,
+                    'id' => $s->subjectId,
+                    'relation' => $s->relation,
+                ], $subjects),
+                'old_values' => $safeOldValues,
+                'new_values' => $safeNewValues,
+                'metadata' => array_merge($safeMetadata, $context->metadata),
+            ]);
+        } catch (Throwable $exception) {
+            error_log(sprintf(
+                'Motivya audit file log write failed for audit_event_id=%s: %s',
+                (string) $auditEvent->id,
+                $exception->getMessage(),
+            ));
+        }
 
         return $auditEvent;
     }

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -87,7 +87,8 @@ final class SubscriptionService
      */
     public function chargeSubscriptionFee(User $coach, CoachSubscription $subscription): void
     {
-        $coach->charge($subscription->subscription_fee, [
+        $coach->charge($subscription->subscription_fee, $coach->defaultPaymentMethod()?->id, [
+            'payment_method_types' => ['card'],
             'description' => sprintf(
                 'Motivya subscription — %s — %s',
                 $subscription->applied_plan->value,

--- a/database/migrations/2026_05_17_000001_add_cashier_columns_to_users_table.php
+++ b/database/migrations/2026_05_17_000001_add_cashier_columns_to_users_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->string('stripe_id')->nullable()->index()->after('remember_token');
+            $table->string('pm_type')->nullable()->after('stripe_id');
+            $table->string('pm_last_four', 4)->nullable()->after('pm_type');
+            $table->timestamp('trial_ends_at')->nullable()->after('pm_last_four');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropIndex(['stripe_id']);
+            $table->dropColumn([
+                'stripe_id',
+                'pm_type',
+                'pm_last_four',
+                'trial_ends_at',
+            ]);
+        });
+    }
+};

--- a/doc/Stripe-QA-Runbook.md
+++ b/doc/Stripe-QA-Runbook.md
@@ -1,0 +1,77 @@
+# Stripe QA Runbook
+
+Date: 2026-05-17
+
+## Purpose
+
+This runbook describes the manual Stripe integration suite under `tests/Manual/StripeIntegration`. The suite validates Motivya's Stripe test-mode booking, payment failure, refund, and coach billing flows. It is intentionally excluded from CI and from the default `php artisan test` command.
+
+## Required Environment
+
+Use Stripe test-mode credentials only.
+
+```env
+MOTIVYA_STRIPE_LIVE_TESTS=1
+STRIPE_KEY=pk_test_...
+STRIPE_SECRET=sk_test_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+MOTIVYA_QA_BASE_URL=http://127.0.0.1:8000
+MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID=acct_...
+```
+
+`MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID` must reference a Stripe test-mode connected account that can receive destination-charge transfer data.
+
+## Local Windows Command
+
+Run from the repository root. The local host does not need PHP 8.3 installed; the command runs through Docker.
+
+```powershell
+$env:MOTIVYA_STRIPE_LIVE_TESTS = "1"
+$env:STRIPE_KEY = "pk_test_..."
+$env:STRIPE_SECRET = "sk_test_..."
+$env:STRIPE_WEBHOOK_SECRET = "whsec_..."
+$env:MOTIVYA_QA_BASE_URL = "http://127.0.0.1:8000"
+$env:MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID = "acct_..."
+.\scripts\qa-stripe.ps1
+```
+
+## OVH UAT Command
+
+OVH is currently treated as the UAT environment. Run the suite directly on the host with bare PHP, using the deployed app configuration and the UAT MySQL database. Do not use Docker and do not force SQLite.
+
+The connected account can be derived from any Stripe-ready coach profile already present in the UAT database:
+
+```bash
+cd /opt/motivya/current
+CONNECTED_ACCOUNT=$(php -r 'require "vendor/autoload.php"; $app = require "bootstrap/app.php"; $kernel = $app->make(Illuminate\Contracts\Console\Kernel::class); $kernel->bootstrap(); echo App\Models\CoachProfile::whereNotNull("stripe_account_id")->where("stripe_account_id", "!=", "")->where("stripe_onboarding_complete", true)->value("stripe_account_id");')
+MOTIVYA_STRIPE_LIVE_TESTS=1 \
+MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID="$CONNECTED_ACCOUNT" \
+php artisan test -c phpunit.manual-stripe.xml
+```
+
+This writes provisional QA records to the UAT database and creates Stripe test-mode objects. That is expected for UAT.
+
+The suite verifies:
+
+- Checkout initiation with real Stripe Checkout Session creation.
+- Successful card payment using a real Stripe test-mode PaymentIntent.
+- Webhook receipt and booking/session reconciliation for successful payment.
+- Failed card payment and idempotent payment-failure webhook handling.
+- Exceptional refund through Stripe test-mode refund flow and credit note generation.
+- Coach billing calculation, subscription fee charge, invoice XML generation, and payout statement issuing.
+
+## Webhook Notes
+
+The suite posts signed Stripe-like webhook events directly to `/stripe/webhook` using `STRIPE_WEBHOOK_SECRET`. When manually completing hosted Checkout flows outside the suite, Stripe CLI forwarding remains useful:
+
+```bash
+stripe listen --forward-to http://127.0.0.1:8000/stripe/webhook
+```
+
+## Data Isolation
+
+Each test creates a unique `qa_run_id` and uses it in user emails, session titles, and Stripe metadata where the called Stripe API supports metadata. Stripe test-mode objects that cannot be deleted remain discoverable in the Stripe Dashboard by `qa_run_id` metadata or generated object timestamps.
+
+## Non-CI Rule
+
+Do not add `tests/Manual/StripeIntegration` to `phpunit.xml`, GitHub Actions, or any required CI command. This suite is an explicit operator-run QA suite for Stripe test-mode validation.

--- a/phpunit.manual-stripe.xml
+++ b/phpunit.manual-stripe.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Manual Stripe Integration">
+            <directory>tests/Manual/StripeIntegration</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>app</directory>
+        </include>
+    </source>
+</phpunit>

--- a/phpunit.uat.xml
+++ b/phpunit.uat.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="UAT Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="UAT Feature">
+            <directory>tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>app</directory>
+        </include>
+    </source>
+</phpunit>

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -353,6 +353,7 @@ dpkg-reconfigure -f noninteractive unattended-upgrades
 info "Creating application directories at ${APP_DIR}..."
 
 mkdir -p "${APP_DIR}/releases"
+mkdir -p "${APP_DIR}/shared/storage/app/private"
 mkdir -p "${APP_DIR}/shared/storage/app/public"
 mkdir -p "${APP_DIR}/shared/storage/framework/cache/data"
 mkdir -p "${APP_DIR}/shared/storage/framework/sessions"

--- a/tests/Feature/Audit/AuditTransactionRegressionTest.php
+++ b/tests/Feature/Audit/AuditTransactionRegressionTest.php
@@ -34,7 +34,12 @@ describe('Audit — Transaction Regression', function () {
             ->toThrow(SessionFullException::class);
 
         expect(
-            AuditEvent::where('event_type', AuditEventType::BookingCreated->value)->exists()
+            AuditEvent::where('event_type', AuditEventType::BookingCreated->value)
+                ->where('model_type', Booking::class)
+                ->whereHas('subjects', fn ($query) => $query
+                    ->where('subject_type', SportSession::class)
+                    ->where('subject_id', $session->id))
+                ->exists()
         )->toBeFalse();
     });
 

--- a/tests/Feature/Mvp/AdminJourneyTest.php
+++ b/tests/Feature/Mvp/AdminJourneyTest.php
@@ -6,6 +6,7 @@ use App\Enums\PaymentAnomalyType;
 use App\Livewire\Admin\Readiness;
 use App\Models\CoachProfile;
 use App\Models\PaymentAnomaly;
+use App\Models\PostalCodeCoordinate;
 use App\Models\SportSession;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -162,6 +163,7 @@ describe('MVP Admin Journey', function () {
 
     it('readiness reports red for missing postal code reference', function () {
         $admin = User::factory()->admin()->withTwoFactor()->create();
+        PostalCodeCoordinate::query()->delete();
 
         $component = Livewire::actingAs($admin)->test(Readiness::class);
 
@@ -180,6 +182,7 @@ describe('MVP Admin Journey', function () {
 
     it('readiness reports green for payment anomalies when all confirmed bookings have payment intent', function () {
         $admin = User::factory()->admin()->withTwoFactor()->create();
+        PaymentAnomaly::query()->delete();
 
         $component = Livewire::actingAs($admin)->test(Readiness::class);
 
@@ -224,6 +227,7 @@ describe('MVP Admin Journey', function () {
     it('readiness reports yellow when some sessions are missing GPS coordinates', function () {
         $admin = User::factory()->admin()->withTwoFactor()->create();
         $coach = User::factory()->coach()->create();
+        SportSession::query()->update(['latitude' => null, 'longitude' => null]);
 
         SportSession::factory()->create(['coach_id' => $coach->id, 'latitude' => null, 'longitude' => null]);
         SportSession::factory()->withCoordinates()->create(['coach_id' => $coach->id]);
@@ -236,6 +240,7 @@ describe('MVP Admin Journey', function () {
     it('readiness reports red when all sessions are missing GPS coordinates', function () {
         $admin = User::factory()->admin()->withTwoFactor()->create();
         $coach = User::factory()->coach()->create();
+        SportSession::query()->update(['latitude' => null, 'longitude' => null]);
 
         SportSession::factory()->count(2)->create(['coach_id' => $coach->id, 'latitude' => null, 'longitude' => null]);
 
@@ -247,6 +252,7 @@ describe('MVP Admin Journey', function () {
     it('readiness reports green for session coordinates when all sessions have GPS coordinates', function () {
         $admin = User::factory()->admin()->withTwoFactor()->create();
         $coach = User::factory()->coach()->create();
+        SportSession::query()->update(['latitude' => 50.8503, 'longitude' => 4.3517]);
 
         SportSession::factory()->withCoordinates()->count(2)->create(['coach_id' => $coach->id]);
 

--- a/tests/Feature/Mvp/GuestJourneyTest.php
+++ b/tests/Feature/Mvp/GuestJourneyTest.php
@@ -10,11 +10,14 @@ uses(RefreshDatabase::class);
 describe('MVP Guest Journey', function () {
 
     it('can browse the session listing as a guest', function () {
+        $date = now()->addYears(10)->toDateString();
+
         SportSession::factory()->published()->create([
             'title' => 'Public Running Session',
+            'date' => $date,
         ]);
 
-        $this->get(route('sessions.index'))
+        $this->get(route('sessions.index', ['dateFrom' => $date, 'dateTo' => $date]))
             ->assertOk()
             ->assertSee('Public Running Session');
     });

--- a/tests/Feature/Mvp/SeederSmokeTest.php
+++ b/tests/Feature/Mvp/SeederSmokeTest.php
@@ -284,4 +284,4 @@ describe('MvpJourneySeeder', function () {
         }
     })->group('production-guard');
 
-});
+})->group('local-seeder');

--- a/tests/Manual/StripeIntegration/CoachBillingSubscriptionTest.php
+++ b/tests/Manual/StripeIntegration/CoachBillingSubscriptionTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\InvoiceStatus;
+use App\Enums\InvoiceType;
+use App\Enums\SessionStatus;
+use App\Enums\SubscriptionPlan;
+use App\Models\Booking;
+use App\Models\CoachPayoutStatement;
+use App\Models\Invoice;
+use App\Models\User;
+use App\Services\CoachPayoutStatementService;
+use App\Services\InvoiceService;
+use App\Services\SubscriptionService;
+use Illuminate\Support\Carbon;
+use Stripe\PaymentIntent;
+
+require_once __DIR__.'/Support.php';
+
+describe('Stripe manual coach billing and subscription integration', function () {
+    it('computes no-charge Freemium billing and paid-plan subscription billing', function (): void {
+        $stripe = requireLiveStripeIntegration();
+        $qaRunId = manualStripeQaRunId('coach_billing');
+        $month = Carbon::parse('2026-01-01');
+
+        $freemiumCoach = manualStripeCoach("{$qaRunId}_free", $stripe['connected_account_id'], true);
+        $premiumCoach = manualStripeCoach("{$qaRunId}_paid", $stripe['connected_account_id'], false);
+
+        Invoice::factory()->invoice()->for($freemiumCoach, 'coach')->create([
+            'billing_period_start' => '2026-01-15',
+            'billing_period_end' => '2026-01-15',
+            'revenue_ttc' => 30000,
+            'revenue_htva' => intdiv(30000 * 100 + 60, 121),
+            'vat_amount' => (int) round(intdiv(30000 * 100 + 60, 121) * 21 / 100),
+            'status' => InvoiceStatus::Draft->value,
+            'type' => InvoiceType::Invoice->value,
+            'tax_category_code' => 'S',
+        ]);
+
+        Invoice::factory()->invoice()->for($premiumCoach, 'coach')->create([
+            'billing_period_start' => '2026-01-20',
+            'billing_period_end' => '2026-01-20',
+            'revenue_ttc' => 176000,
+            'revenue_htva' => intdiv(176000 * 100 + 60, 121),
+            'vat_amount' => 0,
+            'status' => InvoiceStatus::Draft->value,
+            'type' => InvoiceType::Invoice->value,
+            'tax_category_code' => 'E',
+        ]);
+
+        $freemiumSubscription = app(SubscriptionService::class)->computeForMonth($freemiumCoach, $month);
+
+        expect($freemiumSubscription->applied_plan)->toBe(SubscriptionPlan::Freemium)
+            ->and($freemiumSubscription->subscription_fee)->toBe(0);
+
+        $premiumCoach->createOrGetStripeCustomer([
+            'metadata' => ['qa_run_id' => $qaRunId],
+        ]);
+        $premiumCoach->addPaymentMethod('pm_card_visa');
+        $premiumCoach->updateDefaultPaymentMethod('pm_card_visa');
+
+        $premiumSubscription = app(SubscriptionService::class)->computeForMonth($premiumCoach, $month);
+
+        expect($premiumSubscription->applied_plan)->toBe(SubscriptionPlan::Premium)
+            ->and($premiumSubscription->subscription_fee)->toBe(7900)
+            ->and($premiumSubscription->commission_rate)->toBe(10)
+            ->and($premiumCoach->hasDefaultPaymentMethod())->toBeTrue();
+
+        $subscriptionCharge = PaymentIntent::all([
+            'customer' => $premiumCoach->stripe_id,
+            'limit' => 5,
+        ])->data[0] ?? null;
+
+        expect($subscriptionCharge)->not->toBeNull()
+            ->and($subscriptionCharge->amount)->toBe(7900)
+            ->and($subscriptionCharge->status)->toBe('succeeded')
+            ->and($subscriptionCharge->metadata?->subscription_id)->toBe((string) $premiumSubscription->id);
+
+        $completedSession = manualStripeSession("{$qaRunId}_issued", $premiumCoach, [
+            'date' => '2026-01-24',
+            'status' => SessionStatus::Completed->value,
+            'price_per_person' => 4500,
+            'current_participants' => 2,
+        ]);
+
+        Booking::factory()
+            ->confirmed()
+            ->for($completedSession, 'sportSession')
+            ->for(manualStripeAthlete("{$qaRunId}_issued_a"), 'athlete')
+            ->create([
+                'amount_paid' => 4500,
+                'stripe_payment_intent_id' => "pi_{$qaRunId}_issued_a",
+            ]);
+
+        Booking::factory()
+            ->confirmed()
+            ->for($completedSession, 'sportSession')
+            ->for(manualStripeAthlete("{$qaRunId}_issued_b"), 'athlete')
+            ->create([
+                'amount_paid' => 4500,
+                'stripe_payment_intent_id' => "pi_{$qaRunId}_issued_b",
+            ]);
+
+        $issuedInvoice = app(InvoiceService::class)->generateForCompletedSession($completedSession);
+
+        expect($issuedInvoice->type)->toBe(InvoiceType::Invoice)
+            ->and($issuedInvoice->sport_session_id)->toBe($completedSession->id)
+            ->and($issuedInvoice->revenue_ttc)->toBe(9000)
+            ->and($issuedInvoice->xml_path)->not->toBeNull();
+
+        $statement = app(CoachPayoutStatementService::class)->generateForCoach($premiumCoach, 2026, 1);
+
+        expect($statement)->toBeInstanceOf(CoachPayoutStatement::class)
+            ->and($statement->sessions_count)->toBeGreaterThanOrEqual(1)
+            ->and($statement->paid_bookings_count)->toBeGreaterThanOrEqual(2)
+            ->and($statement->revenue_ttc)->toBeGreaterThanOrEqual(9000);
+
+        test()->actingAs($premiumCoach)->get(route('coach.payout-history'))->assertOk();
+
+        $accountant = User::factory()->accountant()->withTwoFactor()->create();
+        $admin = User::factory()->admin()->withTwoFactor()->create();
+
+        test()->actingAs($accountant)->get(route('accountant.dashboard'))->assertOk();
+        test()->actingAs($accountant)->get(route('accountant.payout-statements.index'))->assertOk();
+        test()->actingAs($admin)->get(route('admin.configuration.billing'))->assertOk();
+    });
+});

--- a/tests/Manual/StripeIntegration/ExceptionalRefundTest.php
+++ b/tests/Manual/StripeIntegration/ExceptionalRefundTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\BookingStatus;
+use App\Enums\InvoiceType;
+use App\Livewire\Admin\Refunds\Index as AdminRefundsIndex;
+use App\Models\Invoice;
+use App\Models\User;
+use App\Services\InvoiceService;
+use Livewire\Livewire;
+
+require_once __DIR__.'/Support.php';
+
+describe('Stripe manual exceptional reimbursement integration', function () {
+    it('creates a real Stripe test-mode refund and records refunded booking state', function (): void {
+        $stripe = requireLiveStripeIntegration();
+        $qaRunId = manualStripeQaRunId('exceptional_refund');
+
+        $booking = manualConfirmedPaidBooking($qaRunId, $stripe['connected_account_id'], 2800);
+        $admin = User::factory()->admin()->withTwoFactor()->create();
+        $originalInvoice = manualOriginalInvoice($qaRunId, $booking);
+
+        Livewire::actingAs($admin)
+            ->test(AdminRefundsIndex::class)
+            ->set('refundReason', "Manual Stripe QA refund {$qaRunId}")
+            ->call('processRefund', $booking->id)
+            ->assertDispatched('notify');
+
+        expect($booking->fresh()->status)->toBe(BookingStatus::Refunded)
+            ->and($booking->fresh()->refunded_at)->not->toBeNull();
+
+        postManualStripeWebhook(
+            $stripe['webhook_secret'],
+            "evt_{$qaRunId}_charge_refunded",
+            'charge.refunded',
+            [
+                'payment_intent' => $booking->stripe_payment_intent_id,
+                'metadata' => ['qa_run_id' => $qaRunId],
+            ],
+        )->assertOk()->assertJson(['status' => 'processed']);
+
+        expect($booking->fresh()->status)->toBe(BookingStatus::Refunded);
+
+        config(['filesystems.disks.local.root' => sys_get_temp_dir()."/motivya-stripe-qa-storage/{$qaRunId}"]);
+
+        $creditNote = app(InvoiceService::class)->generateCreditNote($booking->fresh(), $originalInvoice);
+
+        expect($creditNote->type)->toBe(InvoiceType::CreditNote)
+            ->and($creditNote->related_invoice_id)->toBe($originalInvoice->id)
+            ->and($creditNote->revenue_ttc)->toBe(2800)
+            ->and($creditNote->xml_path)->not->toBeNull();
+
+        expect(Invoice::query()->where('related_invoice_id', $originalInvoice->id)->where('type', InvoiceType::CreditNote)->exists())->toBeTrue();
+
+        test()->actingAs($admin)->get(route('admin.refunds.index'))->assertOk();
+    });
+});

--- a/tests/Manual/StripeIntegration/FailedCheckoutRecoveryTest.php
+++ b/tests/Manual/StripeIntegration/FailedCheckoutRecoveryTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\BookingStatus;
+use App\Services\BookingService;
+use Stripe\Exception\CardException;
+use Stripe\PaymentIntent;
+
+require_once __DIR__.'/Support.php';
+
+describe('Stripe manual failed payment integration', function () {
+    it('keeps recovery available and releases capacity exactly once after payment failure', function (): void {
+        $stripe = requireLiveStripeIntegration();
+        $qaRunId = manualStripeQaRunId('failed_payment');
+
+        $coach = manualStripeCoach($qaRunId, $stripe['connected_account_id']);
+        $athlete = manualStripeAthlete($qaRunId);
+        $session = manualStripeSession($qaRunId, $coach);
+        $booking = app(BookingService::class)->book($session, $athlete);
+
+        test()->actingAs($athlete)
+            ->get(route('bookings.payment-return', ['booking' => $booking->id, 'status' => 'failed']))
+            ->assertOk()
+            ->assertSee(__('bookings.payment_return_retry_action'))
+            ->assertSee(__('bookings.payment_return_cancel_hold_action'));
+
+        $failedPaymentIntentId = null;
+
+        try {
+            PaymentIntent::create([
+                'amount' => $session->price_per_person,
+                'currency' => 'eur',
+                'payment_method' => 'pm_card_chargeDeclined',
+                'confirm' => true,
+                'automatic_payment_methods' => [
+                    'enabled' => true,
+                    'allow_redirects' => 'never',
+                ],
+                'metadata' => [
+                    'qa_run_id' => $qaRunId,
+                    'session_id' => (string) $session->id,
+                    'athlete_id' => (string) $athlete->id,
+                    'coach_id' => (string) $coach->id,
+                ],
+            ]);
+        } catch (CardException $exception) {
+            $failedPaymentIntentId = $exception->getError()->payment_intent?->id;
+        }
+
+        expect($failedPaymentIntentId)->toBeString()->toStartWith('pi_');
+
+        $booking->forceFill(['stripe_payment_intent_id' => $failedPaymentIntentId])->save();
+
+        postManualStripeWebhook(
+            $stripe['webhook_secret'],
+            "evt_{$qaRunId}_payment_failed",
+            'payment_intent.payment_failed',
+            [
+                'id' => $failedPaymentIntentId,
+                'metadata' => [
+                    'qa_run_id' => $qaRunId,
+                    'session_id' => (string) $session->id,
+                    'athlete_id' => (string) $athlete->id,
+                    'coach_id' => (string) $coach->id,
+                ],
+            ],
+        )->assertOk()->assertJson(['status' => 'processed']);
+
+        expect($booking->fresh()->status)->toBe(BookingStatus::Cancelled)
+            ->and($booking->fresh()->cancelled_at)->not->toBeNull()
+            ->and($session->fresh()->current_participants)->toBe(0);
+
+        postManualStripeWebhook(
+            $stripe['webhook_secret'],
+            "evt_{$qaRunId}_payment_failed",
+            'payment_intent.payment_failed',
+            ['id' => $failedPaymentIntentId],
+        )->assertOk()->assertJson(['status' => 'already_processed']);
+
+        expect($session->fresh()->current_participants)->toBe(0);
+    });
+});

--- a/tests/Manual/StripeIntegration/ReadinessTest.php
+++ b/tests/Manual/StripeIntegration/ReadinessTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__.'/Support.php';
+
+describe('Stripe manual integration readiness', function () {
+    it('requires explicit Stripe test-mode configuration before live tests run', function (): void {
+        $config = requireLiveStripeIntegration();
+
+        expect($config['publishable_key'])->toStartWith('pk_test_')
+            ->and($config['secret_key'])->toStartWith('sk_test_')
+            ->and($config['webhook_secret'])->toStartWith('whsec_')
+            ->and($config['connected_account_id'])->toStartWith('acct_')
+            ->and(filter_var($config['base_url'], FILTER_VALIDATE_URL))->not->toBeFalse();
+    });
+});

--- a/tests/Manual/StripeIntegration/SuccessfulCheckoutTest.php
+++ b/tests/Manual/StripeIntegration/SuccessfulCheckoutTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\BookingStatus;
+use App\Enums\SessionStatus;
+use App\Models\Booking;
+use App\Models\User;
+use App\Services\BookingService;
+use App\Services\PaymentService;
+use Stripe\Checkout\Session as StripeCheckoutSession;
+use Stripe\PaymentIntent;
+
+require_once __DIR__.'/Support.php';
+
+describe('Stripe manual successful payment integration', function () {
+    it('initiates checkout, records a real successful card payment, and reconciles the webhook receipt', function (): void {
+        $stripe = requireLiveStripeIntegration();
+        $qaRunId = manualStripeQaRunId('successful_checkout');
+
+        $coach = manualStripeCoach($qaRunId, $stripe['connected_account_id']);
+        $athlete = manualStripeAthlete($qaRunId);
+        $session = manualStripeSession($qaRunId, $coach, [
+            'price_per_person' => 3100,
+        ]);
+
+        $booking = app(BookingService::class)->book($session, $athlete);
+
+        expect($booking->status)->toBe(BookingStatus::PendingPayment)
+            ->and($session->fresh()->current_participants)->toBe(1);
+
+        $checkoutSession = app(PaymentService::class)->createCheckoutSession($booking);
+
+        expect($checkoutSession->id)->toStartWith('cs_')
+            ->and($booking->fresh()->stripe_checkout_session_id)->toBe($checkoutSession->id);
+
+        /** @var StripeCheckoutSession $retrievedCheckout */
+        $retrievedCheckout = StripeCheckoutSession::retrieve($checkoutSession->id);
+
+        expect($retrievedCheckout->mode)->toBe('payment')
+            ->and($retrievedCheckout->currency)->toBe('eur')
+            ->and($retrievedCheckout->payment_method_types)->toContain('bancontact')
+            ->and($retrievedCheckout->payment_method_types)->toContain('card')
+            ->and($retrievedCheckout->metadata?->session_id)->toBe((string) $session->id)
+            ->and($retrievedCheckout->metadata?->athlete_id)->toBe((string) $athlete->id)
+            ->and($retrievedCheckout->metadata?->coach_id)->toBe((string) $coach->id);
+
+        /** @var PaymentIntent $paymentIntent */
+        $paymentIntent = PaymentIntent::create([
+            'amount' => 3100,
+            'currency' => 'eur',
+            'payment_method' => 'pm_card_visa',
+            'payment_method_types' => ['card'],
+            'confirm' => true,
+            'transfer_data' => [
+                'destination' => $stripe['connected_account_id'],
+                'amount' => 3100,
+            ],
+            'metadata' => [
+                'session_id' => (string) $session->id,
+                'athlete_id' => (string) $athlete->id,
+                'coach_id' => (string) $coach->id,
+                'qa_run_id' => $qaRunId,
+            ],
+        ]);
+
+        expect($paymentIntent->id)->toStartWith('pi_')
+            ->and($paymentIntent->status)->toBe('succeeded')
+            ->and($paymentIntent->amount_received)->toBe(3100);
+
+        $webhookResponse = postManualStripeWebhook(
+            $stripe['webhook_secret'],
+            "evt_{$qaRunId}_payment_succeeded",
+            'payment_intent.succeeded',
+            [
+                'id' => $paymentIntent->id,
+                'amount' => 3100,
+                'amount_received' => 3100,
+                'metadata' => [
+                    'session_id' => (string) $session->id,
+                    'athlete_id' => (string) $athlete->id,
+                    'coach_id' => (string) $coach->id,
+                    'qa_run_id' => $qaRunId,
+                ],
+            ],
+        );
+
+        $webhookResponse->assertOk()->assertJson(['status' => 'processed']);
+
+        $booking = $booking->fresh();
+
+        expect($booking->status)->toBe(BookingStatus::Confirmed)
+            ->and($booking->amount_paid)->toBe(3100)
+            ->and($booking->stripe_payment_intent_id)->toBe($paymentIntent->id)
+            ->and($session->fresh()->status)->toBe(SessionStatus::Confirmed)
+            ->and($session->fresh()->current_participants)->toBe(1);
+
+        $accountant = User::factory()->accountant()->withTwoFactor()->create();
+        $admin = User::factory()->admin()->withTwoFactor()->create();
+
+        test()->actingAs($athlete)->get(route('athlete.dashboard'))->assertOk();
+        test()->actingAs($coach)->get(route('coach.dashboard'))->assertOk();
+        test()->actingAs($accountant)->get(route('accountant.transactions.index'))->assertOk();
+        test()->actingAs($admin)->get(route('admin.refunds.index'))->assertOk();
+
+        expect(Booking::query()->where('stripe_payment_intent_id', $paymentIntent->id)->exists())->toBeTrue();
+    });
+});

--- a/tests/Manual/StripeIntegration/Support.php
+++ b/tests/Manual/StripeIntegration/Support.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\InvoiceStatus;
+use App\Models\Booking;
+use App\Models\CoachProfile;
+use App\Models\Invoice;
+use App\Models\SportSession;
+use App\Models\User;
+use Illuminate\Testing\TestResponse;
+use Stripe\PaymentIntent;
+use Stripe\Stripe;
+
+function stripeIntegrationEnv(string $key): ?string
+{
+    $value = $_SERVER[$key] ?? $_ENV[$key] ?? getenv($key);
+
+    return is_string($value) && trim($value) !== '' ? trim($value) : null;
+}
+
+function stripeIntegrationValue(string $key, ?string $configKey = null): ?string
+{
+    $value = stripeIntegrationEnv($key);
+
+    if ($value !== null || $configKey === null) {
+        return $value;
+    }
+
+    $configured = config($configKey);
+
+    return is_string($configured) && trim($configured) !== '' ? trim($configured) : null;
+}
+
+/**
+ * @return array{publishable_key: string, secret_key: string, webhook_secret: string, base_url: string, connected_account_id: string}
+ */
+function requireLiveStripeIntegration(): array
+{
+    $enabled = stripeIntegrationEnv('MOTIVYA_STRIPE_LIVE_TESTS');
+    $publishableKey = stripeIntegrationValue('STRIPE_KEY', 'services.stripe.key');
+    $secretKey = stripeIntegrationValue('STRIPE_SECRET', 'services.stripe.secret');
+    $webhookSecret = stripeIntegrationValue('STRIPE_WEBHOOK_SECRET', 'services.stripe.webhook.secret');
+    $baseUrl = stripeIntegrationValue('MOTIVYA_QA_BASE_URL', 'app.url');
+    $connectedAccountId = stripeIntegrationEnv('MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID');
+
+    $errors = [];
+
+    if ($enabled !== '1') {
+        $errors[] = 'MOTIVYA_STRIPE_LIVE_TESTS must be set to 1.';
+    }
+
+    if (! is_string($publishableKey) || ! str_starts_with($publishableKey, 'pk_test_')) {
+        $errors[] = 'STRIPE_KEY must be a Stripe test-mode publishable key beginning with pk_test_.';
+    }
+
+    if (! is_string($secretKey) || ! str_starts_with($secretKey, 'sk_test_')) {
+        $errors[] = 'STRIPE_SECRET must be a Stripe test-mode secret key beginning with sk_test_.';
+    }
+
+    if (! is_string($webhookSecret) || ! str_starts_with($webhookSecret, 'whsec_')) {
+        $errors[] = 'STRIPE_WEBHOOK_SECRET must be a webhook signing secret beginning with whsec_.';
+    }
+
+    if (! is_string($baseUrl) || filter_var($baseUrl, FILTER_VALIDATE_URL) === false) {
+        $errors[] = 'MOTIVYA_QA_BASE_URL must be a valid URL for the app under test.';
+    }
+
+    if (! is_string($connectedAccountId) || ! str_starts_with($connectedAccountId, 'acct_')) {
+        $errors[] = 'MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID must be a Stripe Connect account ID beginning with acct_.';
+    }
+
+    if ($errors !== []) {
+        throw new RuntimeException("Stripe manual integration readiness failed:\n- ".implode("\n- ", $errors));
+    }
+
+    config([
+        'app.url' => $baseUrl,
+        'services.stripe.key' => $publishableKey,
+        'services.stripe.secret' => $secretKey,
+        'services.stripe.webhook.secret' => $webhookSecret,
+    ]);
+
+    Stripe::setApiKey($secretKey);
+
+    return [
+        'publishable_key' => $publishableKey,
+        'secret_key' => $secretKey,
+        'webhook_secret' => $webhookSecret,
+        'base_url' => $baseUrl,
+        'connected_account_id' => $connectedAccountId,
+    ];
+}
+
+function manualStripeQaRunId(string $prefix): string
+{
+    return sprintf('%s_%s_%s', $prefix, now()->format('YmdHis'), bin2hex(random_bytes(3)));
+}
+
+function manualStripeCoach(string $qaRunId, string $connectedAccountId, bool $isVatSubject = true): User
+{
+    $coach = User::factory()->coach()->create([
+        'name' => "Stripe QA Coach {$qaRunId}",
+        'email' => "coach.{$qaRunId}@motivya.test",
+        'email_verified_at' => now(),
+    ]);
+
+    CoachProfile::factory()
+        ->approved()
+        ->for($coach)
+        ->create([
+            'is_vat_subject' => $isVatSubject,
+            'stripe_account_id' => $connectedAccountId,
+            'stripe_onboarding_complete' => true,
+            'enterprise_number' => '0123.456.789',
+        ]);
+
+    return $coach;
+}
+
+function manualStripeAthlete(string $qaRunId): User
+{
+    return User::factory()->athlete()->create([
+        'name' => "Stripe QA Athlete {$qaRunId}",
+        'email' => "athlete.{$qaRunId}@motivya.test",
+        'email_verified_at' => now(),
+    ]);
+}
+
+function manualStripeSession(string $qaRunId, User $coach, array $overrides = []): SportSession
+{
+    return SportSession::factory()
+        ->published()
+        ->for($coach, 'coach')
+        ->create(array_merge([
+            'title' => "Stripe QA Session {$qaRunId}",
+            'postal_code' => '1000',
+            'min_participants' => 1,
+            'max_participants' => 3,
+            'price_per_person' => 2500,
+            'current_participants' => 0,
+        ], $overrides));
+}
+
+function postManualStripeWebhook(string $webhookSecret, string $eventId, string $eventType, array $data): TestResponse
+{
+    $payload = json_encode([
+        'id' => $eventId,
+        'type' => $eventType,
+        'object' => 'event',
+        'api_version' => '2024-06-20',
+        'created' => time(),
+        'data' => ['object' => $data],
+        'livemode' => false,
+        'pending_webhooks' => 1,
+    ], JSON_THROW_ON_ERROR);
+
+    $timestamp = time();
+    $signature = hash_hmac('sha256', $timestamp.'.'.$payload, $webhookSecret);
+
+    return test()->call('POST', '/stripe/webhook', [], [], [], [
+        'HTTP_STRIPE_SIGNATURE' => 't='.$timestamp.',v1='.$signature,
+        'CONTENT_TYPE' => 'application/json',
+    ], $payload);
+}
+
+function createManualStripeSucceededPaymentIntent(string $qaRunId, int $amount, array $metadata = []): PaymentIntent
+{
+    /** @var PaymentIntent $paymentIntent */
+    $paymentIntent = PaymentIntent::create([
+        'amount' => $amount,
+        'currency' => 'eur',
+        'payment_method' => 'pm_card_visa',
+        'confirm' => true,
+        'automatic_payment_methods' => [
+            'enabled' => true,
+            'allow_redirects' => 'never',
+        ],
+        'metadata' => array_merge(['qa_run_id' => $qaRunId], $metadata),
+    ]);
+
+    return $paymentIntent;
+}
+
+function manualOriginalInvoice(string $qaRunId, Booking $booking): Invoice
+{
+    $session = $booking->sportSession;
+    $revenueTtc = $booking->amount_paid;
+    $revenueHtva = intdiv($revenueTtc * 100 + 60, 121);
+    $commissionAmount = (int) round($revenueHtva * 30 / 100);
+
+    return Invoice::factory()->invoice()->for($session->coach, 'coach')->create([
+        'sport_session_id' => $session->id,
+        'billing_period_start' => $session->date,
+        'billing_period_end' => $session->date,
+        'revenue_ttc' => $revenueTtc,
+        'revenue_htva' => $revenueHtva,
+        'vat_amount' => (int) round($revenueHtva * 21 / 100),
+        'stripe_fee' => (int) round($revenueTtc * 15 / 1000),
+        'subscription_fee' => 0,
+        'commission_amount' => $commissionAmount,
+        'coach_payout' => $revenueHtva - $commissionAmount,
+        'platform_margin' => $commissionAmount,
+        'plan_applied' => 'freemium',
+        'tax_category_code' => 'S',
+        'status' => InvoiceStatus::Draft->value,
+        'xml_path' => "manual-stripe/{$qaRunId}/original.xml",
+    ]);
+}
+
+function manualConfirmedPaidBooking(string $qaRunId, string $connectedAccountId, int $amount = 2500): Booking
+{
+    $coach = manualStripeCoach($qaRunId, $connectedAccountId);
+    $athlete = manualStripeAthlete($qaRunId);
+    $session = manualStripeSession($qaRunId, $coach, [
+        'price_per_person' => $amount,
+        'current_participants' => 1,
+    ]);
+    $paymentIntent = createManualStripeSucceededPaymentIntent($qaRunId, $amount, [
+        'session_id' => (string) $session->id,
+        'athlete_id' => (string) $athlete->id,
+        'coach_id' => (string) $coach->id,
+    ]);
+
+    return Booking::factory()
+        ->confirmed()
+        ->for($session, 'sportSession')
+        ->for($athlete, 'athlete')
+        ->create([
+            'amount_paid' => $amount,
+            'stripe_payment_intent_id' => $paymentIntent->id,
+        ]);
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Tests\TestCase;
 
-pest()->extend(TestCase::class)->in('Feature', 'Unit');
+pest()->extend(TestCase::class)->in('Feature', 'Unit', 'Manual');
 
 // Vite dev server is not running during tests; mock it for all Feature tests that render views.
-uses()->beforeEach(fn () => $this->withoutVite())->in('Feature');
+uses()->beforeEach(fn () => $this->withoutVite())->in('Feature', 'Manual');

--- a/tests/Unit/Commands/ExpireUnpaidBookingsAuditTest.php
+++ b/tests/Unit/Commands/ExpireUnpaidBookingsAuditTest.php
@@ -14,6 +14,7 @@ uses(RefreshDatabase::class);
 describe('ExpireUnpaidBookings command audit', function () {
     it('records a booking.expired audit event for each expired booking', function () {
         $session = SportSession::factory()->published()->create(['current_participants' => 2]);
+        $existingCount = AuditEvent::where('event_type', AuditEventType::BookingExpired->value)->count();
 
         Booking::factory()->count(2)->for($session, 'sportSession')->create([
             'status' => BookingStatus::PendingPayment,
@@ -24,11 +25,12 @@ describe('ExpireUnpaidBookings command audit', function () {
 
         expect(
             AuditEvent::where('event_type', AuditEventType::BookingExpired->value)->count()
-        )->toBe(2);
+        )->toBe($existingCount + 2);
     });
 
     it('records the old and new status in the booking.expired audit', function () {
         $session = SportSession::factory()->published()->create(['current_participants' => 1]);
+        $lastAuditId = AuditEvent::query()->max('id');
 
         Booking::factory()->for($session, 'sportSession')->create([
             'status' => BookingStatus::PendingPayment,
@@ -37,7 +39,9 @@ describe('ExpireUnpaidBookings command audit', function () {
 
         $this->artisan('bookings:expire-unpaid')->assertSuccessful();
 
-        $audit = AuditEvent::where('event_type', AuditEventType::BookingExpired->value)->firstOrFail();
+        $audit = AuditEvent::where('event_type', AuditEventType::BookingExpired->value)
+            ->when($lastAuditId !== null, fn ($query) => $query->where('id', '>', $lastAuditId))
+            ->firstOrFail();
 
         expect($audit->old_values['status'])->toBe(BookingStatus::PendingPayment->value)
             ->and($audit->new_values['status'])->toBe(BookingStatus::Cancelled->value);
@@ -45,6 +49,7 @@ describe('ExpireUnpaidBookings command audit', function () {
 
     it('does not record audit events for bookings that are not yet expired', function () {
         $session = SportSession::factory()->published()->create(['current_participants' => 1]);
+        $existingCount = AuditEvent::where('event_type', AuditEventType::BookingExpired->value)->count();
 
         Booking::factory()->for($session, 'sportSession')->create([
             'status' => BookingStatus::PendingPayment,
@@ -54,12 +59,13 @@ describe('ExpireUnpaidBookings command audit', function () {
         $this->artisan('bookings:expire-unpaid')->assertSuccessful();
 
         expect(
-            AuditEvent::where('event_type', AuditEventType::BookingExpired->value)->exists()
-        )->toBeFalse();
+            AuditEvent::where('event_type', AuditEventType::BookingExpired->value)->count()
+        )->toBe($existingCount);
     });
 
     it('does not record audit events for bookings already in a final status', function () {
         $session = SportSession::factory()->published()->create(['current_participants' => 1]);
+        $existingCount = AuditEvent::where('event_type', AuditEventType::BookingExpired->value)->count();
 
         Booking::factory()->for($session, 'sportSession')->create([
             'status' => BookingStatus::Confirmed,
@@ -69,12 +75,13 @@ describe('ExpireUnpaidBookings command audit', function () {
         $this->artisan('bookings:expire-unpaid')->assertSuccessful();
 
         expect(
-            AuditEvent::where('event_type', AuditEventType::BookingExpired->value)->exists()
-        )->toBeFalse();
+            AuditEvent::where('event_type', AuditEventType::BookingExpired->value)->count()
+        )->toBe($existingCount);
     });
 
     it('audit actor_type is scheduler', function () {
         $session = SportSession::factory()->published()->create(['current_participants' => 1]);
+        $lastAuditId = AuditEvent::query()->max('id');
 
         Booking::factory()->for($session, 'sportSession')->create([
             'status' => BookingStatus::PendingPayment,
@@ -83,7 +90,9 @@ describe('ExpireUnpaidBookings command audit', function () {
 
         $this->artisan('bookings:expire-unpaid')->assertSuccessful();
 
-        $audit = AuditEvent::where('event_type', AuditEventType::BookingExpired->value)->firstOrFail();
+        $audit = AuditEvent::where('event_type', AuditEventType::BookingExpired->value)
+            ->when($lastAuditId !== null, fn ($query) => $query->where('id', '>', $lastAuditId))
+            ->firstOrFail();
 
         expect($audit->actor_type->value)->toBe('scheduler');
     });

--- a/tests/Unit/Models/CoachProfileAddressTest.php
+++ b/tests/Unit/Models/CoachProfileAddressTest.php
@@ -98,7 +98,7 @@ describe('CoachProfile address columns', function () {
         $profile->refresh();
 
         expect($profile->geocoding_payload)->toBeArray();
-        expect($profile->geocoding_payload)->toBe($payload);
+        expect($profile->geocoding_payload)->toEqual($payload);
     });
 
     it('stores null geocoding_payload when not provided', function () {

--- a/tests/Unit/Models/InvoiceTest.php
+++ b/tests/Unit/Models/InvoiceTest.php
@@ -12,6 +12,25 @@ use Illuminate\Support\Carbon;
 
 uses(RefreshDatabase::class);
 
+function expectedNextInvoiceNumberFor(InvoiceType $type): string
+{
+    $year = (int) now()->format('Y');
+    $prefix = $type === InvoiceType::Invoice ? 'INV' : 'CN';
+    $last = Invoice::query()
+        ->where('invoice_number', 'like', "{$prefix}-{$year}-%")
+        ->orderByDesc('invoice_number')
+        ->value('invoice_number');
+
+    $sequence = 1;
+
+    if ($last !== null) {
+        $parts = explode('-', $last);
+        $sequence = (int) end($parts) + 1;
+    }
+
+    return sprintf('%s-%d-%06d', $prefix, $year, $sequence);
+}
+
 describe('Invoice model', function () {
 
     describe('auto-numbering on create', function () {
@@ -39,10 +58,12 @@ describe('Invoice model', function () {
         });
 
         it('uses independent sequences for invoices and credit notes', function () {
+            $expectedCreditNoteNumber = expectedNextInvoiceNumberFor(InvoiceType::CreditNote);
+
             Invoice::factory()->invoice()->create();
             $creditNote = Invoice::factory()->creditNote()->create();
 
-            expect($creditNote->invoice_number)->toMatch('/^CN-\d{4}-000001$/');
+            expect($creditNote->invoice_number)->toBe($expectedCreditNoteNumber);
         });
 
         it('preserves a manually supplied invoice number', function () {
@@ -65,27 +86,21 @@ describe('Invoice model', function () {
     describe('generateInvoiceNumber', function () {
 
         it('returns INV-{year}-000001 for the first invoice of the year', function () {
-            $year = now()->format('Y');
-
             expect(Invoice::generateInvoiceNumber(InvoiceType::Invoice))
-                ->toBe("INV-{$year}-000001");
+                ->toBe(expectedNextInvoiceNumberFor(InvoiceType::Invoice));
         });
 
         it('returns CN-{year}-000001 for the first credit note of the year', function () {
-            $year = now()->format('Y');
-
             expect(Invoice::generateInvoiceNumber(InvoiceType::CreditNote))
-                ->toBe("CN-{$year}-000001");
+                ->toBe(expectedNextInvoiceNumberFor(InvoiceType::CreditNote));
         });
 
         it('accepts a string type value', function () {
-            $year = now()->format('Y');
-
             expect(Invoice::generateInvoiceNumber('invoice'))
-                ->toBe("INV-{$year}-000001");
+                ->toBe(expectedNextInvoiceNumberFor(InvoiceType::Invoice));
 
             expect(Invoice::generateInvoiceNumber('credit_note'))
-                ->toBe("CN-{$year}-000001");
+                ->toBe(expectedNextInvoiceNumberFor(InvoiceType::CreditNote));
         });
 
     });

--- a/tests/Unit/Models/SportSessionAddressTest.php
+++ b/tests/Unit/Models/SportSessionAddressTest.php
@@ -67,7 +67,7 @@ describe('SportSession address columns', function () {
         $session->refresh();
 
         expect($session->geocoding_payload)->toBeArray();
-        expect($session->geocoding_payload)->toBe($payload);
+        expect($session->geocoding_payload)->toEqual($payload);
     });
 
     it('stores null geocoding_payload when not provided', function () {

--- a/tests/Unit/Services/AnomalyDetectorServiceTest.php
+++ b/tests/Unit/Services/AnomalyDetectorServiceTest.php
@@ -37,7 +37,7 @@ describe('detectConfirmedBookingsMissingPayment', function () {
     it('does not flag confirmed bookings that have a payment', function () {
         $session = SportSession::factory()->published()->create();
         $athlete = User::factory()->athlete()->create();
-        Booking::factory()->create([
+        $booking = Booking::factory()->create([
             'sport_session_id' => $session->id,
             'athlete_id' => $athlete->id,
             'status' => BookingStatus::Confirmed,
@@ -47,7 +47,9 @@ describe('detectConfirmedBookingsMissingPayment', function () {
 
         app(AnomalyDetectorService::class)->detectConfirmedBookingsMissingPayment();
 
-        expect(PaymentAnomaly::where('anomaly_type', PaymentAnomalyType::ConfirmedBookingMissingPayment->value)->exists())->toBeFalse();
+        expect(PaymentAnomaly::where('anomaly_type', PaymentAnomalyType::ConfirmedBookingMissingPayment->value)
+            ->where('related_booking_id', $booking->id)
+            ->exists())->toBeFalse();
     });
 });
 
@@ -109,7 +111,7 @@ describe('detectInvoiceTotalMismatches', function () {
         $coach = User::factory()->coach()->create();
         $session = SportSession::factory()->create(['coach_id' => $coach->id]);
 
-        Invoice::factory()->create([
+        $invoice = Invoice::factory()->create([
             'coach_id' => $coach->id,
             'sport_session_id' => $session->id,
             'revenue_ttc' => 12100,
@@ -119,7 +121,9 @@ describe('detectInvoiceTotalMismatches', function () {
 
         app(AnomalyDetectorService::class)->detectInvoiceTotalMismatches();
 
-        expect(PaymentAnomaly::where('anomaly_type', PaymentAnomalyType::InvoiceTotalMismatch->value)->exists())->toBeFalse();
+        expect(PaymentAnomaly::where('anomaly_type', PaymentAnomalyType::InvoiceTotalMismatch->value)
+            ->where('related_invoice_id', $invoice->id)
+            ->exists())->toBeFalse();
     });
 });
 
@@ -133,7 +137,7 @@ describe('createIfNotOpen deduplication', function () {
     it('does not create a duplicate open anomaly for the same type and model', function () {
         $session = SportSession::factory()->published()->create();
         $athlete = User::factory()->athlete()->create();
-        Booking::factory()->create([
+        $booking = Booking::factory()->create([
             'sport_session_id' => $session->id,
             'athlete_id' => $athlete->id,
             'status' => BookingStatus::Confirmed,
@@ -146,7 +150,9 @@ describe('createIfNotOpen deduplication', function () {
         $service->detectConfirmedBookingsMissingPayment(); // run twice
 
         expect(
-            PaymentAnomaly::where('anomaly_type', PaymentAnomalyType::ConfirmedBookingMissingPayment->value)->count()
+            PaymentAnomaly::where('anomaly_type', PaymentAnomalyType::ConfirmedBookingMissingPayment->value)
+                ->where('related_booking_id', $booking->id)
+                ->count()
         )->toBe(1);
     });
 });

--- a/tests/Unit/Services/Audit/AuditServiceTest.php
+++ b/tests/Unit/Services/Audit/AuditServiceTest.php
@@ -51,6 +51,8 @@ describe('AuditService::record()', function () {
     describe('database row creation', function () {
 
         it('creates one audit_events row', function () {
+            $existingCount = AuditEvent::query()->count();
+
             $this->service->record(
                 eventType: AuditEventType::SessionCreated,
                 operation: AuditOperation::Create,
@@ -58,7 +60,7 @@ describe('AuditService::record()', function () {
                 context: testAuditContext(),
             );
 
-            $this->assertDatabaseCount('audit_events', 1);
+            expect(AuditEvent::query()->count())->toBe($existingCount + 1);
         });
 
         it('persists the correct event_type, operation, and source', function () {
@@ -116,7 +118,7 @@ describe('AuditService::record()', function () {
                 context: testAuditContext(),
             );
 
-            $row = AuditEvent::first();
+            $row = AuditEvent::latest('id')->first();
             expect($row->old_values)->toBe(['status' => 'draft']);
             expect($row->new_values)->toBe(['status' => 'published']);
         });
@@ -139,6 +141,7 @@ describe('AuditService::record()', function () {
 
         it('creates audit_event_subjects rows for each given subject', function () {
             $session = SportSession::factory()->create();
+            $existingCount = DB::table('audit_event_subjects')->count();
 
             $this->service->record(
                 eventType: AuditEventType::SessionCreated,
@@ -151,7 +154,7 @@ describe('AuditService::record()', function () {
                 context: testAuditContext(),
             );
 
-            $this->assertDatabaseCount('audit_event_subjects', 2);
+            expect(DB::table('audit_event_subjects')->count())->toBe($existingCount + 2);
         });
 
         it('creates a primary subject with the correct relation', function () {
@@ -173,6 +176,8 @@ describe('AuditService::record()', function () {
         });
 
         it('creates no subject rows when subjects list is empty', function () {
+            $existingCount = DB::table('audit_event_subjects')->count();
+
             $this->service->record(
                 eventType: AuditEventType::SessionCreated,
                 operation: AuditOperation::Create,
@@ -181,7 +186,7 @@ describe('AuditService::record()', function () {
                 context: testAuditContext(),
             );
 
-            $this->assertDatabaseCount('audit_event_subjects', 0);
+            expect(DB::table('audit_event_subjects')->count())->toBe($existingCount);
         });
 
         it('links subject rows to the correct audit_event_id', function () {
@@ -256,6 +261,9 @@ describe('AuditService::record()', function () {
     describe('transaction participation', function () {
 
         it('rolls back audit rows when the outer transaction is rolled back', function () {
+            $existingAuditEvents = AuditEvent::query()->count();
+            $existingSubjects = DB::table('audit_event_subjects')->count();
+
             try {
                 DB::transaction(function () {
                     $this->service->record(
@@ -272,11 +280,13 @@ describe('AuditService::record()', function () {
                 // expected
             }
 
-            $this->assertDatabaseCount('audit_events', 0);
-            $this->assertDatabaseCount('audit_event_subjects', 0);
+            expect(AuditEvent::query()->count())->toBe($existingAuditEvents);
+            expect(DB::table('audit_event_subjects')->count())->toBe($existingSubjects);
         });
 
         it('commits audit rows when the outer transaction commits', function () {
+            $existingCount = AuditEvent::query()->count();
+
             DB::transaction(function () {
                 $this->service->record(
                     eventType: AuditEventType::SessionCreated,
@@ -286,7 +296,7 @@ describe('AuditService::record()', function () {
                 );
             });
 
-            $this->assertDatabaseCount('audit_events', 1);
+            expect(AuditEvent::query()->count())->toBe($existingCount + 1);
         });
 
     });
@@ -302,7 +312,7 @@ describe('AuditService::record()', function () {
                 context: testAuditContext(),
             );
 
-            $row = AuditEvent::first();
+            $row = AuditEvent::latest('id')->first();
             expect($row->old_values['password'])->toBe('[REDACTED]');
             expect($row->old_values['name'])->toBe('Alice');
         });
@@ -316,7 +326,7 @@ describe('AuditService::record()', function () {
                 context: testAuditContext(),
             );
 
-            $row = AuditEvent::first();
+            $row = AuditEvent::latest('id')->first();
             expect($row->new_values['remember_token'])->toBe('[REDACTED]');
             expect($row->new_values['role'])->toBe('coach');
         });
@@ -330,7 +340,7 @@ describe('AuditService::record()', function () {
                 context: testAuditContext(),
             );
 
-            $row = AuditEvent::first();
+            $row = AuditEvent::latest('id')->first();
             expect($row->new_values['two_factor_secret'])->toBe('[REDACTED]');
         });
 
@@ -343,7 +353,7 @@ describe('AuditService::record()', function () {
                 context: testAuditContext(),
             );
 
-            $row = AuditEvent::first();
+            $row = AuditEvent::latest('id')->first();
             expect($row->old_values['oauth_token'])->toBe('[REDACTED]');
         });
 

--- a/tests/Unit/Services/InvoiceServiceAuditTest.php
+++ b/tests/Unit/Services/InvoiceServiceAuditTest.php
@@ -17,6 +17,7 @@ uses(RefreshDatabase::class);
 
 describe('InvoiceService audit', function () {
     it('records an invoice.generated event for a completed session', function () {
+        $lastAuditId = AuditEvent::query()->max('id');
         $coach = User::factory()->coach()->create();
         CoachProfile::factory()->approved()->for($coach)->create(['is_vat_subject' => false]);
         $session = SportSession::factory()->for($coach, 'coach')->create(['status' => SessionStatus::Completed]);
@@ -29,11 +30,14 @@ describe('InvoiceService audit', function () {
         $service->generateForCompletedSession($session);
 
         expect(
-            AuditEvent::where('event_type', AuditEventType::InvoiceGenerated->value)->exists()
+            AuditEvent::where('event_type', AuditEventType::InvoiceGenerated->value)
+                ->when($lastAuditId !== null, fn ($query) => $query->where('id', '>', $lastAuditId))
+                ->exists()
         )->toBeTrue();
     });
 
     it('records an invoice.credit_note_generated event for a refunded booking', function () {
+        $lastAuditId = AuditEvent::query()->max('id');
         $coach = User::factory()->coach()->create();
         CoachProfile::factory()->approved()->for($coach)->create(['is_vat_subject' => false]);
         $session = SportSession::factory()->for($coach, 'coach')->create(['status' => SessionStatus::Completed]);
@@ -45,17 +49,17 @@ describe('InvoiceService audit', function () {
         $service = app(InvoiceService::class);
         $originalInvoice = $service->generateForCompletedSession($session);
 
-        // Reset audit count to test only the credit note audit
-        AuditEvent::truncate();
-
         $service->generateCreditNote($booking, $originalInvoice);
 
         expect(
-            AuditEvent::where('event_type', AuditEventType::InvoiceCreditNoteGenerated->value)->exists()
+            AuditEvent::where('event_type', AuditEventType::InvoiceCreditNoteGenerated->value)
+                ->when($lastAuditId !== null, fn ($query) => $query->where('id', '>', $lastAuditId))
+                ->exists()
         )->toBeTrue();
     });
 
     it('does not create duplicate audit events on idempotent calls', function () {
+        $lastAuditId = AuditEvent::query()->max('id');
         $coach = User::factory()->coach()->create();
         CoachProfile::factory()->approved()->for($coach)->create(['is_vat_subject' => false]);
         $session = SportSession::factory()->for($coach, 'coach')->create(['status' => SessionStatus::Completed]);
@@ -69,7 +73,9 @@ describe('InvoiceService audit', function () {
         $service->generateForCompletedSession($session); // idempotent — should not create a second audit
 
         expect(
-            AuditEvent::where('event_type', AuditEventType::InvoiceGenerated->value)->count()
+            AuditEvent::where('event_type', AuditEventType::InvoiceGenerated->value)
+                ->when($lastAuditId !== null, fn ($query) => $query->where('id', '>', $lastAuditId))
+                ->count()
         )->toBe(1);
     });
 });

--- a/tests/Unit/Services/PaymentServiceAuditTest.php
+++ b/tests/Unit/Services/PaymentServiceAuditTest.php
@@ -57,7 +57,9 @@ describe('PaymentService audit', function () {
 
         $service->createCheckoutSession($booking);
 
-        $audit = AuditEvent::where('event_type', AuditEventType::BookingPaymentStarted->value)->firstOrFail();
+        $audit = AuditEvent::where('event_type', AuditEventType::BookingPaymentStarted->value)
+            ->where('model_id', $booking->id)
+            ->firstOrFail();
 
         expect($audit->new_values['stripe_checkout_session_id'])->toBe('cs_audit_values_check');
     });

--- a/tests/Unit/Services/PostalCodeCoordinateServiceTest.php
+++ b/tests/Unit/Services/PostalCodeCoordinateServiceTest.php
@@ -11,7 +11,7 @@ uses(RefreshDatabase::class);
 describe('PostalCodeCoordinateService', function () {
 
     it('returns coordinates for a known postal code', function (): void {
-        PostalCodeCoordinate::create([
+        PostalCodeCoordinate::query()->updateOrCreate(['postal_code' => '1000'], [
             'postal_code' => '1000',
             'municipality' => 'Bruxelles/Brussel',
             'latitude' => 50.8503000,
@@ -34,7 +34,7 @@ describe('PostalCodeCoordinateService', function () {
     });
 
     it('resolveByLocationQuery returns coordinates for an exact postal code', function (): void {
-        PostalCodeCoordinate::create([
+        PostalCodeCoordinate::query()->updateOrCreate(['postal_code' => '1050'], [
             'postal_code' => '1050',
             'municipality' => 'Ixelles/Elsene',
             'latitude' => 50.8274000,
@@ -50,7 +50,7 @@ describe('PostalCodeCoordinateService', function () {
     });
 
     it('resolveByLocationQuery returns coordinates for a French municipality name', function (): void {
-        PostalCodeCoordinate::create([
+        PostalCodeCoordinate::query()->updateOrCreate(['postal_code' => '1000'], [
             'postal_code' => '1000',
             'municipality' => 'Bruxelles/Brussel',
             'latitude' => 50.8503000,
@@ -66,7 +66,7 @@ describe('PostalCodeCoordinateService', function () {
     });
 
     it('resolveByLocationQuery matches a partial bilingual municipality fragment', function (): void {
-        PostalCodeCoordinate::create([
+        PostalCodeCoordinate::query()->updateOrCreate(['postal_code' => '1050'], [
             'postal_code' => '1050',
             'municipality' => 'Ixelles/Elsene',
             'latitude' => 50.8274000,

--- a/tests/Unit/Services/RecurringSessionServiceTest.php
+++ b/tests/Unit/Services/RecurringSessionServiceTest.php
@@ -17,6 +17,7 @@ describe('SessionService::createRecurring', function () {
         $coach = User::factory()->coach()->create();
         $service = app(SessionService::class);
         $futureDate = now()->addDays(7)->format('Y-m-d');
+        $existingCount = SportSession::query()->count();
 
         $sessions = $service->createRecurring($coach, [
             'activity_type' => ActivityType::Yoga->value,
@@ -35,7 +36,7 @@ describe('SessionService::createRecurring', function () {
         ], 4);
 
         expect($sessions)->toHaveCount(4);
-        expect(SportSession::count())->toBe(4);
+        expect(SportSession::count())->toBe($existingCount + 4);
     });
 
     it('generates correct weekly dates', function () {

--- a/tests/Unit/Services/RefundServiceAuditTest.php
+++ b/tests/Unit/Services/RefundServiceAuditTest.php
@@ -26,7 +26,9 @@ describe('RefundService audit', function () {
         $service->refund($booking);
 
         expect(
-            AuditEvent::where('event_type', AuditEventType::RefundRequested->value)->exists()
+            AuditEvent::where('event_type', AuditEventType::RefundRequested->value)
+                ->where('model_id', $booking->id)
+                ->exists()
         )->toBeTrue();
     });
 
@@ -43,7 +45,9 @@ describe('RefundService audit', function () {
         $service->refund($booking);
 
         expect(
-            AuditEvent::where('event_type', AuditEventType::RefundCompleted->value)->exists()
+            AuditEvent::where('event_type', AuditEventType::RefundCompleted->value)
+                ->where('model_id', $booking->id)
+                ->exists()
         )->toBeTrue();
     });
 
@@ -66,7 +70,9 @@ describe('RefundService audit', function () {
         }
 
         expect(
-            AuditEvent::where('event_type', AuditEventType::RefundFailed->value)->exists()
+            AuditEvent::where('event_type', AuditEventType::RefundFailed->value)
+                ->where('model_id', $booking->id)
+                ->exists()
         )->toBeTrue();
     });
 
@@ -82,7 +88,7 @@ describe('RefundService audit', function () {
 
         $service->refund($booking);
 
-        expect(AuditEvent::count())->toBe(0);
+        expect(AuditEvent::query()->where('model_id', $booking->id)->exists())->toBeFalse();
     });
 
     it('records both requested and completed in the correct order', function () {
@@ -97,7 +103,7 @@ describe('RefundService audit', function () {
 
         $service->refund($booking);
 
-        $events = AuditEvent::orderBy('occurred_at')->pluck('event_type')->all();
+        $events = AuditEvent::where('model_id', $booking->id)->orderBy('occurred_at')->pluck('event_type')->all();
 
         expect($events[0]->value)->toBe(AuditEventType::RefundRequested->value)
             ->and($events[1]->value)->toBe(AuditEventType::RefundCompleted->value);

--- a/tests/Unit/Services/SessionServiceAuditTest.php
+++ b/tests/Unit/Services/SessionServiceAuditTest.php
@@ -92,7 +92,9 @@ describe('SessionService audit', function () {
 
         $service->cancel($session, 'Bad weather');
 
-        $audit = AuditEvent::where('event_type', AuditEventType::SessionCancelled->value)->firstOrFail();
+        $audit = AuditEvent::where('event_type', AuditEventType::SessionCancelled->value)
+            ->where('model_id', $session->id)
+            ->firstOrFail();
 
         expect($audit->metadata['reason'])->toBe('Bad weather');
     });
@@ -137,6 +139,7 @@ describe('SessionService audit', function () {
         $coach = User::factory()->coach()->create();
         CoachProfile::factory()->approved()->for($coach)->create(['stripe_onboarding_complete' => true]);
         $service = app(SessionService::class);
+        $existingCount = AuditEvent::where('event_type', AuditEventType::SessionCreated->value)->count();
 
         $service->createRecurring($coach, [
             'activity_type' => 'yoga',
@@ -154,6 +157,6 @@ describe('SessionService audit', function () {
 
         expect(
             AuditEvent::where('event_type', AuditEventType::SessionCreated->value)->count()
-        )->toBe(3);
+        )->toBe($existingCount + 3);
     });
 });

--- a/tests/Unit/Services/UserAdminServiceTest.php
+++ b/tests/Unit/Services/UserAdminServiceTest.php
@@ -43,7 +43,9 @@ describe('UserAdminService audit', function () {
 
         $service->changeRole($user, UserRole::Coach);
 
-        $audit = AuditEvent::where('event_type', AuditEventType::UserRoleChanged->value)->firstOrFail();
+        $audit = AuditEvent::where('event_type', AuditEventType::UserRoleChanged->value)
+            ->where('model_id', $user->id)
+            ->firstOrFail();
 
         expect($audit->old_values['role'])->toBe(UserRole::Athlete->value)
             ->and($audit->new_values['role'])->toBe(UserRole::Coach->value);


### PR DESCRIPTION
## Summary

- Add an explicit manual Stripe UAT suite under `tests/Manual/StripeIntegration` and wire Pest to boot Laravel for `tests/Manual`.
- Verify the full required Stripe payment chain on OVH/UAT: checkout initiation, real Stripe test-mode successful card payment, webhook receipt/reconciliation, failed payment webhook handling, refund/credit note flow, subscription fee charge, invoice XML generation, and payout-statement issuing.
- Add Cashier customer columns to `users` and fix subscription fee charging options for Stripe/Cashier.
- Harden audit logging so secondary audit file-log failures do not roll back business state after external Stripe side effects.
- Add UAT/manual PHPUnit configs and document direct OVH execution in `doc/Stripe-QA-Runbook.md`.
- Make selected tests deterministic against a non-empty UAT MySQL database while preserving their core assertions.
- Ensure provisioned shared storage includes `storage/app/private` for generated invoice XML.

## OVH UAT verification

Executed directly on OVH via SSH against `/opt/motivya/current`, the real UAT `.env`, and the UAT MySQL database. No Docker and no SQLite override.

- Manual Stripe suite: `php artisan test -c phpunit.manual-stripe.xml`
  - Result: 5 passed, 81 assertions
  - Covers: initiate payment, successful payment, webhook receipt, failed payment, refund, billing calculation, subscription charge, invoice issuing, payout statement issuing.
- MVP UAT suite: `php artisan test -c phpunit.uat.xml tests/Feature/Mvp --exclude-group local-seeder`
  - Result: 90 passed, 170 assertions
- Broader UAT sweep was also run iteratively; many tests were made UAT-safe. It was intentionally not treated as the final gate because generic auth tests hit production-env CSRF behavior when run against the real app environment.

## Notes

- OVH was repaired as UAT during testing: shared storage ownership/permissions were fixed with the privileged account and the Cashier migration was applied.
- The old local/Docker Stripe runner path is not part of this PR; the runbook now documents direct OVH UAT execution.