### PR TITLE
Bootstrap manual Stripe connected accounts

### DIFF
--- a/tests/Feature/Stripe/ManualStripeConfigTest.php
+++ b/tests/Feature/Stripe/ManualStripeConfigTest.php
@@ -23,7 +23,16 @@ describe('manual Stripe UAT configuration', function () {
         expect($config['publishable_key'])->toBe('pk_test_config_ready')
             ->and($config['secret_key'])->toBe('sk_test_config_ready')
             ->and($config['webhook_secret'])->toBe('whsec_config_ready')
-            ->and($config['connected_account_id'])->toBe('acct_config_ready')
             ->and($config['base_url'])->toBe('https://motivya.metanull.eu');
+    });
+
+    it('uses an optional configured connected account when one is present', function (): void {
+        unset($_SERVER['MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID'], $_ENV['MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID']);
+
+        config([
+            'services.stripe.manual_tests.connected_account_id' => 'acct_config_ready',
+        ]);
+
+        expect(manualStripeConnectedAccountId('config_test'))->toBe('acct_config_ready');
     });
 });

--- a/tests/Manual/StripeIntegration/CoachBillingSubscriptionTest.php
+++ b/tests/Manual/StripeIntegration/CoachBillingSubscriptionTest.php
@@ -22,10 +22,11 @@ describe('Stripe manual coach billing and subscription integration', function ()
     it('computes no-charge Freemium billing and paid-plan subscription billing', function (): void {
         $stripe = requireLiveStripeIntegration();
         $qaRunId = manualStripeQaRunId('coach_billing');
+        $connectedAccountId = manualStripeConnectedAccountId($qaRunId);
         $month = Carbon::parse('2026-01-01');
 
-        $freemiumCoach = manualStripeCoach("{$qaRunId}_free", $stripe['connected_account_id'], true);
-        $premiumCoach = manualStripeCoach("{$qaRunId}_paid", $stripe['connected_account_id'], false);
+        $freemiumCoach = manualStripeCoach("{$qaRunId}_free", $connectedAccountId, true);
+        $premiumCoach = manualStripeCoach("{$qaRunId}_paid", $connectedAccountId, false);
 
         Invoice::factory()->invoice()->for($freemiumCoach, 'coach')->create([
             'billing_period_start' => '2026-01-15',

--- a/tests/Manual/StripeIntegration/ExceptionalRefundTest.php
+++ b/tests/Manual/StripeIntegration/ExceptionalRefundTest.php
@@ -16,8 +16,9 @@ describe('Stripe manual exceptional reimbursement integration', function () {
     it('creates a real Stripe test-mode refund and records refunded booking state', function (): void {
         $stripe = requireLiveStripeIntegration();
         $qaRunId = manualStripeQaRunId('exceptional_refund');
+        $connectedAccountId = manualStripeConnectedAccountId($qaRunId);
 
-        $booking = manualConfirmedPaidBooking($qaRunId, $stripe['connected_account_id'], 2800);
+        $booking = manualConfirmedPaidBooking($qaRunId, $connectedAccountId, 2800);
         $admin = User::factory()->admin()->withTwoFactor()->create();
         $originalInvoice = manualOriginalInvoice($qaRunId, $booking);
 

--- a/tests/Manual/StripeIntegration/FailedCheckoutRecoveryTest.php
+++ b/tests/Manual/StripeIntegration/FailedCheckoutRecoveryTest.php
@@ -13,8 +13,9 @@ describe('Stripe manual failed payment integration', function () {
     it('keeps recovery available and releases capacity exactly once after payment failure', function (): void {
         $stripe = requireLiveStripeIntegration();
         $qaRunId = manualStripeQaRunId('failed_payment');
+        $connectedAccountId = manualStripeConnectedAccountId($qaRunId);
 
-        $coach = manualStripeCoach($qaRunId, $stripe['connected_account_id']);
+        $coach = manualStripeCoach($qaRunId, $connectedAccountId);
         $athlete = manualStripeAthlete($qaRunId);
         $session = manualStripeSession($qaRunId, $coach);
         $booking = app(BookingService::class)->book($session, $athlete);

--- a/tests/Manual/StripeIntegration/ReadinessTest.php
+++ b/tests/Manual/StripeIntegration/ReadinessTest.php
@@ -11,7 +11,6 @@ describe('Stripe manual integration readiness', function () {
         expect($config['publishable_key'])->toStartWith('pk_test_')
             ->and($config['secret_key'])->toStartWith('sk_test_')
             ->and($config['webhook_secret'])->toStartWith('whsec_')
-            ->and($config['connected_account_id'])->toStartWith('acct_')
             ->and(filter_var($config['base_url'], FILTER_VALIDATE_URL))->not->toBeFalse();
     });
 });

--- a/tests/Manual/StripeIntegration/SuccessfulCheckoutTest.php
+++ b/tests/Manual/StripeIntegration/SuccessfulCheckoutTest.php
@@ -17,8 +17,9 @@ describe('Stripe manual successful payment integration', function () {
     it('initiates checkout, records a real successful card payment, and reconciles the webhook receipt', function (): void {
         $stripe = requireLiveStripeIntegration();
         $qaRunId = manualStripeQaRunId('successful_checkout');
+        $connectedAccountId = manualStripeConnectedAccountId($qaRunId);
 
-        $coach = manualStripeCoach($qaRunId, $stripe['connected_account_id']);
+        $coach = manualStripeCoach($qaRunId, $connectedAccountId);
         $athlete = manualStripeAthlete($qaRunId);
         $session = manualStripeSession($qaRunId, $coach, [
             'price_per_person' => 3100,
@@ -53,7 +54,7 @@ describe('Stripe manual successful payment integration', function () {
             'payment_method_types' => ['card'],
             'confirm' => true,
             'transfer_data' => [
-                'destination' => $stripe['connected_account_id'],
+                'destination' => $connectedAccountId,
                 'amount' => 3100,
             ],
             'metadata' => [

--- a/tests/Manual/StripeIntegration/Support.php
+++ b/tests/Manual/StripeIntegration/Support.php
@@ -9,6 +9,7 @@ use App\Models\Invoice;
 use App\Models\SportSession;
 use App\Models\User;
 use Illuminate\Testing\TestResponse;
+use Stripe\Account as StripeAccount;
 use Stripe\PaymentIntent;
 use Stripe\Stripe;
 
@@ -33,7 +34,7 @@ function stripeIntegrationValue(string $key, ?string $configKey = null): ?string
 }
 
 /**
- * @return array{publishable_key: string, secret_key: string, webhook_secret: string, base_url: string, connected_account_id: string}
+ * @return array{publishable_key: string, secret_key: string, webhook_secret: string, base_url: string}
  */
 function requireLiveStripeIntegration(): array
 {
@@ -42,7 +43,6 @@ function requireLiveStripeIntegration(): array
     $secretKey = stripeIntegrationValue('STRIPE_SECRET', 'services.stripe.secret');
     $webhookSecret = stripeIntegrationValue('STRIPE_WEBHOOK_SECRET', 'services.stripe.webhook.secret');
     $baseUrl = stripeIntegrationValue('MOTIVYA_QA_BASE_URL', 'services.stripe.manual_tests.base_url');
-    $connectedAccountId = stripeIntegrationValue('MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID', 'services.stripe.manual_tests.connected_account_id');
 
     $errors = [];
 
@@ -66,10 +66,6 @@ function requireLiveStripeIntegration(): array
         $errors[] = 'MOTIVYA_QA_BASE_URL must be a valid URL for the app under test.';
     }
 
-    if (! is_string($connectedAccountId) || ! str_starts_with($connectedAccountId, 'acct_')) {
-        $errors[] = 'MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID must be a Stripe Connect account ID beginning with acct_.';
-    }
-
     if ($errors !== []) {
         throw new RuntimeException("Stripe manual integration readiness failed:\n- ".implode("\n- ", $errors));
     }
@@ -88,8 +84,53 @@ function requireLiveStripeIntegration(): array
         'secret_key' => $secretKey,
         'webhook_secret' => $webhookSecret,
         'base_url' => $baseUrl,
-        'connected_account_id' => $connectedAccountId,
     ];
+}
+
+function manualStripeConnectedAccountId(string $qaRunId): string
+{
+    $configured = stripeIntegrationValue('MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID', 'services.stripe.manual_tests.connected_account_id');
+
+    if (is_string($configured) && str_starts_with($configured, 'acct_')) {
+        return $configured;
+    }
+
+    try {
+        $accounts = StripeAccount::all(['limit' => 100]);
+    } catch (Throwable $exception) {
+        throw new RuntimeException('Unable to list Stripe test connected accounts: '.$exception->getMessage(), previous: $exception);
+    }
+
+    foreach ($accounts->data as $account) {
+        if (is_string($account->id ?? null) && str_starts_with($account->id, 'acct_')) {
+            return $account->id;
+        }
+    }
+
+    try {
+        $account = StripeAccount::create([
+            'type' => 'express',
+            'country' => 'BE',
+            'email' => "connect.{$qaRunId}@motivya.test",
+            'capabilities' => [
+                'card_payments' => ['requested' => true],
+                'transfers' => ['requested' => true],
+            ],
+            'business_type' => 'individual',
+            'metadata' => [
+                'qa_run_id' => $qaRunId,
+                'created_by' => 'motivya_manual_stripe_suite',
+            ],
+        ]);
+    } catch (Throwable $exception) {
+        throw new RuntimeException('Unable to create a Stripe test connected account: '.$exception->getMessage(), previous: $exception);
+    }
+
+    if (! is_string($account->id ?? null) || ! str_starts_with($account->id, 'acct_')) {
+        throw new RuntimeException('Stripe did not return a valid connected account ID.');
+    }
+
+    return $account->id;
 }
 
 function manualStripeQaRunId(string $prefix): string


### PR DESCRIPTION
## Summary

- Stop treating `MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID` as a global readiness requirement for the manual Stripe suite.
- Add `manualStripeConnectedAccountId($qaRunId)` to resolve a connected account during each test setup:
  - use optional configured `MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID` when present
  - otherwise list Stripe test Connect accounts
  - otherwise create a Stripe Express test account for the run
- Update manual Stripe scenarios to create their test coach profiles with the resolved connected account ID.
- Update readiness expectations so they only require platform Stripe test-mode config and app URL.
- Add regression coverage for the optional configured connected-account path.

## Why

After the suite moved toward isolated test data, requiring `MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID` in `.env.uat` became wrong. The connected account is part of scenario setup, not a prerequisite for booting the suite.

## Validation

- Pint passed on touched files.
- `tests/Feature/Stripe/ManualStripeConfigTest.php`: passed, `2 tests`, `5 assertions`.
- `tests/Manual/StripeIntegration/ReadinessTest.php` under `phpunit.manual-stripe.xml` without `MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID`: passed, `1 test`, `4 assertions`.

## Post-deploy

With Stripe test-mode keys configured in `.env.uat`, this should no longer fail because `MOTIVYA_STRIPE_CONNECTED_ACCOUNT_ID` is blank:

```bash
cd /opt/motivya/current
php artisan optimize:clear
php artisan config:cache
php artisan test -c phpunit.manual-stripe.xml
```