### PR TITLE
Fix UAT release profile environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,8 @@ jobs:
     name: Build Release Artifact
     runs-on: ubuntu-24.04
     needs: test
+    environment:
+      name: motivya.metanull.eu
     env:
       MOTIVYA_DEPLOY_PROFILE: ${{ vars.MOTIVYA_DEPLOY_PROFILE || 'production' }}
 
@@ -141,6 +143,10 @@ jobs:
           path: vendor
           key: composer-${{ hashFiles('composer.lock') }}
           restore-keys: composer-
+
+      - name: Show release profile
+        run: |
+          echo "MOTIVYA_DEPLOY_PROFILE=${MOTIVYA_DEPLOY_PROFILE}"
 
       - name: Install Composer dependencies for release profile
         run: |
@@ -186,6 +192,19 @@ jobs:
           fi
 
           tar czf /tmp/release.tar.gz "${EXCLUDES[@]}" .
+
+      - name: Verify release artifact profile
+        run: |
+          mkdir -p /tmp/release-check
+          tar xzf /tmp/release.tar.gz -C /tmp/release-check
+
+          if [ "$MOTIVYA_DEPLOY_PROFILE" = "uat" ]; then
+            test -x /tmp/release-check/vendor/bin/pest || { echo "::error::UAT artifact is missing vendor/bin/pest"; exit 1; }
+            test -d /tmp/release-check/tests || { echo "::error::UAT artifact is missing tests/"; exit 1; }
+            test -f /tmp/release-check/phpunit.manual-stripe.xml || { echo "::error::UAT artifact is missing phpunit.manual-stripe.xml"; exit 1; }
+          else
+            test ! -d /tmp/release-check/tests || { echo "::error::Production artifact unexpectedly contains tests/"; exit 1; }
+          fi
 
       - name: Upload release artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

- Bind the CI `build` job to the `motivya.metanull.eu` GitHub Environment so environment-scoped `vars.MOTIVYA_DEPLOY_PROFILE` is available during artifact creation.
- Log the selected release profile in the build job.
- Add artifact verification before upload:
  - `uat` artifacts must contain `vendor/bin/pest`, `tests/`, and `phpunit.manual-stripe.xml`.
  - `production` artifacts must not contain `tests/`.

## Investigation

After PR #403 was merged and UAT mode was activated on OVH, the host showed:

- `APP_ENV=uat`
- `MOTIVYA_DEPLOY_PROFILE=uat`
- `vendor/bin/pest` missing
- `tests/` missing

So the runtime env toggle worked, but the deployed release artifact was still production-shaped. Root cause: `MOTIVYA_DEPLOY_PROFILE` is stored in the GitHub Environment `motivya.metanull.eu`, but the CI `build` job was not attached to that environment. Only the deploy job was. GitHub environment variables are not visible to jobs unless the job declares that environment.

## Validation

This change is workflow-only. The new build guard should fail loudly if a future UAT artifact is missing test tooling/dev dependencies.

## Post-merge expectation

After merge to `main`, CI should build a UAT-shaped artifact when `MOTIVYA_DEPLOY_PROFILE=uat` is set in the `motivya.metanull.eu` environment. The following should then exist on OVH after deploy:

```bash
cd /opt/motivya/current
test -x vendor/bin/pest && echo pest=yes
test -d tests && echo tests=yes
php artisan test -c phpunit.manual-stripe.xml
```