### PR TITLE
Read manual Stripe flags from UAT config

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -47,6 +47,11 @@ return [
         'webhook' => [
             'secret' => env('STRIPE_WEBHOOK_SECRET'),
         ],
+        'manual_tests' => [
+            'enabled' => env('MOTIVYA_STRIPE_LIVE_TESTS', '0'),
+            'connected_account_id' => env('MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID'),
+            'base_url' => env('MOTIVYA_QA_BASE_URL', env('APP_URL')),
+        ],
     ],
 
 ];

--- a/tests/Feature/Stripe/ManualStripeConfigTest.php
+++ b/tests/Feature/Stripe/ManualStripeConfigTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__.'/../../Manual/StripeIntegration/Support.php';
+
+describe('manual Stripe UAT configuration', function () {
+    it('reads readiness flags from cached Laravel config values', function (): void {
+        unset($_SERVER['MOTIVYA_STRIPE_LIVE_TESTS'], $_ENV['MOTIVYA_STRIPE_LIVE_TESTS']);
+        unset($_SERVER['MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID'], $_ENV['MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID']);
+
+        config([
+            'services.stripe.key' => 'pk_test_config_ready',
+            'services.stripe.secret' => 'sk_test_config_ready',
+            'services.stripe.webhook.secret' => 'whsec_config_ready',
+            'services.stripe.manual_tests.enabled' => '1',
+            'services.stripe.manual_tests.connected_account_id' => 'acct_config_ready',
+            'services.stripe.manual_tests.base_url' => 'https://motivya.metanull.eu',
+        ]);
+
+        $config = requireLiveStripeIntegration();
+
+        expect($config['publishable_key'])->toBe('pk_test_config_ready')
+            ->and($config['secret_key'])->toBe('sk_test_config_ready')
+            ->and($config['webhook_secret'])->toBe('whsec_config_ready')
+            ->and($config['connected_account_id'])->toBe('acct_config_ready')
+            ->and($config['base_url'])->toBe('https://motivya.metanull.eu');
+    });
+});

--- a/tests/Manual/StripeIntegration/Support.php
+++ b/tests/Manual/StripeIntegration/Support.php
@@ -37,12 +37,12 @@ function stripeIntegrationValue(string $key, ?string $configKey = null): ?string
  */
 function requireLiveStripeIntegration(): array
 {
-    $enabled = stripeIntegrationEnv('MOTIVYA_STRIPE_LIVE_TESTS');
+    $enabled = stripeIntegrationValue('MOTIVYA_STRIPE_LIVE_TESTS', 'services.stripe.manual_tests.enabled');
     $publishableKey = stripeIntegrationValue('STRIPE_KEY', 'services.stripe.key');
     $secretKey = stripeIntegrationValue('STRIPE_SECRET', 'services.stripe.secret');
     $webhookSecret = stripeIntegrationValue('STRIPE_WEBHOOK_SECRET', 'services.stripe.webhook.secret');
-    $baseUrl = stripeIntegrationValue('MOTIVYA_QA_BASE_URL', 'app.url');
-    $connectedAccountId = stripeIntegrationEnv('MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID');
+    $baseUrl = stripeIntegrationValue('MOTIVYA_QA_BASE_URL', 'services.stripe.manual_tests.base_url');
+    $connectedAccountId = stripeIntegrationValue('MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID', 'services.stripe.manual_tests.connected_account_id');
 
     $errors = [];
 


### PR DESCRIPTION
## Summary

- Add `services.stripe.manual_tests` config entries backed by:
  - `MOTIVYA_STRIPE_LIVE_TESTS`
  - `MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID`
  - `MOTIVYA_QA_BASE_URL` / `APP_URL`
- Update the manual Stripe support helper so readiness reads those values from Laravel config as a fallback, matching the `.env.uat` + `config:cache` workflow.
- Add a regression test proving manual Stripe readiness can be satisfied by config-cached values rather than only process environment variables.

## Why

After UAT artifact deployment worked, running:

```bash
php artisan test -c phpunit.manual-stripe.xml
```

still failed with:

```text
MOTIVYA_STRIPE_LIVE_TESTS must be set to 1.
MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID must be a Stripe Connect account ID beginning with acct_.
```

Root cause: the manual test helper read those two values only from process env (`$_SERVER`, `$_ENV`, `getenv`) even though `env:make-uat` writes them to `.env.uat` and Laravel uses cached config in deployed mode.

## Validation

- Pint passed on touched files.
- Targeted tests passed: `4 tests passed (15 assertions)`.

## Post-deploy

After merge/deploy, run:

```bash
cd /opt/motivya/current
php artisan optimize:clear
php artisan config:cache
php artisan test -c phpunit.manual-stripe.xml
```

Until this is deployed, the temporary workaround is still:

```bash
MOTIVYA_STRIPE_LIVE_TESTS=1 \
MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID=acct_... \
php artisan test -c phpunit.manual-stripe.xml
```