### PR TITLE
Add UAT env toggle commands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,9 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
-MOTIVYA_DEPLOY_PROFILE=local
+# Define the deployment profile for this environment. Acceptable values are: 'uat', 'production'.
+# This is used to conditionally enable features and configuration specific to each environment.
+MOTIVYA_DEPLOY_PROFILE=uat
 
 APP_LOCALE=fr
 APP_FALLBACK_LOCALE=en

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
+MOTIVYA_DEPLOY_PROFILE=local
 
 APP_LOCALE=fr
 APP_FALLBACK_LOCALE=en

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,8 @@ jobs:
     name: Build Release Artifact
     runs-on: ubuntu-24.04
     needs: test
+    env:
+      MOTIVYA_DEPLOY_PROFILE: ${{ vars.MOTIVYA_DEPLOY_PROFILE || 'uat' }}
 
     steps:
       - name: Checkout code
@@ -140,8 +142,13 @@ jobs:
           key: composer-${{ hashFiles('composer.lock') }}
           restore-keys: composer-
 
-      - name: Install Composer dependencies (production)
-        run: composer install --no-interaction --prefer-dist --optimize-autoloader --no-dev
+      - name: Install Composer dependencies for release profile
+        run: |
+          if [ "$MOTIVYA_DEPLOY_PROFILE" = "production" ]; then
+            composer install --no-interaction --prefer-dist --optimize-autoloader --no-dev
+          else
+            composer install --no-interaction --prefer-dist --optimize-autoloader
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -163,17 +170,22 @@ jobs:
 
       - name: Create release archive
         run: |
-          tar czf /tmp/release.tar.gz \
-            --exclude='.git' \
-            --exclude='node_modules' \
-            --exclude='tests' \
-            --exclude='.github' \
-            --exclude='.env' \
-            --exclude='storage/logs/*' \
-            --exclude='storage/framework/cache/data/*' \
-            --exclude='storage/framework/sessions/*' \
-            --exclude='storage/framework/views/*' \
-            .
+          EXCLUDES=(
+            --exclude='.git'
+            --exclude='node_modules'
+            --exclude='.github'
+            --exclude='.env'
+            --exclude='storage/logs/*'
+            --exclude='storage/framework/cache/data/*'
+            --exclude='storage/framework/sessions/*'
+            --exclude='storage/framework/views/*'
+          )
+
+          if [ "$MOTIVYA_DEPLOY_PROFILE" = "production" ]; then
+            EXCLUDES+=(--exclude='tests')
+          fi
+
+          tar czf /tmp/release.tar.gz "${EXCLUDES[@]}" .
 
       - name: Upload release artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: test
     env:
-      MOTIVYA_DEPLOY_PROFILE: ${{ vars.MOTIVYA_DEPLOY_PROFILE || 'uat' }}
+      MOTIVYA_DEPLOY_PROFILE: ${{ vars.MOTIVYA_DEPLOY_PROFILE || 'production' }}
 
     steps:
       - name: Checkout code

--- a/app/Console/Commands/ActivateEnv.php
+++ b/app/Console/Commands/ActivateEnv.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class ActivateEnv extends Command
+{
+    protected $signature = 'env:activate
+                            {profile : Environment profile to activate: uat or production}
+                            {--shared-path= : Directory containing .env.uat and .env.production}
+                            {--force : Back up and replace a regular .env file if one exists}';
+
+    protected $description = 'Activate a shared environment file by switching the shared .env symlink';
+
+    public function handle(): int
+    {
+        $profile = (string) $this->argument('profile');
+        if (! in_array($profile, ['uat', 'production'], true)) {
+            $this->error('Profile must be either "uat" or "production".');
+
+            return self::FAILURE;
+        }
+
+        $sharedPath = $this->sharedPath();
+        if (! File::isDirectory($sharedPath)) {
+            $this->error("Shared path does not exist: {$sharedPath}");
+
+            return self::FAILURE;
+        }
+
+        $target = $sharedPath.DIRECTORY_SEPARATOR.".env.{$profile}";
+        $active = $sharedPath.DIRECTORY_SEPARATOR.'.env';
+
+        if (! File::exists($target)) {
+            $this->error("Target env file does not exist: {$target}");
+
+            return self::FAILURE;
+        }
+
+        if (File::exists($active) && ! is_link($active)) {
+            if (! (bool) $this->option('force')) {
+                $this->error("Refusing to replace regular env file: {$active}. Re-run with --force to back it up first.");
+
+                return self::FAILURE;
+            }
+
+            $backup = $active.'.backup.'.now()->format('YmdHis');
+            File::move($active, $backup);
+            $this->warn("Backed up existing .env to {$backup}");
+        }
+
+        if (is_link($active) || File::exists($active)) {
+            File::delete($active);
+        }
+
+        if (! symlink($target, $active)) {
+            $this->error("Failed to activate {$target} as {$active}.");
+
+            return self::FAILURE;
+        }
+
+        $this->info("Activated {$profile} env: {$active} -> {$target}");
+        $this->warn('Run these from /opt/motivya/current after activation: php artisan optimize:clear && php artisan config:cache');
+
+        return self::SUCCESS;
+    }
+
+    private function sharedPath(): string
+    {
+        $option = $this->option('shared-path');
+
+        if (is_string($option) && trim($option) !== '') {
+            return rtrim(trim($option), DIRECTORY_SEPARATOR);
+        }
+
+        return dirname(base_path('.env'));
+    }
+}

--- a/app/Console/Commands/ListStripeConnectAccounts.php
+++ b/app/Console/Commands/ListStripeConnectAccounts.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Enums\CoachProfileStatus;
+use App\Models\CoachProfile;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+final class ListStripeConnectAccounts extends Command
+{
+    protected $signature = 'stripe:connect-accounts
+                            {--json : Output JSON for scripting}
+                            {--usable-only : Include only approved, onboarded profiles with an acct_ identifier}
+                            {--account-id-only : Print only the recommended usable Stripe account ID}';
+
+    protected $description = 'List Stripe Connect account IDs attached to coach profiles';
+
+    public function handle(): int
+    {
+        $accounts = $this->accounts();
+
+        if ((bool) $this->option('usable-only')) {
+            $accounts = $accounts->filter(fn (array $account): bool => $account['is_usable_for_uat'])->values();
+        }
+
+        $recommended = $accounts->firstWhere('is_usable_for_uat', true)['stripe_account_id'] ?? null;
+
+        if ((bool) $this->option('account-id-only')) {
+            if (! is_string($recommended) || $recommended === '') {
+                $this->error('No usable Stripe Connect account was found.');
+
+                return self::FAILURE;
+            }
+
+            $this->line($recommended);
+
+            return self::SUCCESS;
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode([
+                'accounts' => $accounts->values()->all(),
+                'recommended_account_id' => $recommended,
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return self::SUCCESS;
+        }
+
+        if ($accounts->isEmpty()) {
+            $this->warn('No Stripe Connect accounts found.');
+
+            return self::SUCCESS;
+        }
+
+        $this->table([
+            'User ID',
+            'Email',
+            'Name',
+            'Profile ID',
+            'Status',
+            'Stripe Account',
+            'Onboarded',
+            'Usable UAT',
+        ], $accounts->map(fn (array $account): array => [
+            $account['user_id'],
+            $account['user_email'],
+            $account['user_name'],
+            $account['coach_profile_id'],
+            $account['status'],
+            $account['stripe_account_id'] ?? '—',
+            $account['stripe_onboarding_complete'] ? 'yes' : 'no',
+            $account['is_usable_for_uat'] ? 'yes' : 'no',
+        ])->all());
+
+        if (is_string($recommended)) {
+            $this->info("Recommended UAT account: {$recommended}");
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return Collection<int, array{user_id: int|null, user_email: string|null, user_name: string|null, coach_profile_id: int, status: string|null, stripe_account_id: string|null, stripe_onboarding_complete: bool, is_usable_for_uat: bool}>
+     */
+    private function accounts(): Collection
+    {
+        return CoachProfile::query()
+            ->with('user')
+            ->whereNotNull('stripe_account_id')
+            ->where('stripe_account_id', '!=', '')
+            ->orderByDesc('stripe_onboarding_complete')
+            ->orderBy('id')
+            ->get()
+            ->map(function (CoachProfile $profile): array {
+                $stripeAccountId = is_string($profile->stripe_account_id) ? $profile->stripe_account_id : null;
+                $isUsable = $profile->status === CoachProfileStatus::Approved
+                    && $profile->stripe_onboarding_complete
+                    && is_string($stripeAccountId)
+                    && str_starts_with($stripeAccountId, 'acct_');
+
+                return [
+                    'user_id' => $profile->user?->id,
+                    'user_email' => $profile->user?->email,
+                    'user_name' => $profile->user?->name,
+                    'coach_profile_id' => $profile->id,
+                    'status' => $profile->status?->value,
+                    'stripe_account_id' => $stripeAccountId,
+                    'stripe_onboarding_complete' => (bool) $profile->stripe_onboarding_complete,
+                    'is_usable_for_uat' => $isUsable,
+                ];
+            });
+    }
+}

--- a/app/Console/Commands/MakeUatEnv.php
+++ b/app/Console/Commands/MakeUatEnv.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Enums\CoachProfileStatus;
+use App\Models\CoachProfile;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class MakeUatEnv extends Command
+{
+    protected $signature = 'env:make-uat
+                            {--path= : Destination .env.uat path}
+                            {--from= : Source env file path}
+                            {--stripe-connected-account=auto : auto, an explicit acct_ ID, or blank}
+                            {--force : Overwrite an existing destination file}
+                            {--print : Print generated content instead of writing a file}';
+
+    protected $description = 'Generate a non-destructive UAT environment file';
+
+    public function handle(): int
+    {
+        $destination = $this->pathOption('path') ?? base_path('.env.uat');
+        $source = $this->pathOption('from') ?? $this->defaultSourcePath();
+        $printOnly = (bool) $this->option('print');
+
+        if (! File::exists($source)) {
+            $this->error("Source env file not found: {$source}");
+
+            return self::FAILURE;
+        }
+
+        if (! $printOnly && File::exists($destination) && ! (bool) $this->option('force')) {
+            $this->error("Destination already exists: {$destination}. Re-run with --force to overwrite it.");
+
+            return self::FAILURE;
+        }
+
+        $content = File::get($source);
+        $values = $this->parseEnv($content);
+
+        if (! $this->validateStripeTestMode($values)) {
+            return self::FAILURE;
+        }
+
+        $stripeAccountId = $this->resolveStripeAccountId((string) $this->option('stripe-connected-account'));
+        if ($stripeAccountId === false) {
+            return self::FAILURE;
+        }
+
+        $content = $this->upsertEnvValue($content, 'APP_ENV', 'uat');
+        $content = $this->upsertEnvValue($content, 'APP_DEBUG', 'false');
+        $content = $this->upsertEnvValue($content, 'MOTIVYA_DEPLOY_PROFILE', 'uat');
+        $content = $this->upsertEnvValue($content, 'MOTIVYA_STRIPE_LIVE_TESTS', '1');
+        $content = $this->upsertEnvValue($content, 'MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID', $stripeAccountId ?? '');
+
+        if ($printOnly) {
+            $this->line($content);
+
+            return self::SUCCESS;
+        }
+
+        $directory = dirname($destination);
+        if (! File::isDirectory($directory)) {
+            File::makeDirectory($directory, 0775, true);
+        }
+
+        File::put($destination, $content);
+        $this->info("Generated UAT env file: {$destination}");
+
+        if ($stripeAccountId === null || $stripeAccountId === '') {
+            $this->warn('No usable Stripe Connect account was written. Set MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID before running manual Stripe UAT tests.');
+        } else {
+            $this->info('Wrote MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID from the selected usable coach profile.');
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function defaultSourcePath(): string
+    {
+        $envPath = base_path('.env');
+
+        return File::exists($envPath) ? $envPath : base_path('.env.example');
+    }
+
+    private function pathOption(string $name): ?string
+    {
+        $value = $this->option($name);
+
+        return is_string($value) && trim($value) !== '' ? trim($value) : null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function parseEnv(string $content): array
+    {
+        $values = [];
+
+        foreach (preg_split('/\R/', $content) ?: [] as $line) {
+            $trimmed = trim($line);
+
+            if ($trimmed === '' || str_starts_with($trimmed, '#') || ! str_contains($line, '=')) {
+                continue;
+            }
+
+            [$key, $value] = explode('=', $line, 2);
+            $values[trim($key)] = trim(trim($value), "\"'");
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param  array<string, string>  $values
+     */
+    private function validateStripeTestMode(array $values): bool
+    {
+        $rules = [
+            'STRIPE_KEY' => 'pk_test_',
+            'STRIPE_SECRET' => 'sk_test_',
+            'STRIPE_WEBHOOK_SECRET' => 'whsec_',
+        ];
+
+        foreach ($rules as $key => $prefix) {
+            $value = $values[$key] ?? '';
+
+            if ($value !== '' && ! str_starts_with($value, $prefix)) {
+                $this->error("{$key} must be blank or a test-mode value beginning with {$prefix} for UAT env generation.");
+
+                return false;
+            }
+
+            if ($value === '') {
+                $this->warn("{$key} is blank in the source env file; fill it in {$prefix}... form before running Stripe UAT tests.");
+            }
+        }
+
+        return true;
+    }
+
+    private function resolveStripeAccountId(string $option): string|false|null
+    {
+        $option = trim($option);
+
+        if ($option === 'auto') {
+            $profile = CoachProfile::query()
+                ->where('status', CoachProfileStatus::Approved->value)
+                ->where('stripe_onboarding_complete', true)
+                ->where('stripe_account_id', '!=', null)
+                ->where('stripe_account_id', 'like', 'acct_%')
+                ->orderBy('id', 'asc')
+                ->first();
+
+            return is_string($profile?->stripe_account_id) ? $profile->stripe_account_id : null;
+        }
+
+        if ($option === '') {
+            return null;
+        }
+
+        if (! str_starts_with($option, 'acct_')) {
+            $this->error('--stripe-connected-account must be auto, blank, or a Stripe account ID beginning with acct_.');
+
+            return false;
+        }
+
+        return $option;
+    }
+
+    private function upsertEnvValue(string $content, string $key, string $value): string
+    {
+        $line = $key.'='.$this->formatEnvValue($value);
+        $pattern = '/^'.preg_quote($key, '/').'=.*/m';
+
+        if (preg_match($pattern, $content) === 1) {
+            return (string) preg_replace($pattern, $line, $content, 1);
+        }
+
+        return rtrim($content).PHP_EOL.$line.PHP_EOL;
+    }
+
+    private function formatEnvValue(string $value): string
+    {
+        if ($value === '') {
+            return '';
+        }
+
+        return preg_match('/\s|#|=/', $value) === 1
+            ? '"'.str_replace('"', '\\"', $value).'"'
+            : $value;
+    }
+}

--- a/doc/Stripe-QA-Runbook.md
+++ b/doc/Stripe-QA-Runbook.md
@@ -21,31 +21,56 @@ MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID=acct_...
 
 `MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID` must reference a Stripe test-mode connected account that can receive destination-charge transfer data.
 
-## Local Windows Command
+## UAT Environment Setup
 
-Run from the repository root. The local host does not need PHP 8.3 installed; the command runs through Docker.
+Generate a dedicated UAT env file without overwriting the active `.env`:
 
-```powershell
-$env:MOTIVYA_STRIPE_LIVE_TESTS = "1"
-$env:STRIPE_KEY = "pk_test_..."
-$env:STRIPE_SECRET = "sk_test_..."
-$env:STRIPE_WEBHOOK_SECRET = "whsec_..."
-$env:MOTIVYA_QA_BASE_URL = "http://127.0.0.1:8000"
-$env:MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID = "acct_..."
-.\scripts\qa-stripe.ps1
+```bash
+cd /opt/motivya/current
+php artisan env:make-uat --path=/opt/motivya/shared/.env.uat --from=/opt/motivya/shared/.env
+```
+
+The command writes UAT-safe values including:
+
+```env
+APP_ENV=uat
+APP_DEBUG=false
+MOTIVYA_DEPLOY_PROFILE=uat
+MOTIVYA_STRIPE_LIVE_TESTS=1
+MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID=acct_...
+```
+
+It discovers the connected account from approved, onboarded coach profiles. To inspect accounts yourself:
+
+```bash
+php artisan stripe:connect-accounts --json
+php artisan stripe:connect-accounts --usable-only --account-id-only
+```
+
+Activate UAT by switching the shared `.env` symlink:
+
+```bash
+php artisan env:activate uat --shared-path=/opt/motivya/shared
+php artisan optimize:clear
+php artisan config:cache
+```
+
+Switch back to production later with:
+
+```bash
+php artisan env:activate production --shared-path=/opt/motivya/shared
+php artisan optimize:clear
+php artisan config:cache
 ```
 
 ## OVH UAT Command
 
 OVH is currently treated as the UAT environment. Run the suite directly on the host with bare PHP, using the deployed app configuration and the UAT MySQL database. Do not use Docker and do not force SQLite.
 
-The connected account can be derived from any Stripe-ready coach profile already present in the UAT database:
+With `.env.uat` active, the command is intentionally short:
 
 ```bash
 cd /opt/motivya/current
-CONNECTED_ACCOUNT=$(php -r 'require "vendor/autoload.php"; $app = require "bootstrap/app.php"; $kernel = $app->make(Illuminate\Contracts\Console\Kernel::class); $kernel->bootstrap(); echo App\Models\CoachProfile::whereNotNull("stripe_account_id")->where("stripe_account_id", "!=", "")->where("stripe_onboarding_complete", true)->value("stripe_account_id");')
-MOTIVYA_STRIPE_LIVE_TESTS=1 \
-MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID="$CONNECTED_ACCOUNT" \
 php artisan test -c phpunit.manual-stripe.xml
 ```
 

--- a/tests/Feature/Console/ActivateEnvCommandTest.php
+++ b/tests/Feature/Console/ActivateEnvCommandTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+
+beforeEach(function (): void {
+    if (PHP_OS_FAMILY === 'Windows') {
+        $this->markTestSkipped('Symlink activation behavior is covered on Linux CI/UAT hosts.');
+    }
+});
+
+describe('env:activate', function () {
+    it('activates UAT by switching the shared .env symlink', function (): void {
+        $directory = storage_path('framework/testing/env-activate-'.bin2hex(random_bytes(4)));
+        File::makeDirectory($directory, 0775, true);
+        File::put($directory.'/.env.uat', "APP_ENV=uat\n");
+        File::put($directory.'/.env.production', "APP_ENV=production\n");
+
+        $this->artisan("env:activate uat --shared-path={$directory}")
+            ->assertSuccessful();
+
+        expect(is_link($directory.'/.env'))->toBeTrue()
+            ->and(readlink($directory.'/.env'))->toBe($directory.'/.env.uat');
+    });
+
+    it('refuses to replace a regular .env file without force', function (): void {
+        $directory = storage_path('framework/testing/env-activate-'.bin2hex(random_bytes(4)));
+        File::makeDirectory($directory, 0775, true);
+        File::put($directory.'/.env.uat', "APP_ENV=uat\n");
+        File::put($directory.'/.env', "APP_ENV=production\n");
+
+        $this->artisan("env:activate uat --shared-path={$directory}")
+            ->assertFailed();
+
+        expect(is_link($directory.'/.env'))->toBeFalse()
+            ->and(File::get($directory.'/.env'))->toBe("APP_ENV=production\n");
+    });
+
+    it('backs up and replaces a regular .env file when forced', function (): void {
+        $directory = storage_path('framework/testing/env-activate-'.bin2hex(random_bytes(4)));
+        File::makeDirectory($directory, 0775, true);
+        File::put($directory.'/.env.uat', "APP_ENV=uat\n");
+        File::put($directory.'/.env', "APP_ENV=production\n");
+
+        $this->artisan("env:activate uat --shared-path={$directory} --force")
+            ->assertSuccessful();
+
+        expect(is_link($directory.'/.env'))->toBeTrue()
+            ->and(File::glob($directory.'/.env.backup.*'))->not->toBeEmpty();
+    });
+});

--- a/tests/Feature/Console/MakeUatEnvCommandTest.php
+++ b/tests/Feature/Console/MakeUatEnvCommandTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\CoachProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+
+uses(RefreshDatabase::class);
+
+describe('env:make-uat', function () {
+    it('generates a separate UAT env file with a discovered Stripe Connect account', function (): void {
+        $directory = storage_path('framework/testing/env-uat-'.bin2hex(random_bytes(4)));
+        File::makeDirectory($directory, 0775, true);
+
+        $source = $directory.'/.env';
+        $destination = $directory.'/.env.uat';
+        File::put($source, implode(PHP_EOL, [
+            'APP_ENV=production',
+            'APP_DEBUG=false',
+            'APP_URL=https://motivya.metanull.eu',
+            'STRIPE_KEY=pk_test_123',
+            'STRIPE_SECRET=sk_test_123',
+            'STRIPE_WEBHOOK_SECRET=whsec_123',
+            '',
+        ]));
+
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->approved()->for($coach)->create([
+            'stripe_account_id' => 'acct_env_ready',
+            'stripe_onboarding_complete' => true,
+        ]);
+
+        $this->artisan("env:make-uat --path={$destination} --from={$source}")
+            ->assertSuccessful();
+
+        expect(File::get($source))->toContain('APP_ENV=production')
+            ->and(File::get($destination))->toContain('APP_ENV=uat')
+            ->and(File::get($destination))->toContain('MOTIVYA_DEPLOY_PROFILE=uat')
+            ->and(File::get($destination))->toContain('MOTIVYA_STRIPE_LIVE_TESTS=1')
+            ->and(File::get($destination))->toContain('MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID=acct_env_ready');
+    });
+
+    it('refuses to overwrite an existing UAT env file without force', function (): void {
+        $directory = storage_path('framework/testing/env-uat-'.bin2hex(random_bytes(4)));
+        File::makeDirectory($directory, 0775, true);
+
+        $source = $directory.'/.env';
+        $destination = $directory.'/.env.uat';
+        File::put($source, "APP_ENV=production\nSTRIPE_KEY=pk_test_123\nSTRIPE_SECRET=sk_test_123\nSTRIPE_WEBHOOK_SECRET=whsec_123\n");
+        File::put($destination, "APP_ENV=uat\n");
+
+        $this->artisan("env:make-uat --path={$destination} --from={$source}")
+            ->assertFailed();
+
+        expect(File::get($destination))->toBe("APP_ENV=uat\n");
+    });
+
+    it('rejects live Stripe keys when generating UAT env files', function (): void {
+        $directory = storage_path('framework/testing/env-uat-'.bin2hex(random_bytes(4)));
+        File::makeDirectory($directory, 0775, true);
+
+        $source = $directory.'/.env';
+        $destination = $directory.'/.env.uat';
+        File::put($source, "APP_ENV=production\nSTRIPE_KEY=pk_live_123\nSTRIPE_SECRET=sk_test_123\nSTRIPE_WEBHOOK_SECRET=whsec_123\n");
+
+        $this->artisan("env:make-uat --path={$destination} --from={$source}")
+            ->assertFailed();
+
+        expect(File::exists($destination))->toBeFalse();
+    });
+});

--- a/tests/Feature/Console/StripeConnectAccountsCommandTest.php
+++ b/tests/Feature/Console/StripeConnectAccountsCommandTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\CoachProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+
+uses(RefreshDatabase::class);
+
+describe('stripe:connect-accounts', function () {
+    it('outputs usable Stripe Connect accounts as JSON', function (): void {
+        $coach = User::factory()->coach()->create([
+            'email' => 'coach@example.test',
+            'name' => 'UAT Coach',
+        ]);
+
+        CoachProfile::factory()->approved()->for($coach)->create([
+            'stripe_account_id' => 'acct_uat_ready',
+            'stripe_onboarding_complete' => true,
+        ]);
+
+        expect(Artisan::call('stripe:connect-accounts', ['--json' => true]))->toBe(0);
+
+        $payload = json_decode(trim(Artisan::output()), true, 512, JSON_THROW_ON_ERROR);
+
+        expect($payload['recommended_account_id'])->toBe('acct_uat_ready')
+            ->and($payload['accounts'][0]['user_email'])->toBe('coach@example.test')
+            ->and($payload['accounts'][0]['is_usable_for_uat'])->toBeTrue();
+    });
+
+    it('prints only the recommended account id for shell scripts', function (): void {
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->approved()->for($coach)->create([
+            'stripe_account_id' => 'acct_script_ready',
+            'stripe_onboarding_complete' => true,
+        ]);
+
+        $this->artisan('stripe:connect-accounts --usable-only --account-id-only')
+            ->expectsOutput('acct_script_ready')
+            ->assertSuccessful();
+    });
+
+    it('fails account-id-only when no usable account exists', function (): void {
+        $coach = User::factory()->coach()->create();
+        CoachProfile::factory()->pending()->for($coach)->create([
+            'stripe_account_id' => 'acct_not_ready',
+            'stripe_onboarding_complete' => false,
+        ]);
+
+        $this->artisan('stripe:connect-accounts --usable-only --account-id-only')
+            ->assertFailed();
+    });
+});


### PR DESCRIPTION
## Summary

- Add `stripe:connect-accounts` for scriptable Stripe Connect account discovery:
  - `php artisan stripe:connect-accounts --json`
  - `php artisan stripe:connect-accounts --usable-only --account-id-only`
- Add `env:make-uat` to generate a separate UAT env file without overwriting the active `.env`:
  - `php artisan env:make-uat --path=/opt/motivya/shared/.env.uat --from=/opt/motivya/shared/.env`
  - writes `APP_ENV=uat`, `APP_DEBUG=false`, `MOTIVYA_DEPLOY_PROFILE=uat`, `MOTIVYA_STRIPE_LIVE_TESTS=1`, and an auto-discovered `MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID` when available
  - rejects non-test Stripe keys for UAT generation
- Add `env:activate` to switch `/opt/motivya/shared/.env` between `.env.uat` and `.env.production` via symlink:
  - `php artisan env:activate uat --shared-path=/opt/motivya/shared`
  - `php artisan env:activate production --shared-path=/opt/motivya/shared`
- Make CI release artifacts profile-aware while preserving the same push-to-main deployment flow:
  - `MOTIVYA_DEPLOY_PROFILE=uat` includes dev dependencies and tests in the release artifact
  - `MOTIVYA_DEPLOY_PROFILE=production` keeps no-dev dependencies and excludes tests
- Update `.env.example` and the Stripe QA runbook for the new UAT workflow.

## Validation

- `vendor/bin/pint --test` on the new command/test files: passed
- Targeted command tests through Docker: `9 tests passed (26 assertions)`

## Notes

This keeps deployment on PR merge unchanged. The only operational switch is the repository/environment variable `MOTIVYA_DEPLOY_PROFILE`; default is `uat` so the current OVH UAT host receives test tooling/dev dependencies until switched to `production`.