### PR TITLE
Isolate manual Stripe tests on SQLite

### DIFF
--- a/app/Console/Commands/ChangeUserRole.php
+++ b/app/Console/Commands/ChangeUserRole.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Enums\UserRole;
+use App\Models\User;
+use Illuminate\Console\Command;
+
+final class ChangeUserRole extends Command
+{
+    protected $signature = 'users:change-role
+                            {email : Email address of the user to update}
+                            {role : New role: coach, athlete, accountant, admin}';
+
+    protected $description = 'Change the role of an existing user account';
+
+    public function handle(): int
+    {
+        $email = (string) $this->argument('email');
+        $roleValue = (string) $this->argument('role');
+
+        try {
+            $role = UserRole::from($roleValue);
+        } catch (\ValueError) {
+            $this->error('Role must be one of: coach, athlete, accountant, admin.');
+
+            return self::FAILURE;
+        }
+
+        $user = User::where('email', '=', $email, 'and')->first();
+
+        if ($user === null) {
+            $this->error("No user found with email: {$email}");
+
+            return self::FAILURE;
+        }
+
+        $previousRole = $user->role->value;
+        $user->update(['role' => $role]);
+
+        $this->info("User {$email} role changed from {$previousRole} to {$role->value}.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/CreateUser.php
+++ b/app/Console/Commands/CreateUser.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Enums\UserRole;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
+
+final class CreateUser extends Command
+{
+    protected $signature = 'users:create
+                            {--email= : Email address}
+                            {--name= : Display name}
+                            {--role=athlete : Role: coach, athlete, accountant, admin}
+                            {--password= : Password; prompted interactively if omitted}
+                            {--unverified : Leave email unverified}';
+
+    protected $description = 'Create a user account with a Motivya role';
+
+    public function handle(): int
+    {
+        $email = $this->stringOption('email') ?? $this->ask('Email address');
+        $name = $this->stringOption('name') ?? $this->ask('Display name');
+        $password = $this->stringOption('password') ?? $this->secret('Password');
+        $roleValue = $this->stringOption('role') ?? UserRole::Athlete->value;
+
+        try {
+            $role = UserRole::from($roleValue);
+        } catch (\ValueError) {
+            $this->error('--role must be one of: coach, athlete, accountant, admin.');
+
+            return self::FAILURE;
+        }
+
+        $validator = Validator::make([
+            'email' => $email,
+            'name' => $name,
+            'password' => $password,
+        ], [
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email'],
+            'name' => ['required', 'string', 'max:255'],
+            'password' => ['required', 'string', 'min:8'],
+        ]);
+
+        if ($validator->fails()) {
+            foreach ($validator->errors()->all() as $error) {
+                $this->error($error);
+            }
+
+            return self::FAILURE;
+        }
+
+        $user = User::create([
+            'name' => $name,
+            'email' => $email,
+            'password' => Hash::make((string) $password),
+            'role' => $role,
+        ]);
+
+        if (! (bool) $this->option('unverified')) {
+            $user->markEmailAsVerified();
+        }
+
+        $this->info("User created: {$user->email} ({$user->role->value})");
+
+        return self::SUCCESS;
+    }
+
+    private function stringOption(string $name): ?string
+    {
+        $value = $this->option($name);
+
+        return is_string($value) && trim($value) !== '' ? trim($value) : null;
+    }
+}

--- a/app/Console/Commands/ListStripeConnectAccounts.php
+++ b/app/Console/Commands/ListStripeConnectAccounts.php
@@ -8,18 +8,29 @@ use App\Enums\CoachProfileStatus;
 use App\Models\CoachProfile;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
+use Stripe\Account as StripeAccount;
+use Stripe\Stripe;
 
 final class ListStripeConnectAccounts extends Command
 {
     protected $signature = 'stripe:connect-accounts
                             {--json : Output JSON for scripting}
                             {--usable-only : Include only approved, onboarded profiles with an acct_ identifier}
-                            {--account-id-only : Print only the recommended usable Stripe account ID}';
+                            {--account-id-only : Print only the recommended usable Stripe account ID}
+                            {--source=all : Account source: all, database, or stripe}';
 
     protected $description = 'List Stripe Connect account IDs attached to coach profiles';
 
     public function handle(): int
     {
+        $source = (string) $this->option('source');
+
+        if (! in_array($source, ['all', 'database', 'stripe'], true)) {
+            $this->error('--source must be one of: all, database, stripe.');
+
+            return self::FAILURE;
+        }
+
         $accounts = $this->accounts();
 
         if ((bool) $this->option('usable-only')) {
@@ -57,6 +68,7 @@ final class ListStripeConnectAccounts extends Command
 
         $this->table([
             'User ID',
+            'Source',
             'Email',
             'Name',
             'Profile ID',
@@ -66,6 +78,7 @@ final class ListStripeConnectAccounts extends Command
             'Usable UAT',
         ], $accounts->map(fn (array $account): array => [
             $account['user_id'],
+            $account['source'],
             $account['user_email'],
             $account['user_name'],
             $account['coach_profile_id'],
@@ -87,12 +100,34 @@ final class ListStripeConnectAccounts extends Command
      */
     private function accounts(): Collection
     {
+        $source = (string) $this->option('source');
+
+        $accounts = collect();
+
+        if ($source !== 'stripe') {
+            $accounts = $accounts->concat($this->databaseAccounts());
+        }
+
+        if ($source !== 'database') {
+            $accounts = $accounts->concat($this->stripeAccounts());
+        }
+
+        return $accounts
+            ->unique(fn (array $account): string => (string) ($account['stripe_account_id'] ?? spl_object_id((object) $account)))
+            ->values();
+    }
+
+    /**
+     * @return Collection<int, array{source: string, user_id: int|null, user_email: string|null, user_name: string|null, coach_profile_id: int|null, status: string|null, stripe_account_id: string|null, stripe_onboarding_complete: bool, is_usable_for_uat: bool}>
+     */
+    private function databaseAccounts(): Collection
+    {
         return CoachProfile::query()
             ->with('user')
             ->whereNotNull('stripe_account_id')
             ->where('stripe_account_id', '!=', '')
             ->orderByDesc('stripe_onboarding_complete')
-            ->orderBy('id')
+            ->orderBy('id', 'asc')
             ->get()
             ->map(function (CoachProfile $profile): array {
                 $stripeAccountId = is_string($profile->stripe_account_id) ? $profile->stripe_account_id : null;
@@ -102,6 +137,7 @@ final class ListStripeConnectAccounts extends Command
                     && str_starts_with($stripeAccountId, 'acct_');
 
                 return [
+                    'source' => 'database',
                     'user_id' => $profile->user?->id,
                     'user_email' => $profile->user?->email,
                     'user_name' => $profile->user?->name,
@@ -112,5 +148,41 @@ final class ListStripeConnectAccounts extends Command
                     'is_usable_for_uat' => $isUsable,
                 ];
             });
+    }
+
+    /**
+     * @return Collection<int, array{source: string, user_id: null, user_email: string|null, user_name: string|null, coach_profile_id: null, status: string|null, stripe_account_id: string|null, stripe_onboarding_complete: bool, is_usable_for_uat: bool}>
+     */
+    private function stripeAccounts(): Collection
+    {
+        $secret = config('services.stripe.secret');
+
+        if (! is_string($secret) || ! str_starts_with($secret, 'sk_test_')) {
+            return collect();
+        }
+
+        try {
+            Stripe::setApiKey($secret);
+            $accounts = StripeAccount::all(['limit' => 100]);
+        } catch (\Throwable $exception) {
+            $this->warn('Stripe account discovery failed: '.$exception->getMessage());
+
+            return collect();
+        }
+
+        return collect($accounts->data)
+            ->filter(fn (StripeAccount $account): bool => is_string($account->id) && str_starts_with($account->id, 'acct_'))
+            ->map(fn (StripeAccount $account): array => [
+                'source' => 'stripe',
+                'user_id' => null,
+                'user_email' => is_string($account->email ?? null) ? $account->email : null,
+                'user_name' => is_string($account->business_profile?->name ?? null) ? $account->business_profile->name : null,
+                'coach_profile_id' => null,
+                'status' => is_string($account->type ?? null) ? $account->type : null,
+                'stripe_account_id' => $account->id,
+                'stripe_onboarding_complete' => (bool) ($account->charges_enabled ?? false),
+                'is_usable_for_uat' => true,
+            ])
+            ->values();
     }
 }

--- a/app/Console/Commands/ListUsers.php
+++ b/app/Console/Commands/ListUsers.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Enums\UserRole;
+use App\Models\User;
+use Illuminate\Console\Command;
+
+final class ListUsers extends Command
+{
+    protected $signature = 'users:list
+                            {--role= : Filter by role: coach, athlete, accountant, admin}
+                            {--json : Output JSON for scripting}';
+
+    protected $description = 'List user accounts and roles';
+
+    public function handle(): int
+    {
+        $role = $this->option('role');
+
+        if (is_string($role) && $role !== '') {
+            try {
+                $role = UserRole::from($role);
+            } catch (\ValueError) {
+                $this->error('--role must be one of: coach, athlete, accountant, admin.');
+
+                return self::FAILURE;
+            }
+        } else {
+            $role = null;
+        }
+
+        $users = User::query()
+            ->when($role instanceof UserRole, fn ($query) => $query->where('role', $role->value))
+            ->orderBy('id', 'asc')
+            ->get()
+            ->map(fn (User $user): array => [
+                'id' => $user->id,
+                'name' => $user->name,
+                'email' => $user->email,
+                'role' => $user->role->value,
+                'email_verified' => $user->email_verified_at !== null,
+                'suspended' => $user->suspended_at !== null,
+                'created_at' => $user->created_at?->toISOString(),
+            ]);
+
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode(['users' => $users->all()], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return self::SUCCESS;
+        }
+
+        if ($users->isEmpty()) {
+            $this->warn('No users found.');
+
+            return self::SUCCESS;
+        }
+
+        $this->table(
+            ['ID', 'Name', 'Email', 'Role', 'Verified', 'Suspended'],
+            $users->map(fn (array $user): array => [
+                $user['id'],
+                $user['name'],
+                $user['email'],
+                $user['role'],
+                $user['email_verified'] ? 'yes' : 'no',
+                $user['suspended'] ? 'yes' : 'no',
+            ])->all()
+        );
+
+        return self::SUCCESS;
+    }
+}

--- a/doc/Stripe-QA-Runbook.md
+++ b/doc/Stripe-QA-Runbook.md
@@ -65,7 +65,7 @@ php artisan config:cache
 
 ## OVH UAT Command
 
-OVH is currently treated as the UAT environment. Run the suite directly on the host with bare PHP, using the deployed app configuration and the UAT MySQL database. Do not use Docker and do not force SQLite.
+OVH is currently treated as the UAT environment. Run the suite directly on the host with bare PHP. Stripe credentials and app URL come from the active `.env.uat`, but the suite forces an isolated SQLite in-memory test database and runs migrations before each test. It must not use or reset the configured UAT MySQL database.
 
 With `.env.uat` active, the command is intentionally short:
 
@@ -74,7 +74,7 @@ cd /opt/motivya/current
 php artisan test -c phpunit.manual-stripe.xml
 ```
 
-This writes provisional QA records to the UAT database and creates Stripe test-mode objects. That is expected for UAT.
+This creates temporary Laravel test records in SQLite and real Stripe test-mode objects in Stripe. Stripe test-mode objects that cannot be deleted remain visible in the Stripe dashboard.
 
 The suite verifies:
 
@@ -95,7 +95,17 @@ stripe listen --forward-to http://127.0.0.1:8000/stripe/webhook
 
 ## Data Isolation
 
-Each test creates a unique `qa_run_id` and uses it in user emails, session titles, and Stripe metadata where the called Stripe API supports metadata. Stripe test-mode objects that cannot be deleted remain discoverable in the Stripe Dashboard by `qa_run_id` metadata or generated object timestamps.
+The manual suite uses Laravel migrations and factories against SQLite `:memory:`. Each test starts from a fresh schema, creates the users/profiles/sessions/bookings it needs, and uses a unique `qa_run_id` in user emails, session titles, and Stripe metadata where the called Stripe API supports metadata. Stripe test-mode objects that cannot be deleted remain discoverable in the Stripe Dashboard by `qa_run_id` metadata or generated object timestamps.
+
+The existing full demo data feeder is `Database\Seeders\MvpJourneySeeder`. It is called by `DevSeeder` in local/testing and creates one user per role plus a full MVP smoke journey. It is intentionally skipped in production.
+
+Useful UAT account operations after a database restore or reset:
+
+```bash
+php artisan users:list --json
+php artisan users:create --email=admin@example.test --name="Admin User" --role=admin --password='change-me-now'
+php artisan users:change-role admin@example.test admin
+```
 
 ## Non-CI Rule
 

--- a/phpunit.manual-stripe.xml
+++ b/phpunit.manual-stripe.xml
@@ -14,4 +14,12 @@
             <directory>app</directory>
         </include>
     </source>
+    <php>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="CACHE_STORE" value="array"/>
+        <env name="SESSION_DRIVER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="MAIL_MAILER" value="array"/>
+    </php>
 </phpunit>

--- a/tests/Feature/Console/UserManagementCommandsTest.php
+++ b/tests/Feature/Console/UserManagementCommandsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\UserRole;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+
+uses(RefreshDatabase::class);
+
+describe('user management console commands', function () {
+    it('creates a verified user with the requested role', function (): void {
+        $this->artisan('users:create --email=admin@example.test --name="Admin User" --role=admin --password=Password1!')
+            ->assertSuccessful();
+
+        $user = User::where('email', '=', 'admin@example.test', 'and')->firstOrFail();
+
+        expect($user->role)->toBe(UserRole::Admin)
+            ->and($user->email_verified_at)->not->toBeNull();
+    });
+
+    it('changes an existing user role', function (): void {
+        $user = User::factory()->athlete()->create([
+            'email' => 'role-change@example.test',
+        ]);
+
+        $this->artisan('users:change-role role-change@example.test accountant')
+            ->assertSuccessful();
+
+        expect($user->fresh()->role)->toBe(UserRole::Accountant);
+    });
+
+    it('lists users as JSON for scripting', function (): void {
+        User::factory()->coach()->create([
+            'email' => 'coach-list@example.test',
+            'name' => 'Coach List',
+        ]);
+
+        expect(Artisan::call('users:list', ['--json' => true]))->toBe(0);
+
+        $payload = json_decode(trim(Artisan::output()), true, 512, JSON_THROW_ON_ERROR);
+
+        expect($payload['users'][0]['email'])->toBe('coach-list@example.test')
+            ->and($payload['users'][0]['role'])->toBe(UserRole::Coach->value);
+    });
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,9 +2,12 @@
 
 declare(strict_types=1);
 
+use Tests\Support\UsesManualStripeTestDatabase;
 use Tests\TestCase;
 
 pest()->extend(TestCase::class)->in('Feature', 'Unit', 'Manual');
+
+uses(UsesManualStripeTestDatabase::class)->in('Manual');
 
 // Vite dev server is not running during tests; mock it for all Feature tests that render views.
 uses()->beforeEach(fn () => $this->withoutVite())->in('Feature', 'Manual');

--- a/tests/Support/UsesManualStripeTestDatabase.php
+++ b/tests/Support/UsesManualStripeTestDatabase.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+trait UsesManualStripeTestDatabase
+{
+    use RefreshDatabase {
+        refreshDatabase as protected refreshDatabaseBase;
+    }
+
+    public function refreshDatabase(): void
+    {
+        config([
+            'database.default' => 'sqlite',
+            'database.connections.sqlite.database' => ':memory:',
+            'database.connections.sqlite.foreign_key_constraints' => true,
+            'cache.default' => 'array',
+            'queue.default' => 'sync',
+            'session.driver' => 'array',
+            'mail.default' => 'array',
+        ]);
+
+        DB::purge('mysql');
+        DB::purge('sqlite');
+
+        $this->refreshDatabaseBase();
+    }
+}


### PR DESCRIPTION
## Summary

- Make the manual Stripe suite use an isolated SQLite `:memory:` test database via `Tests\Support\UsesManualStripeTestDatabase`.
- Keep Stripe credentials/account/app URL coming from `.env.uat` / Laravel config, but prevent the suite from touching the configured UAT MySQL database.
- Update `phpunit.manual-stripe.xml` to set SQLite/cache/session/queue/mail test drivers for the manual suite.
- Extend `stripe:connect-accounts` so it can discover test Connect accounts from Stripe itself when the local DB has no coach profiles:
  - `php artisan stripe:connect-accounts --json`
  - `php artisan stripe:connect-accounts --usable-only --account-id-only`
  - optional `--source=database|stripe|all`
- Add UAT operator user commands:
  - `php artisan users:list --json`
  - `php artisan users:create --email=... --name=... --role=admin --password=...`
  - `php artisan users:change-role user@example.test admin`
- Update the Stripe QA runbook to document SQLite isolation and the existing demo feeder.

## Existing feeder

The existing full demo/test account feeder is `Database\Seeders\MvpJourneySeeder`, called by `DevSeeder` in local/testing. It creates one user per role and an MVP smoke journey. It is intentionally skipped in production.

## Why

Running the normal or manual test suite against the configured UAT MySQL database is unsafe because Laravel test traits can reset/migrate the active DB. The manual Stripe suite can safely use the same approach as the normal suite: isolated SQLite test data created by migrations/factories, while still using real Stripe test-mode API calls.

## Validation

- Pint check passed on touched PHP files.
- Focused tests passed: `7 tests passed (20 assertions)`.
- Manual Stripe readiness test under `phpunit.manual-stripe.xml` with fake test-mode env passed: `1 test passed (5 assertions)`.

## Post-deploy

After deploy, use:

```bash
cd /opt/motivya/current
php artisan optimize:clear
php artisan config:cache
php artisan stripe:connect-accounts --usable-only --account-id-only
php artisan test -c phpunit.manual-stripe.xml
```

The test suite should use SQLite in memory for Laravel data and should not reset `motivya` MySQL.